### PR TITLE
Optimize NFAEngine: Eliminate ASTNode copying in backtracking

### DIFF
--- a/src/regex/ast.mojo
+++ b/src/regex/ast.mojo
@@ -69,8 +69,8 @@ struct ASTNode(
         self.max = other.max
         self.positive_logic = other.positive_logic
         self.children = other.children
-        var call_location = __call_location()
-        print("Copying ASTNode:", self, "in ", call_location)
+        # var call_location = __call_location()
+        # print("Copying ASTNode:", self, "in ", call_location)
 
     fn __bool__(self) -> Bool:
         """Return True if the node is not None."""

--- a/src/regex/ast.mojo
+++ b/src/regex/ast.mojo
@@ -52,11 +52,7 @@ struct ASTNode(
         self.min = min
         self.max = max
         self.positive_logic = positive_logic
-        # TODO: Uncomment when unpacked arguments are supported in Mojo
-        # self.children = List[ASTNode[origin]](*children)
-        self.children = List[ASTNode](capacity=len(children))
-        for child in children:
-            self.children.append(child)
+        self.children = children^
 
     @always_inline
     fn __copyinit__(out self, other: ASTNode):

--- a/src/regex/ast.mojo
+++ b/src/regex/ast.mojo
@@ -10,6 +10,7 @@ alias OR = 8
 alias NOT = 9
 alias GROUP = 10
 
+from builtin._location import __call_location
 from regex.constants import ZERO_CODE, NINE_CODE
 
 
@@ -57,6 +58,7 @@ struct ASTNode(
         for child in children:
             self.children.append(child)
 
+    @always_inline
     fn __copyinit__(out self, other: ASTNode):
         """Copy constructor for ASTNode."""
         self.type = other.type
@@ -67,6 +69,8 @@ struct ASTNode(
         self.max = other.max
         self.positive_logic = other.positive_logic
         self.children = other.children
+        var call_location = __call_location()
+        print("Copying ASTNode:", self, "in ", call_location)
 
     fn __bool__(self) -> Bool:
         """Return True if the node is not None."""

--- a/src/regex/nfa.mojo
+++ b/src/regex/nfa.mojo
@@ -548,7 +548,7 @@ struct NFAEngine(Engine):
             )
 
         # For multiple remaining children, we need to handle backtracking
-        var first_child = children[child_index]
+        ref first_child = children[child_index]
 
         # Try different match lengths for the first child
         if self._has_quantifier(first_child):

--- a/src/regex/optimizer.mojo
+++ b/src/regex/optimizer.mojo
@@ -303,7 +303,7 @@ struct PatternAnalyzer:
 
         # All children must be character classes (RANGE, DIGIT, SPACE)
         for i in range(len(ast.children)):
-            var element = ast.children[i]
+            ref element = ast.children[i]
             if not (
                 element.type == RANGE
                 or element.type == DIGIT


### PR DESCRIPTION
## Summary
- Eliminate exponential ASTNode copying during regex backtracking operations
- Replace list-copying approach with index-based traversal for zero-copy backtracking
- Achieve significant performance improvement for complex regex patterns

## Performance Impact
**Before**: Exponential copying of `remaining_children` lists during recursive backtracking  
**After**: Index-based traversal with zero list copies - only individual node access

## Technical Changes
### Core Optimization
- **Modified `_match_sequence`**: Added `child_index` parameter, eliminated `remaining_children` list creation
- **Updated `_match_with_backtracking`**: Uses children reference + `remaining_index` instead of copied lists
- **Updated all callers**: Pass appropriate indices instead of creating sublists

### Implementation Details
```diff
# Before: Exponential list copying
var remaining_children = List[ASTNode](capacity=len(children) - 1)
for i in range(1, len(children)):
    remaining_children.append(children[i])  // Triggers copy constructor\!

# After: Zero-copy index-based approach  
var first_child = children[child_index]
# Pass child_index + 1 for remaining children
```

## Benchmarking

<img width="2255" height="466" alt="2025-07-14_00-42" src="https://github.com/user-attachments/assets/010efd5f-a82c-40ab-80e1-3787ab09a7df" />
