### PR TITLE
Match optimizations - Make Match struct trivial and avoid string copies

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,13 +73,13 @@ from regex import match_first, findall
 # Basic literal matching
 var result = match_first("hello", "hello world")
 if result:
-    print("Match found:", result.value().match_text)
+    print("Match found:", result.value().get_match_text())
 
 # Find all matches
 var matches = findall("a", "banana")
 print("Found", len(matches), "matches:")
 for i in range(len(matches)):
-    print("  Match", i, ":", matches[i].match_text, "at position", matches[i].start_idx)
+    print("  Match", i, ":", matches[i].get_match_text(), "at position", matches[i].start_idx)
 
 # Wildcard and quantifiers
 result = match_first(".*@.*", "user@domain.com")
@@ -89,22 +89,22 @@ if result:
 # Find all numbers in text
 var numbers = findall("[0-9]+", "Price: $123, Quantity: 456, Total: $579")
 for i in range(len(numbers)):
-    print("Number found:", numbers[i].match_text)
+    print("Number found:", numbers[i].get_match_text())
 
 # Character ranges
 result = match_first("[a-z]+", "hello123")
 if result:
-    print("Letters:", result.value().match_text)
+    print("Letters:", result.value().get_match_text())
 
 # Groups and alternation
 result = match_first("(com|org|net)", "example.com")
 if result:
-    print("TLD found:", result.value().match_text)
+    print("TLD found:", result.value().get_match_text())
 
 # Find all domains in text
 var domains = findall("(com|org|net)", "Visit example.com or test.org for more info")
 for i in range(len(domains)):
-    print("Domain found:", domains[i].match_text)
+    print("Domain found:", domains[i].get_match_text())
 
 # Anchors
 result = match_first("^https?://", "https://example.com")
@@ -119,7 +119,7 @@ if result:
 # Find all email addresses in text
 var emails = findall("[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}", "Contact john@example.com or mary@test.org")
 for i in range(len(emails)):
-    print("Email found:", emails[i].match_text)
+    print("Email found:", emails[i].get_match_text())
 ```
 
 ## Performance

--- a/proposals/optimization-plan.md
+++ b/proposals/optimization-plan.md
@@ -101,7 +101,7 @@ struct DFAEngine:
             if current_state == -1:  # No transition, no match
                 return None
             if self.states[current_state].is_accepting:
-                return Match(0, start, pos + 1, text, "DFA")
+                return Match(0, start, pos + 1, text)
             pos += 1
 
         return None
@@ -243,7 +243,7 @@ struct RegexVM:
                     if not self._backtrack():
                         return None
             elif instr.opcode == Opcode.MATCH:
-                return Match(0, start, pos, text, "VM")
+                return Match(0, start, pos, text)
             # ... handle other opcodes
 
         return None
@@ -264,7 +264,7 @@ struct MatchPool:
             return match
         else:
             # Expand pool if needed
-            self.pool.append(Match(0, 0, 0, "", ""))
+            self.pool.append(Match(0, 0, 0, ""))
             return self.get_match()
 
     fn reset(mut self):
@@ -314,7 +314,7 @@ struct AhoCorasick:
             # Check for pattern matches at current state
             for pattern in self.output[state]:
                 var start = i - len(pattern) + 1
-                matches.append(Match(0, start, i + 1, text, pattern))
+                matches.append(Match(0, start, i + 1, text))
 
         return matches
 ```

--- a/src/regex/dfa.mojo
+++ b/src/regex/dfa.mojo
@@ -684,7 +684,7 @@ struct DFAEngine(Engine):
                 len(self.states) > 0
                 and self.states[self.start_state].is_accepting
             ):
-                return Match(0, start_pos, start_pos, text, "DFA")
+                return Match(0, start_pos, start_pos, text)
             return None
 
         var current_state = self.start_state
@@ -728,7 +728,7 @@ struct DFAEngine(Engine):
             # Check end anchor constraint
             if self.has_end_anchor and last_accepting_pos != len(text):
                 return None  # End anchor requires match to end at string end
-            return Match(0, start_pos, last_accepting_pos, text, "DFA")
+            return Match(0, start_pos, last_accepting_pos, text)
 
         return None
 
@@ -818,7 +818,7 @@ struct DFAEngine(Engine):
     #         # Check end anchor constraint
     #         if self.has_end_anchor and match_end != text_len:
     #             return None
-    #         return Match(0, start_pos, match_end, text, "DFA+SIMD")
+    #         return Match(0, start_pos, match_end, text)
     #
     #     return None
 

--- a/src/regex/dfa.mojo
+++ b/src/regex/dfa.mojo
@@ -732,7 +732,7 @@ struct DFAEngine(Engine):
 
         return None
 
-    fn match_all(self, text: String) -> List[Match]:
+    fn match_all(self, text: String) -> List[Match, hint_trivial_type=True]:
         """Find all non-overlapping matches using DFA.
 
         Args:
@@ -741,7 +741,7 @@ struct DFAEngine(Engine):
         Returns:
             List of all matches found.
         """
-        var matches = List[Match]()
+        var matches = List[Match, hint_trivial_type=True]()
 
         # Special handling for anchored patterns
         if self.has_start_anchor or self.has_end_anchor:

--- a/src/regex/dfa.mojo
+++ b/src/regex/dfa.mojo
@@ -732,7 +732,9 @@ struct DFAEngine(Engine):
 
         return None
 
-    fn match_all(self, text: String) -> List[Match, hint_trivial_type=True]:
+    fn match_all(
+        self, text: String, out matches: List[Match, hint_trivial_type=True]
+    ):
         """Find all non-overlapping matches using DFA.
 
         Args:
@@ -741,7 +743,7 @@ struct DFAEngine(Engine):
         Returns:
             List of all matches found.
         """
-        var matches = List[Match, hint_trivial_type=True]()
+        matches = List[Match, hint_trivial_type=True]()
 
         # Special handling for anchored patterns
         if self.has_start_anchor or self.has_end_anchor:
@@ -749,7 +751,7 @@ struct DFAEngine(Engine):
             var match_result = self.match_next(text, 0)
             if match_result:
                 matches.append(match_result.value())
-            return matches
+            return
 
         var pos = 0
         while pos <= len(text):
@@ -765,8 +767,6 @@ struct DFAEngine(Engine):
                     pos = match_obj.end_idx
             else:
                 pos += 1
-
-        return matches
 
     # fn _try_match_simd(self, text: String, start_pos: Int) -> Optional[Match]:
     #     """SIMD-optimized matching for character class patterns.

--- a/src/regex/engine.mojo
+++ b/src/regex/engine.mojo
@@ -15,7 +15,7 @@ trait Engine(Copyable, Movable):
         """
         ...
 
-    fn match_all(self, text: String) -> List[Match]:
+    fn match_all(self, text: String) -> List[Match, hint_trivial_type=True]:
         """Find all non-overlapping matches using DFA.
 
         Args:

--- a/src/regex/engine.mojo
+++ b/src/regex/engine.mojo
@@ -15,13 +15,12 @@ trait Engine(Copyable, Movable):
         """
         ...
 
-    fn match_all(self, text: String) -> List[Match, hint_trivial_type=True]:
+    fn match_all(
+        self, text: String, out matches: List[Match, hint_trivial_type=True]
+    ):
         """Find all non-overlapping matches using DFA.
 
         Args:
             text: Input text to search.
-
-        Returns:
-            List of all matches found.
         """
         ...

--- a/src/regex/engine.mojo
+++ b/src/regex/engine.mojo
@@ -1,3 +1,6 @@
+from regex.matching import Match
+
+
 trait Engine(Copyable, Movable):
     fn match_first(self, text: String, start: Int = 0) -> Optional[Match]:
         """Execute DFA matching against input text. To be Python compatible,

--- a/src/regex/matcher.mojo
+++ b/src/regex/matcher.mojo
@@ -32,8 +32,8 @@ trait RegexMatcher:
         ...
 
     fn match_all(
-        self, text: String
-    ) raises -> List[Match, hint_trivial_type=True]:
+        self, text: String, out matches: List[Match, hint_trivial_type=True]
+    ) raises:
         """Find all non-overlapping matches in text.
 
         Args:
@@ -75,8 +75,8 @@ struct DFAMatcher(Copyable, Movable, RegexMatcher):
         return self.engine.match_next(text, start)
 
     fn match_all(
-        self, text: String
-    ) raises -> List[Match, hint_trivial_type=True]:
+        self, text: String, out matches: List[Match, hint_trivial_type=True]
+    ) raises:
         """Find all matches using DFA execution."""
         return self.engine.match_all(text)
 
@@ -116,10 +116,10 @@ struct NFAMatcher(Copyable, Movable, RegexMatcher):
         return self.engine.match_next(text, start)
 
     fn match_all(
-        self, text: String
-    ) raises -> List[Match, hint_trivial_type=True]:
+        self, text: String, out matches: List[Match, hint_trivial_type=True]
+    ) raises:
         """Find all matches using NFA execution."""
-        return self.engine.match_all(text)
+        matches = self.engine.match_all(text)
 
 
 struct HybridMatcher(Copyable, Movable, RegexMatcher):
@@ -194,18 +194,18 @@ struct HybridMatcher(Copyable, Movable, RegexMatcher):
             return self.nfa_matcher.match_next(text, start)
 
     fn match_all(
-        self, text: String
-    ) raises -> List[Match, hint_trivial_type=True]:
+        self, text: String, out matches: List[Match, hint_trivial_type=True]
+    ) raises:
         """Find all matches using optimal engine."""
         if (
             self.dfa_matcher
             and self.complexity.value == PatternComplexity.SIMPLE
         ):
             # Use high-performance DFA for simple patterns
-            return self.dfa_matcher.value().match_all(text)
+            matches = self.dfa_matcher.value().match_all(text)
         else:
             # Fall back to NFA for complex patterns
-            return self.nfa_matcher.match_all(text)
+            matches = self.nfa_matcher.match_all(text)
 
     fn get_engine_type(self) -> String:
         """Get the type of engine being used (for debugging/profiling).
@@ -279,8 +279,8 @@ struct CompiledRegex(Copyable, Movable):
         return self.matcher.match_next(text, start)
 
     fn match_all(
-        self, text: String
-    ) raises -> List[Match, hint_trivial_type=True]:
+        self, text: String, out matches: List[Match, hint_trivial_type=True]
+    ) raises:
         """Find all matches in text.
 
         Args:
@@ -289,7 +289,7 @@ struct CompiledRegex(Copyable, Movable):
         Returns:
             List of all matches found.
         """
-        return self.matcher.match_all(text)
+        matches = self.matcher.match_all(text)
 
     fn test(self, text: String) -> Bool:
         """Test if pattern matches anywhere in text.
@@ -399,8 +399,10 @@ fn search(pattern: String, text: String) raises -> Optional[Match]:
 
 
 fn findall(
-    pattern: String, text: String
-) raises -> List[Match, hint_trivial_type=True]:
+    pattern: String,
+    text: String,
+    out matches: List[Match, hint_trivial_type=True],
+) raises:
     """Find all matches of pattern in text (equivalent to re.findall in Python).
 
     Args:
@@ -411,7 +413,7 @@ fn findall(
         List of all matches found.
     """
     var compiled = compile_regex(pattern)
-    return compiled.match_all(text)
+    matches = compiled.match_all(text)
 
 
 fn match_first(pattern: String, text: String) raises -> Optional[Match]:

--- a/src/regex/matcher.mojo
+++ b/src/regex/matcher.mojo
@@ -31,7 +31,9 @@ trait RegexMatcher:
         """
         ...
 
-    fn match_all(self, text: String) raises -> List[Match]:
+    fn match_all(
+        self, text: String
+    ) raises -> List[Match, hint_trivial_type=True]:
         """Find all non-overlapping matches in text.
 
         Args:
@@ -72,7 +74,9 @@ struct DFAMatcher(Copyable, Movable, RegexMatcher):
         """Find first match using DFA execution."""
         return self.engine.match_next(text, start)
 
-    fn match_all(self, text: String) raises -> List[Match]:
+    fn match_all(
+        self, text: String
+    ) raises -> List[Match, hint_trivial_type=True]:
         """Find all matches using DFA execution."""
         return self.engine.match_all(text)
 
@@ -111,7 +115,9 @@ struct NFAMatcher(Copyable, Movable, RegexMatcher):
         """Find first match using DFA execution."""
         return self.engine.match_next(text, start)
 
-    fn match_all(self, text: String) raises -> List[Match]:
+    fn match_all(
+        self, text: String
+    ) raises -> List[Match, hint_trivial_type=True]:
         """Find all matches using NFA execution."""
         return self.engine.match_all(text)
 
@@ -187,7 +193,9 @@ struct HybridMatcher(Copyable, Movable, RegexMatcher):
             # Fall back to NFA for complex patterns
             return self.nfa_matcher.match_next(text, start)
 
-    fn match_all(self, text: String) raises -> List[Match]:
+    fn match_all(
+        self, text: String
+    ) raises -> List[Match, hint_trivial_type=True]:
         """Find all matches using optimal engine."""
         if (
             self.dfa_matcher
@@ -270,7 +278,9 @@ struct CompiledRegex(Copyable, Movable):
         """
         return self.matcher.match_next(text, start)
 
-    fn match_all(self, text: String) raises -> List[Match]:
+    fn match_all(
+        self, text: String
+    ) raises -> List[Match, hint_trivial_type=True]:
         """Find all matches in text.
 
         Args:
@@ -388,7 +398,9 @@ fn search(pattern: String, text: String) raises -> Optional[Match]:
     return compiled.match_first(text)
 
 
-fn findall(pattern: String, text: String) raises -> List[Match]:
+fn findall(
+    pattern: String, text: String
+) raises -> List[Match, hint_trivial_type=True]:
     """Find all matches of pattern in text (equivalent to re.findall in Python).
 
     Args:

--- a/src/regex/matching.mojo
+++ b/src/regex/matching.mojo
@@ -1,10 +1,13 @@
+from memory import UnsafePointer
+
+
 struct Match(Copyable, Movable):
     """Contains the information of a match in a regular expression."""
 
     var group_id: Int
     var start_idx: Int
     var end_idx: Int
-    var match_text: String
+    var text_ptr: UnsafePointer[String, mut=False]
     var name: String
 
     fn __init__(
@@ -13,10 +16,14 @@ struct Match(Copyable, Movable):
         start_idx: Int,
         end_idx: Int,
         text: String,
-        name: String,
+        owned name: String,
     ):
         self.group_id = group_id
-        self.name: String = name
+        self.name: String = name^
         self.start_idx = start_idx
         self.end_idx = end_idx
-        self.match_text = text[start_idx:end_idx]
+        self.text_ptr = UnsafePointer(to=text)
+
+    fn get_match_text(self) -> StringSlice[ImmutableAnyOrigin]:
+        """Returns the text that was matched."""
+        return self.text_ptr[].as_string_slice()[self.start_idx : self.end_idx]

--- a/src/regex/matching.mojo
+++ b/src/regex/matching.mojo
@@ -17,14 +17,6 @@ struct Match(Copyable, Movable):
         end_idx: Int,
         text: String,
     ):
-        print(
-            "Match.__init__ called with group_id:",
-            group_id,
-            "start_idx:",
-            start_idx,
-            "end_idx:",
-            end_idx,
-        )
         self.group_id = group_id
         self.start_idx = start_idx
         self.end_idx = end_idx

--- a/src/regex/matching.mojo
+++ b/src/regex/matching.mojo
@@ -1,6 +1,7 @@
 from memory import UnsafePointer
 
 
+@register_passable("trivial")
 struct Match(Copyable, Movable):
     """Contains the information of a match in a regular expression."""
 

--- a/src/regex/matching.mojo
+++ b/src/regex/matching.mojo
@@ -8,7 +8,6 @@ struct Match(Copyable, Movable):
     var start_idx: Int
     var end_idx: Int
     var text_ptr: UnsafePointer[String, mut=False]
-    var name: String
 
     fn __init__(
         out self,
@@ -16,10 +15,16 @@ struct Match(Copyable, Movable):
         start_idx: Int,
         end_idx: Int,
         text: String,
-        owned name: String,
     ):
+        print(
+            "Match.__init__ called with group_id:",
+            group_id,
+            "start_idx:",
+            start_idx,
+            "end_idx:",
+            end_idx,
+        )
         self.group_id = group_id
-        self.name: String = name^
         self.start_idx = start_idx
         self.end_idx = end_idx
         self.text_ptr = UnsafePointer(to=text)

--- a/src/regex/nfa.mojo
+++ b/src/regex/nfa.mojo
@@ -61,11 +61,12 @@ struct NFAEngine(Engine):
             except:
                 return []
 
-        var matches = List[Match]()
+        var matches = List[Match](capacity=len(text))
         var current_pos = 0
 
+        var temp_matches = List[Match](capacity=10)
         while current_pos <= len(text):
-            var temp_matches = List[Match]()
+            temp_matches.clear()
             var result = self._match_node(
                 ast,
                 text,

--- a/src/regex/nfa.mojo
+++ b/src/regex/nfa.mojo
@@ -26,7 +26,7 @@ struct NFAEngine(Engine):
     fn match_all(
         self,
         text: String,
-    ) -> List[Match]:
+    ) -> List[Match, hint_trivial_type=True]:
         """Searches a regex in a test string.
 
         Searches the passed regular expression in the passed test string and
@@ -61,10 +61,10 @@ struct NFAEngine(Engine):
             except:
                 return []
 
-        var matches = List[Match](capacity=len(text))
+        var matches = List[Match, hint_trivial_type=True](capacity=len(text))
         var current_pos = 0
 
-        var temp_matches = List[Match](capacity=10)
+        var temp_matches = List[Match, hint_trivial_type=True](capacity=10)
         while current_pos <= len(text):
             temp_matches.clear()
             var result = self._match_node(
@@ -108,7 +108,7 @@ struct NFAEngine(Engine):
             position contains the whole match, and the subsequent positions
             contain all the group and subgroups matched.
         """
-        var matches = List[Match]()
+        var matches = List[Match, hint_trivial_type=True]()
         var str_i = start
         var ast: ASTNode
         if self.regex:
@@ -150,7 +150,7 @@ struct NFAEngine(Engine):
             position contains the whole match, and the subsequent positions
             contain all the group and subgroups matched.
         """
-        var matches = List[Match]()
+        var matches = List[Match, hint_trivial_type=True]()
         var str_i = start
         var ast: ASTNode
         if self.regex:
@@ -182,7 +182,7 @@ struct NFAEngine(Engine):
         ast: ASTNode,
         string: String,
         str_i: Int,
-        mut matches: List[Match],
+        mut matches: List[Match, hint_trivial_type=True],
         match_first_mode: Bool = False,
         required_start_pos: Int = -1,
     ) capturing -> Tuple[Bool, Int]:
@@ -396,7 +396,7 @@ struct NFAEngine(Engine):
         ast: ASTNode,
         string: String,
         str_i: Int,
-        mut matches: List[Match],
+        mut matches: List[Match, hint_trivial_type=True],
         match_first_mode: Bool,
         required_start_pos: Int,
     ) capturing -> Tuple[Bool, Int]:
@@ -432,7 +432,7 @@ struct NFAEngine(Engine):
         ast: ASTNode,
         string: String,
         str_i: Int,
-        mut matches: List[Match],
+        mut matches: List[Match, hint_trivial_type=True],
         match_first_mode: Bool,
         required_start_pos: Int,
     ) capturing -> Tuple[Bool, Int]:
@@ -475,7 +475,7 @@ struct NFAEngine(Engine):
         ast: ASTNode,
         string: String,
         str_i: Int,
-        mut matches: List[Match],
+        mut matches: List[Match, hint_trivial_type=True],
         match_first_mode: Bool,
         required_start_pos: Int,
     ) capturing -> Tuple[Bool, Int]:
@@ -526,7 +526,7 @@ struct NFAEngine(Engine):
         children: List[ASTNode],
         string: String,
         str_i: Int,
-        mut matches: List[Match],
+        mut matches: List[Match, hint_trivial_type=True],
         match_first_mode: Bool,
         required_start_pos: Int,
     ) capturing -> Tuple[Bool, Int]:
@@ -594,7 +594,7 @@ struct NFAEngine(Engine):
         remaining_children: List[ASTNode],
         string: String,
         str_i: Int,
-        mut matches: List[Match],
+        mut matches: List[Match, hint_trivial_type=True],
         match_first_mode: Bool,
         required_start_pos: Int,
     ) capturing -> Tuple[Bool, Int]:
@@ -681,7 +681,7 @@ struct NFAEngine(Engine):
         ast: ASTNode,
         string: String,
         str_i: Int,
-        mut matches: List[Match],
+        mut matches: List[Match, hint_trivial_type=True],
         match_first_mode: Bool,
         required_start_pos: Int,
     ) capturing -> Tuple[Bool, Int]:
@@ -743,7 +743,9 @@ struct NFAEngine(Engine):
             return (False, str_i)
 
 
-fn findall(pattern: String, text: String) raises -> List[Match]:
+fn findall(
+    pattern: String, text: String
+) raises -> List[Match, hint_trivial_type=True]:
     """Find all matches of pattern in text (equivalent to re.findall in Python).
 
     Args:

--- a/src/regex/nfa.mojo
+++ b/src/regex/nfa.mojo
@@ -26,7 +26,8 @@ struct NFAEngine(Engine):
     fn match_all(
         self,
         text: String,
-    ) -> List[Match, hint_trivial_type=True]:
+        out matches: List[Match, hint_trivial_type=True],
+    ):
         """Searches a regex in a test string.
 
         Searches the passed regular expression in the passed test string and
@@ -59,9 +60,10 @@ struct NFAEngine(Engine):
             try:
                 ast = parse(self.pattern)
             except:
-                return []
+                matches = []
+                return
 
-        var matches = List[Match, hint_trivial_type=True](capacity=len(text))
+        matches = List[Match, hint_trivial_type=True](capacity=len(text))
         var current_pos = 0
 
         var temp_matches = List[Match, hint_trivial_type=True](capacity=10)
@@ -91,8 +93,6 @@ struct NFAEngine(Engine):
                     current_pos = match_end
             else:
                 current_pos += 1
-
-        return matches
 
     fn match_first(self, text: String, start: Int = 0) -> Optional[Match]:
         """Same as match_all, but always returns after the first match.
@@ -744,8 +744,10 @@ struct NFAEngine(Engine):
 
 
 fn findall(
-    pattern: String, text: String
-) raises -> List[Match, hint_trivial_type=True]:
+    pattern: String,
+    text: String,
+    out matches: List[Match, hint_trivial_type=True],
+) raises:
     """Find all matches of pattern in text (equivalent to re.findall in Python).
 
     Args:
@@ -756,7 +758,7 @@ fn findall(
         List of all matches found.
     """
     var engine = NFAEngine(pattern)
-    return engine.match_all(text)
+    matches = engine.match_all(text)
 
 
 fn match_first(pattern: String, text: String) raises -> Optional[Match]:

--- a/src/regex/nfa.mojo
+++ b/src/regex/nfa.mojo
@@ -80,7 +80,7 @@ struct NFAEngine(Engine):
                 var match_end = result[1]
 
                 # Create match object
-                var matched = Match(0, match_start, match_end, text, "RegEx")
+                var matched = Match(0, match_start, match_end, text)
                 matches.append(matched)
 
                 # Move past this match to find next one
@@ -132,7 +132,7 @@ struct NFAEngine(Engine):
         if result[0]:  # Match found
             var end_idx = result[1]
             # Create the match object
-            var matched = Match(0, str_i, end_idx, text, "RegEx")
+            var matched = Match(0, str_i, end_idx, text)
             return matched^
 
         return None
@@ -173,7 +173,7 @@ struct NFAEngine(Engine):
         if result[0]:  # Match found
             var end_idx = result[1]
             # Always return the overall match with correct range
-            var matched = Match(0, str_i, end_idx, text, "RegEx")
+            var matched = Match(0, str_i, end_idx, text)
             return matched^
 
         return None
@@ -467,7 +467,7 @@ struct NFAEngine(Engine):
 
         # If this is a capturing group, add the match
         if ast.is_capturing():
-            var matched = Match(0, start_pos, result[1], string, ast.group_name)
+            var matched = Match(0, start_pos, result[1], string)
             matches.append(matched)
 
         return result
@@ -512,9 +512,7 @@ struct NFAEngine(Engine):
                 ):
                     break
                 if ast.is_capturing():
-                    var matched = Match(
-                        0, str_i, current_pos, string, ast.group_name
-                    )
+                    var matched = Match(0, str_i, current_pos, string)
                     matches.append(matched)
             else:
                 break

--- a/src/regex/nfa.mojo
+++ b/src/regex/nfa.mojo
@@ -132,8 +132,7 @@ struct NFAEngine(Engine):
         if result[0]:  # Match found
             var end_idx = result[1]
             # Create the match object
-            var matched = Match(0, str_i, end_idx, text)
-            return matched^
+            return Match(0, str_i, end_idx, text)
 
         return None
 
@@ -173,8 +172,7 @@ struct NFAEngine(Engine):
         if result[0]:  # Match found
             var end_idx = result[1]
             # Always return the overall match with correct range
-            var matched = Match(0, str_i, end_idx, text)
-            return matched^
+            return Match(0, str_i, end_idx, text)
 
         return None
 

--- a/tests/test_dfa.mojo
+++ b/tests/test_dfa.mojo
@@ -20,7 +20,7 @@ def test_dfa_literal_pattern():
     var match1 = result1.value()
     assert_equal(match1.start_idx, 0)
     assert_equal(match1.end_idx, 5)
-    assert_equal(match1.match_text, "hello")
+    assert_equal(match1.get_match_text(), "hello")
 
     # Test in middle of string
     var result2 = dfa.match_first("say hello there", 0)
@@ -60,7 +60,7 @@ def test_dfa_character_class():
     var match1 = result1.value()
     assert_equal(match1.start_idx, 0)
     assert_equal(match1.end_idx, 5)
-    assert_equal(match1.match_text, "hello")
+    assert_equal(match1.get_match_text(), "hello")
 
     var result2 = dfa.match_first("123hello", 0)
     # Like Python, this should return False if not at start
@@ -119,7 +119,7 @@ def test_compile_simple_pattern():
 
     var result1 = dfa1.match_first("hello world", 0)
     assert_true(result1.__bool__())
-    assert_equal(result1.value().match_text, "hello")
+    assert_equal(result1.value().get_match_text(), "hello")
 
 
 def test_dfa_single_character():
@@ -130,7 +130,7 @@ def test_dfa_single_character():
     # Should match single character
     var result1 = dfa.match_first("a", 0)
     assert_true(result1.__bool__())
-    assert_equal(result1.value().match_text, "a")
+    assert_equal(result1.value().get_match_text(), "a")
 
     # Should match in longer string
     var result2 = dfa.match_first("banana", 0)
@@ -179,7 +179,7 @@ def test_dfa_state_transitions():
     # Should match complete pattern
     var result1 = dfa.match_first("abc", 0)
     assert_true(result1.__bool__())
-    assert_equal(result1.value().match_text, "abc")
+    assert_equal(result1.value().get_match_text(), "abc")
 
     # Should not match partial pattern
     var result2 = dfa.match_first("ab", 0)
@@ -201,7 +201,7 @@ def test_dfa_start_anchor():
     var match1 = result1.value()
     assert_equal(match1.start_idx, 0)
     assert_equal(match1.end_idx, 5)
-    assert_equal(match1.match_text, "hello")
+    assert_equal(match1.get_match_text(), "hello")
 
     # Should not match when not at start
     var result2 = dfa.match_first("say hello", 0)
@@ -238,7 +238,7 @@ def test_dfa_both_anchors():
     var match1 = result1.value()
     assert_equal(match1.start_idx, 0)
     assert_equal(match1.end_idx, 5)
-    assert_equal(match1.match_text, "hello")
+    assert_equal(match1.get_match_text(), "hello")
 
     # Should not match if there's extra content
     var result2 = dfa.match_first("hello world", 0)
@@ -312,7 +312,7 @@ def test_dfa_anchors_with_high_level_api():
 
     var result1 = dfa1.match_first("hello world", 0)
     assert_true(result1.__bool__())
-    assert_equal(result1.value().match_text, "hello")
+    assert_equal(result1.value().get_match_text(), "hello")
 
     var ast2 = parse("world$")
     var dfa2 = compile_simple_pattern(ast2)
@@ -326,7 +326,7 @@ def test_dfa_anchors_with_high_level_api():
 
     var result3 = dfa3.match_first("hello", 0)
     assert_true(result3.__bool__())
-    assert_equal(result3.value().match_text, "hello")
+    assert_equal(result3.value().get_match_text(), "hello")
 
 
 def test_phone_numbers():
@@ -337,7 +337,7 @@ def test_phone_numbers():
     var dfa = compile_ast_pattern(ast)
     var result = dfa.match_first("+1-541-236-5432", 0)
     assert_true(result.__bool__())
-    assert_equal(result.value().match_text, "+1-541-236-5432")
+    assert_equal(result.value().get_match_text(), "+1-541-236-5432")
 
 
 # Pattern too complex for current DFA implementation
@@ -348,13 +348,13 @@ def test_phone_numbers():
 #     var dfa = compile_ast_pattern(ast)
 #     var result = dfa.match_first(phone, 0)
 #     assert_true(result.__bool__())
-#     assert_equal(result.value().match_text, phone)
+#     assert_equal(result.value().get_match_text(), phone)
 #     es_fixed_line_pattern = "96906(?:0[0-8]|1[1-9]|[2-9]\\d)\\d\\d|9(?:69(?:0[0-57-9]|[1-9]\\d)|73(?:[0-8]\\d|9[1-9]))\\d{4}|(?:8(?:[1356]\\d|[28][0-8]|[47][1-9])|9(?:[135]\\d|[268][0-8]|4[1-9]|7[124-9]))\\d{6}"
 #     var ast2 = parse(es_fixed_line_pattern)
 #     var dfa2 = compile_ast_pattern(ast2)
 #     var result2 = dfa2.match_first(phone)
 #     assert_true(result2.__bool__())
-#     assert_equal(result2.value().match_text, phone)
+#     assert_equal(result2.value().get_match_text(), phone)
 
 
 def test_dfa_state_construction_logic():
@@ -370,7 +370,7 @@ def test_dfa_state_construction_logic():
     # Should work correctly
     var result1 = dfa1.match_first("hello123", 0)
     assert_true(result1.__bool__())
-    assert_equal(result1.value().match_text, "hello123")
+    assert_equal(result1.value().get_match_text(), "hello123")
 
     # Test pattern with different quantifiers to ensure state logic is correct
     var ast2 = parse("[A-Z][a-z]+[0-9]+")
@@ -379,7 +379,7 @@ def test_dfa_state_construction_logic():
     # Should match capital letter, lowercase letters, then digits
     var result2 = dfa2.match_first("Hello123", 0)
     assert_true(result2.__bool__())
-    assert_equal(result2.value().match_text, "Hello123")
+    assert_equal(result2.value().get_match_text(), "Hello123")
 
     # Should not match without capital letter
     var result3 = dfa2.match_first("hello123", 0)
@@ -408,12 +408,12 @@ def test_dfa_optional_element_state_logic():
         result1.__bool__()
     )  # Acknowledge we're checking this but not asserting yet
     # TODO: Uncomment when fixed: assert_true(result1.__bool__())
-    # TODO: Uncomment when fixed: assert_equal(result1.value().match_text, "123")
+    # TODO: Uncomment when fixed: assert_equal(result1.value().get_match_text(), "123")
 
     # Case 2: Letters followed by digits (should work)
     var result2 = dfa.match_first("abc123", 0)
     assert_true(result2.__bool__())
-    assert_equal(result2.value().match_text, "abc123")
+    assert_equal(result2.value().get_match_text(), "abc123")
 
     # Case 3: Only letters, no digits (should fail)
     var result3 = dfa.match_first("abc", 0)

--- a/tests/test_matcher.mojo
+++ b/tests/test_matcher.mojo
@@ -26,7 +26,7 @@ def test_hybrid_matcher_simple_pattern():
     var match_obj = result.value()
     assert_equal(match_obj.start_idx, 0)
     assert_equal(match_obj.end_idx, 5)
-    assert_equal(match_obj.match_text, "hello")
+    assert_equal(match_obj.get_match_text(), "hello")
 
 
 def test_hybrid_matcher_complex_pattern():
@@ -58,7 +58,7 @@ def test_compiled_regex():
     # Test match_first
     var result1 = regex.match_first("hello world")
     assert_true(result1.__bool__())
-    assert_equal(result1.value().match_text, "hello")
+    assert_equal(result1.value().get_match_text(), "hello")
 
     # Test match_all
     var matches = regex.match_all("hello world hello")
@@ -97,14 +97,16 @@ def test_regex_caching():
 
     assert_true(result1.__bool__())
     assert_true(result2.__bool__())
-    assert_equal(result1.value().match_text, result2.value().match_text)
+    assert_equal(
+        result1.value().get_match_text(), result2.value().get_match_text()
+    )
 
 
 def test_search_function():
     """Test high-level search function."""
     var result = search("hello", "hello world")
     assert_true(result.__bool__())
-    assert_equal(result.value().match_text, "hello")
+    assert_equal(result.value().get_match_text(), "hello")
 
     var no_result = search("xyz", "hello world")
     assert_false(no_result.__bool__())
@@ -163,7 +165,7 @@ def test_multiple_patterns():
         var test_text = pattern + " text"
         var result = regex.match_first(test_text)
         assert_true(result.__bool__())
-        assert_equal(result.value().match_text, pattern)
+        assert_equal(result.value().get_match_text(), pattern)
 
 
 def test_empty_pattern():
@@ -576,7 +578,7 @@ def test_findall_one_match():
     assert_equal(len(matches), 1)
     assert_equal(matches[0].start_idx, 0)
     assert_equal(matches[0].end_idx, 3)
-    assert_equal(matches[0].match_text, "ban")
+    assert_equal(matches[0].get_match_text(), "ban")
 
 
 def test_findall_overlapping_avoided():
@@ -593,10 +595,10 @@ def test_findall_with_quantifiers():
     """Test findall with quantifiers."""
     var matches = findall("[0-9]+", "abc123def456ghi")
     assert_equal(len(matches), 2)
-    assert_equal(matches[0].match_text, "123")
+    assert_equal(matches[0].get_match_text(), "123")
     assert_equal(matches[0].start_idx, 3)
     assert_equal(matches[0].end_idx, 6)
-    assert_equal(matches[1].match_text, "456")
+    assert_equal(matches[1].get_match_text(), "456")
     assert_equal(matches[1].start_idx, 9)
     assert_equal(matches[1].end_idx, 12)
 
@@ -605,9 +607,9 @@ def test_findall_wildcard():
     """Test findall with wildcard pattern."""
     var matches = findall(".", "abc")
     assert_equal(len(matches), 3)
-    assert_equal(matches[0].match_text, "a")
-    assert_equal(matches[1].match_text, "b")
-    assert_equal(matches[2].match_text, "c")
+    assert_equal(matches[0].get_match_text(), "a")
+    assert_equal(matches[1].get_match_text(), "b")
+    assert_equal(matches[2].get_match_text(), "c")
 
 
 def test_findall_empty_string():
@@ -646,7 +648,7 @@ def test_dfa_character_class_plus():
     var matched = result.value()
     assert_equal(matched.start_idx, 0)
     assert_equal(matched.end_idx, 5)
-    assert_equal(matched.match_text, "hello")
+    assert_equal(matched.get_match_text(), "hello")
 
 
 def test_dfa_character_class_star():
@@ -657,7 +659,7 @@ def test_dfa_character_class_star():
     var matched1 = result1.value()
     assert_equal(matched1.start_idx, 0)
     assert_equal(matched1.end_idx, 3)
-    assert_equal(matched1.match_text, "123")
+    assert_equal(matched1.get_match_text(), "123")
 
     # Test [0-9]* pattern with no digits at start
     var result2 = match_first("[0-9]*", "abc123")
@@ -665,7 +667,7 @@ def test_dfa_character_class_star():
     var matched2 = result2.value()
     assert_equal(matched2.start_idx, 0)
     assert_equal(matched2.end_idx, 0)
-    assert_equal(matched2.match_text, "")
+    assert_equal(matched2.get_match_text(), "")
 
 
 def test_dfa_character_class_exact():
@@ -676,7 +678,7 @@ def test_dfa_character_class_exact():
     var matched1 = result1.value()
     assert_equal(matched1.start_idx, 0)
     assert_equal(matched1.end_idx, 3)
-    assert_equal(matched1.match_text, "hel")
+    assert_equal(matched1.get_match_text(), "hel")
 
     # Test [a-z]{5} pattern with insufficient characters
     var result2 = match_first("[a-z]{5}", "hi")
@@ -691,7 +693,7 @@ def test_dfa_character_class_range():
     var matched1 = result1.value()
     assert_equal(matched1.start_idx, 0)
     assert_equal(matched1.end_idx, 4)
-    assert_equal(matched1.match_text, "1234")
+    assert_equal(matched1.get_match_text(), "1234")
 
     # Test minimum requirement
     var result2 = match_first("[0-9]{2,4}", "1a")
@@ -703,7 +705,7 @@ def test_dfa_character_class_range():
     var matched3 = result3.value()
     assert_equal(matched3.start_idx, 0)
     assert_equal(matched3.end_idx, 2)
-    assert_equal(matched3.match_text, "12")
+    assert_equal(matched3.get_match_text(), "12")
 
 
 def test_dfa_character_class_anchors():
@@ -714,7 +716,7 @@ def test_dfa_character_class_anchors():
     var matched1 = result1.value()
     assert_equal(matched1.start_idx, 0)
     assert_equal(matched1.end_idx, 5)
-    assert_equal(matched1.match_text, "hello")
+    assert_equal(matched1.get_match_text(), "hello")
 
     # Test ^[a-z]+$ pattern with mixed case (should fail)
     var result2 = match_first("^[a-z]+$", "Hello")
@@ -729,7 +731,7 @@ def test_dfa_mixed_character_classes():
     var matched = result.value()
     assert_equal(matched.start_idx, 0)
     assert_equal(matched.end_idx, 8)
-    assert_equal(matched.match_text, "Hello123")
+    assert_equal(matched.get_match_text(), "Hello123")
 
 
 def test_dfa_character_class_findall():
@@ -737,10 +739,10 @@ def test_dfa_character_class_findall():
     # Test finding all [0-9]+ sequences
     var matches = findall("[0-9]+", "abc123def456ghi")
     assert_equal(len(matches), 2)
-    assert_equal(matches[0].match_text, "123")
+    assert_equal(matches[0].get_match_text(), "123")
     assert_equal(matches[0].start_idx, 3)
     assert_equal(matches[0].end_idx, 6)
-    assert_equal(matches[1].match_text, "456")
+    assert_equal(matches[1].get_match_text(), "456")
     assert_equal(matches[1].start_idx, 9)
     assert_equal(matches[1].end_idx, 12)
 
@@ -753,7 +755,7 @@ def test_dfa_negated_character_class():
     var matched = result.value()
     assert_equal(matched.start_idx, 0)
     assert_equal(matched.end_idx, 3)
-    assert_equal(matched.match_text, "abc")
+    assert_equal(matched.get_match_text(), "abc")
 
 
 def test_dfa_performance_vs_nfa():
@@ -775,7 +777,7 @@ def test_dfa_multi_character_class_basic():
     var matched1 = result1.value()
     assert_equal(matched1.start_idx, 0)
     assert_equal(matched1.end_idx, 8)
-    assert_equal(matched1.match_text, "hello123")
+    assert_equal(matched1.get_match_text(), "hello123")
 
     # Test pattern that should not match
     var result2 = match_first("[a-z]+[0-9]+", "hello")
@@ -794,7 +796,7 @@ def test_dfa_multi_character_class_digit_alpha():
     var matched1 = result1.value()
     assert_equal(matched1.start_idx, 0)
     assert_equal(matched1.end_idx, 6)
-    assert_equal(matched1.match_text, "123abc")
+    assert_equal(matched1.get_match_text(), "123abc")
 
     # Test with insufficient second part
     var result2 = match_first("[0-9]+[a-z]+", "123")
@@ -809,7 +811,7 @@ def test_dfa_multi_character_class_with_quantifiers():
     var matched1 = result1.value()
     assert_equal(matched1.start_idx, 0)
     assert_equal(matched1.end_idx, 6)
-    assert_equal(matched1.match_text, "abc123")
+    assert_equal(matched1.get_match_text(), "abc123")
 
     # Test with both parts present
     var result2 = match_first("[a-z]*[0-9]+", "abc123")
@@ -817,7 +819,7 @@ def test_dfa_multi_character_class_with_quantifiers():
     var matched2 = result2.value()
     assert_equal(matched2.start_idx, 0)
     assert_equal(matched2.end_idx, 6)
-    assert_equal(matched2.match_text, "abc123")
+    assert_equal(matched2.get_match_text(), "abc123")
 
 
 def test_dfa_multi_character_class_three_parts():
@@ -828,7 +830,7 @@ def test_dfa_multi_character_class_three_parts():
     var matched1 = result1.value()
     assert_equal(matched1.start_idx, 0)
     assert_equal(matched1.end_idx, 8)
-    assert_equal(matched1.match_text, "Hello123")
+    assert_equal(matched1.get_match_text(), "Hello123")
 
     # Test insufficient first part
     var result2 = match_first("[A-Z][a-z]+[0-9]+", "hello123")
@@ -843,7 +845,7 @@ def test_dfa_multi_character_class_anchored():
     var matched1 = result1.value()
     assert_equal(matched1.start_idx, 0)
     assert_equal(matched1.end_idx, 8)
-    assert_equal(matched1.match_text, "hello123")
+    assert_equal(matched1.get_match_text(), "hello123")
 
     # Test with extra characters that should fail end anchor
     var result2 = match_first("^[a-z]+[0-9]+$", "hello123x")
@@ -855,11 +857,11 @@ def test_dfa_multi_character_class_findall():
     # Test finding all [a-z]+[0-9]+ patterns
     var matches = findall("[a-z]+[0-9]+", "hello123 world456 test789")
     assert_equal(len(matches), 3)
-    assert_equal(matches[0].match_text, "hello123")
+    assert_equal(matches[0].get_match_text(), "hello123")
     assert_equal(matches[0].start_idx, 0)
-    assert_equal(matches[1].match_text, "world456")
+    assert_equal(matches[1].get_match_text(), "world456")
     assert_equal(matches[1].start_idx, 9)
-    assert_equal(matches[2].match_text, "test789")
+    assert_equal(matches[2].get_match_text(), "test789")
     assert_equal(matches[2].start_idx, 18)
 
 
@@ -881,7 +883,7 @@ def test_dfa_negated_character_class_basic():
     var matched1 = result1.value()
     assert_equal(matched1.start_idx, 0)
     assert_equal(matched1.end_idx, 1)
-    assert_equal(matched1.match_text, "A")
+    assert_equal(matched1.get_match_text(), "A")
 
     # Test [^a-z] should not match lowercase
     var result2 = match_first("[^a-z]", "a")
@@ -891,7 +893,7 @@ def test_dfa_negated_character_class_basic():
     var result3 = match_first("[^0-9]", "x")
     assert_true(result3.__bool__())
     var matched3 = result3.value()
-    assert_equal(matched3.match_text, "x")
+    assert_equal(matched3.get_match_text(), "x")
 
     # Test [^0-9] should not match digits
     var result4 = match_first("[^0-9]", "5")
@@ -906,7 +908,7 @@ def test_dfa_negated_character_class_quantifiers():
     var matched1 = result1.value()
     assert_equal(matched1.start_idx, 0)
     assert_equal(matched1.end_idx, 3)
-    assert_equal(matched1.match_text, "abc")
+    assert_equal(matched1.get_match_text(), "abc")
 
     # Test [^a-z]* pattern (zero or more non-lowercase)
     var result2 = match_first("[^a-z]*", "ABC123def")
@@ -914,7 +916,7 @@ def test_dfa_negated_character_class_quantifiers():
     var matched2 = result2.value()
     assert_equal(matched2.start_idx, 0)
     assert_equal(matched2.end_idx, 6)
-    assert_equal(matched2.match_text, "ABC123")
+    assert_equal(matched2.get_match_text(), "ABC123")
 
     # Test [^abc]{3} pattern (exactly 3 non-abc characters)
     var result3 = match_first("[^abc]{3}", "xyz123")
@@ -922,7 +924,7 @@ def test_dfa_negated_character_class_quantifiers():
     var matched3 = result3.value()
     assert_equal(matched3.start_idx, 0)
     assert_equal(matched3.end_idx, 3)
-    assert_equal(matched3.match_text, "xyz")
+    assert_equal(matched3.get_match_text(), "xyz")
 
 
 def test_dfa_negated_character_class_anchors():
@@ -936,7 +938,7 @@ def test_dfa_negated_character_class_anchors():
     var matched1 = result1.value()
     assert_equal(matched1.start_idx, 0)
     assert_equal(matched1.end_idx, 1)
-    assert_equal(matched1.match_text, "h")
+    assert_equal(matched1.get_match_text(), "h")
 
     # Test [^0-9] should not match digits
     var result2 = match_first("[^0-9]", "5")
@@ -946,7 +948,7 @@ def test_dfa_negated_character_class_anchors():
     var result3 = match_first("[^a-z]", "A")
     assert_true(result3.__bool__())
     var matched3 = result3.value()
-    assert_equal(matched3.match_text, "A")
+    assert_equal(matched3.get_match_text(), "A")
 
 
 def test_dfa_negated_character_class_complex():
@@ -955,7 +957,7 @@ def test_dfa_negated_character_class_complex():
     var result1 = match_first("[^aeiou]+", "bcdfg")
     assert_true(result1.__bool__())
     var matched1 = result1.value()
-    assert_equal(matched1.match_text, "bcdfg")
+    assert_equal(matched1.get_match_text(), "bcdfg")
 
     # Test [^aeiou]+ should stop at vowels
     var result2 = match_first("[^aeiou]+", "bcde")
@@ -963,13 +965,13 @@ def test_dfa_negated_character_class_complex():
     var matched2 = result2.value()
     assert_equal(matched2.start_idx, 0)
     assert_equal(matched2.end_idx, 3)
-    assert_equal(matched2.match_text, "bcd")
+    assert_equal(matched2.get_match_text(), "bcd")
 
     # Test [^A-Z0-9]+ pattern (not uppercase or digits)
     var result3 = match_first("[^A-Z0-9]+", "hello!@#")
     assert_true(result3.__bool__())
     var matched3 = result3.value()
-    assert_equal(matched3.match_text, "hello!@#")
+    assert_equal(matched3.get_match_text(), "hello!@#")
 
 
 def test_dfa_negated_character_class_findall():
@@ -977,13 +979,13 @@ def test_dfa_negated_character_class_findall():
     # Test finding all [^0-9]+ sequences (non-digit sequences)
     var matches = findall("[^0-9]+", "abc123def456ghi")
     assert_equal(len(matches), 3)
-    assert_equal(matches[0].match_text, "abc")
+    assert_equal(matches[0].get_match_text(), "abc")
     assert_equal(matches[0].start_idx, 0)
     assert_equal(matches[0].end_idx, 3)
-    assert_equal(matches[1].match_text, "def")
+    assert_equal(matches[1].get_match_text(), "def")
     assert_equal(matches[1].start_idx, 6)
     assert_equal(matches[1].end_idx, 9)
-    assert_equal(matches[2].match_text, "ghi")
+    assert_equal(matches[2].get_match_text(), "ghi")
     assert_equal(matches[2].start_idx, 12)
     assert_equal(matches[2].end_idx, 15)
 
@@ -997,19 +999,19 @@ def test_dfa_negated_character_class_edge_cases():
     var result1 = match_first("[^abc]", " ")
     assert_true(result1.__bool__())
     var matched1 = result1.value()
-    assert_equal(matched1.match_text, " ")
+    assert_equal(matched1.get_match_text(), " ")
 
     # Test [^abc] with newline (should match since newline is not in "abc")
     var result2 = match_first("[^abc]", "\n")
     assert_true(result2.__bool__())
     var matched2 = result2.value()
-    assert_equal(matched2.match_text, "\n")
+    assert_equal(matched2.get_match_text(), "\n")
 
     # Test [^abc] with tab (should match)
     var result3 = match_first("[^abc]", "\t")
     assert_true(result3.__bool__())
     var matched3 = result3.value()
-    assert_equal(matched3.match_text, "\t")
+    assert_equal(matched3.get_match_text(), "\t")
 
 
 def test_dfa_negated_vs_positive_character_classes():
@@ -1020,14 +1022,14 @@ def test_dfa_negated_vs_positive_character_classes():
     # Positive class should match lowercase letters
     var pos_matches = findall("[a-z]+", test_string)
     assert_equal(len(pos_matches), 2)
-    assert_equal(pos_matches[0].match_text, "ello")
-    assert_equal(pos_matches[1].match_text, "orld")
+    assert_equal(pos_matches[0].get_match_text(), "ello")
+    assert_equal(pos_matches[1].get_match_text(), "orld")
 
     # Negative class should match everything except lowercase letters
     var neg_matches = findall("[^a-z]+", test_string)
     assert_equal(len(neg_matches), 2)
-    assert_equal(neg_matches[0].match_text, "H")
-    assert_equal(neg_matches[1].match_text, "123W")
+    assert_equal(neg_matches[0].get_match_text(), "H")
+    assert_equal(neg_matches[1].get_match_text(), "123W")
 
 
 def test_dfa_negated_character_class_engine_selection():

--- a/tests/test_nfa.mojo
+++ b/tests/test_nfa.mojo
@@ -967,7 +967,7 @@ def test_findall_one_match():
     assert_equal(len(matches), 1)
     assert_equal(matches[0].start_idx, 0)
     assert_equal(matches[0].end_idx, 3)
-    assert_equal(matches[0].match_text, "ban")
+    assert_equal(matches[0].get_match_text(), "ban")
 
 
 def test_findall_overlapping_avoided():
@@ -984,10 +984,10 @@ def test_findall_with_quantifiers():
     """Test findall with quantifiers."""
     var matches = findall("[0-9]+", "abc123def456ghi")
     assert_equal(len(matches), 2)
-    assert_equal(matches[0].match_text, "123")
+    assert_equal(matches[0].get_match_text(), "123")
     assert_equal(matches[0].start_idx, 3)
     assert_equal(matches[0].end_idx, 6)
-    assert_equal(matches[1].match_text, "456")
+    assert_equal(matches[1].get_match_text(), "456")
     assert_equal(matches[1].start_idx, 9)
     assert_equal(matches[1].end_idx, 12)
 
@@ -996,9 +996,9 @@ def test_findall_wildcard():
     """Test findall with wildcard pattern."""
     var matches = findall(".", "abc")
     assert_equal(len(matches), 3)
-    assert_equal(matches[0].match_text, "a")
-    assert_equal(matches[1].match_text, "b")
-    assert_equal(matches[2].match_text, "c")
+    assert_equal(matches[0].get_match_text(), "a")
+    assert_equal(matches[1].get_match_text(), "b")
+    assert_equal(matches[2].get_match_text(), "c")
 
 
 def test_findall_empty_string():
@@ -1036,7 +1036,7 @@ def test_phone_numbers():
     pattern = "[+]*\\d+[-]*\\d+[-]*\\d+[-]*\\d+"
     result = match_first(pattern, "+1-541-236-5432")
     assert_true(result.__bool__())
-    assert_equal(result.value().match_text, "+1-541-236-5432")
+    assert_equal(result.value().get_match_text(), "+1-541-236-5432")
 
 
 def test_es_phone_numbers():
@@ -1044,11 +1044,11 @@ def test_es_phone_numbers():
     phone = "810123456"
     var result = match_first(es_pattern, phone)
     assert_true(result.__bool__())
-    assert_equal(result.value().match_text, phone)
+    assert_equal(result.value().get_match_text(), phone)
     es_fixed_line_pattern = "96906(?:0[0-8]|1[1-9]|[2-9]\\d)\\d\\d|9(?:69(?:0[0-57-9]|[1-9]\\d)|73(?:[0-8]\\d|9[1-9]))\\d{4}|(?:8(?:[1356]\\d|[28][0-8]|[47][1-9])|9(?:[135]\\d|[268][0-8]|4[1-9]|7[124-9]))\\d{6}"
     var result2 = match_first(es_fixed_line_pattern, phone)
     assert_true(result2.__bool__())
-    assert_equal(result2.value().match_text, phone)
+    assert_equal(result2.value().get_match_text(), phone)
 
 
 def test_comprehensive_spanish_phone_patterns():
@@ -1067,7 +1067,7 @@ def test_comprehensive_spanish_phone_patterns():
         var number = mobile_numbers[i]
         var result = match_first(mobile_pattern, number)
         assert_true(result.__bool__())
-        assert_equal(result.value().match_text, number)
+        assert_equal(result.value().get_match_text(), number)
 
     # Test invalid mobile numbers (should not match)
     var invalid_numbers = List[String]()
@@ -1086,22 +1086,22 @@ def test_non_capturing_groups_comprehensive():
     # Test simple non-capturing group
     var result1 = match_first("(?:ab)+", "ababab")
     assert_true(result1.__bool__())
-    assert_equal(result1.value().match_text, "ababab")
+    assert_equal(result1.value().get_match_text(), "ababab")
 
     # Test non-capturing groups with simple alternation
     var result2 = match_first("(?:cat|dog)", "cat")
     assert_true(result2.__bool__())
-    assert_equal(result2.value().match_text, "cat")
+    assert_equal(result2.value().get_match_text(), "cat")
 
     # Test non-capturing groups with alternation and quantifier
     var result3 = match_first("(?:a|b)+", "ababab")
     assert_true(result3.__bool__())
-    assert_equal(result3.value().match_text, "ababab")
+    assert_equal(result3.value().get_match_text(), "ababab")
 
     # Test nested non-capturing groups with alternation
     var result4 = match_first("(?:(?:a|b)(?:c|d))+", "acbdac")
     assert_true(result4.__bool__())
-    assert_equal(result4.value().match_text, "acbdac")
+    assert_equal(result4.value().get_match_text(), "acbdac")
 
 
 def test_complex_alternation_patterns():
@@ -1109,16 +1109,16 @@ def test_complex_alternation_patterns():
     # Test multiple character class alternations
     var result1 = match_first("(?:[1356]\\d|[28][0-8]|[47][1-9])", "81")
     assert_true(result1.__bool__())
-    assert_equal(result1.value().match_text, "81")
+    assert_equal(result1.value().get_match_text(), "81")
 
     # Test different branches
     var result2 = match_first("(?:[1356]\\d|[28][0-8]|[47][1-9])", "15")
     assert_true(result2.__bool__())
-    assert_equal(result2.value().match_text, "15")
+    assert_equal(result2.value().get_match_text(), "15")
 
     var result3 = match_first("(?:[1356]\\d|[28][0-8]|[47][1-9])", "41")
     assert_true(result3.__bool__())
-    assert_equal(result3.value().match_text, "41")
+    assert_equal(result3.value().get_match_text(), "41")
 
     # Test pattern that should not match
     var result4 = match_first("(?:[1356]\\d|[28][0-8]|[47][1-9])", "09")
@@ -1142,7 +1142,7 @@ def test_match_first_vs_search_behavior():
     var match2 = result2.value()
     assert_equal(match2.start_idx, 0)
     assert_equal(match2.end_idx, 5)
-    assert_equal(match2.match_text, "hello")
+    assert_equal(match2.get_match_text(), "hello")
 
     # Test case: pattern should not match if there's prefix
     var result3 = match_first("hello", "say hello")
@@ -1157,7 +1157,7 @@ def test_match_first_anchored_patterns():
     var result1 = match_first("^hello", "hello world")
     assert_true(result1.__bool__())
     var match1 = result1.value()
-    assert_equal(match1.match_text, "hello")
+    assert_equal(match1.get_match_text(), "hello")
 
     # Test that it fails when not at start
     var result2 = match_first("^hello", "say hello")
@@ -1171,7 +1171,7 @@ def test_match_first_empty_pattern():
     var match1 = result1.value()
     assert_equal(match1.start_idx, 0)
     assert_equal(match1.end_idx, 0)
-    assert_equal(match1.match_text, "")
+    assert_equal(match1.get_match_text(), "")
 
 
 def test_specific_user_issue():


### PR DESCRIPTION
## Summary
- Make Match struct trivial by adding `@register_passable("trivial")` decorator
- Replace string storage with pointer reference to avoid unnecessary string copies
- Remove unused `name` field from Match struct
- Add `get_match_text()` method that returns `StringSlice` for efficient text access
- Update all code to use the new getter method instead of direct field access

## Performance Benefits
- **Zero-allocation matches**: Match objects no longer allocate memory for storing matched text
- **Trivial type**: Match can be passed by value efficiently without move semantics
- **Reduced memory footprint**: Eliminated redundant string storage and unused name field
- **Improved cache locality**: Smaller Match objects fit better in CPU cache

## Test Plan
- [x] All existing tests pass with the new Match API
- [x] README examples updated to demonstrate new `get_match_text()` usage
- [x] Performance benchmarks validate the improvements
- [x] DFA and NFA engines work correctly with trivial Match objects 

## Benchmarks

### Before

![image](https://github.com/user-attachments/assets/afc30705-844f-444a-812a-7209ba59a2ea)

### After

![image](https://github.com/user-attachments/assets/e60d401e-88b2-4219-9a3e-3dd1cfa08ee3)
