### PR TITLE
Optimize var→ref conversions across core modules for memory allocation reductions

### DIFF
--- a/docs/performance-tips.md
+++ b/docs/performance-tips.md
@@ -184,6 +184,15 @@ var char = String(token.value)  # Allocates!
 var codepoint = ord(token.value[0])  # No allocation
 ```
 
+Use references instead of var assignments to avoid unnecessary copies:
+
+```mojo
+# This generate a copy
+var child = ast.get_child(i)  # Allocates a new ASTNode
+# Use this to avoid copying
+ref child = ast.get_child(i)  # No allocation, uses reference
+```
+
 ## Compile-Time Optimizations
 
 ### Using Parameters for Static Values

--- a/src/regex/ast.mojo
+++ b/src/regex/ast.mojo
@@ -373,7 +373,7 @@ struct ASTNode[regex_origin: ImmutableOrigin](
             # For range elements, use XNOR logic for positive/negative matching
             var ch_found = False
             if self.get_value():
-                var range_pattern = self.get_value().value()
+                ref range_pattern = self.get_value().value()
                 ch_found = self._is_char_in_range(value, range_pattern)
             return not (
                 ch_found ^ self.positive_logic

--- a/src/regex/dfa.mojo
+++ b/src/regex/dfa.mojo
@@ -484,7 +484,7 @@ struct DFAEngine(Engine):
         var current_state_index = 0
 
         for element_idx in range(len(pattern_info.elements)):
-            var element = pattern_info.elements[element_idx]
+            ref element = pattern_info.elements[element_idx]
             var is_last_element = element_idx == len(pattern_info.elements) - 1
 
             # Create states for this element based on its quantifier
@@ -598,7 +598,7 @@ struct DFAEngine(Engine):
         var current_state_index = 0
 
         for element_idx in range(len(sequence_info.elements)):
-            var element = sequence_info.elements[element_idx]
+            ref element = sequence_info.elements[element_idx]
             var is_last_element = element_idx == len(sequence_info.elements) - 1
 
             # Check if all remaining elements are optional
@@ -685,7 +685,7 @@ struct DFAEngine(Engine):
                 # we also need to add transitions from the optional element's match state
                 if element_idx == 1 and current_state_index == 0:
                     # The previous element was optional, add transitions from its match state too
-                    var prev_element = sequence_info.elements[0]
+                    ref prev_element = sequence_info.elements[0]
                     if prev_element.min_matches == 0:
                         # Add transitions from the optional element's match state (which should be state 1)
                         self._add_character_class_transitions_with_logic(
@@ -858,7 +858,7 @@ struct DFAEngine(Engine):
 
         # Navigate to the quantified group: RE -> GROUP -> GROUP (with quantifier)
         ref outer_group = ast.get_child(0)  # First GROUP
-        var inner_group = outer_group.get_child(
+        ref inner_group = outer_group.get_child(
             0
         )  # Second GROUP (with quantifier)
 
@@ -999,7 +999,7 @@ struct DFAEngine(Engine):
         self.start_state = 0
 
         # Navigate to the group containing elements with quantifiers
-        var group = ast.get_child(0)  # GROUP
+        ref group = ast.get_child(0)  # GROUP
 
         # Extract pattern text and find quantifier info
         var pattern_parts = List[String]()
@@ -1009,8 +1009,8 @@ struct DFAEngine(Engine):
 
         # Process each element to build pattern and detect quantifier
         for i in range(group.get_children_len()):
-            var element = group.get_child(i)
-            var char_text = String(element.get_value().value())
+            ref element = group.get_child(i)
+            ref char_text = String(element.get_value().value())
 
             if element.min == 0 and element.max == -1:  # *
                 quantifier_type = "*"
@@ -1194,8 +1194,8 @@ struct DFAEngine(Engine):
         self.start_state = 0
 
         # Navigate to the wildcard element
-        var group = ast.get_child(0)  # GROUP
-        var wildcard = group.get_child(0)  # WILDCARD
+        ref group = ast.get_child(0)  # GROUP
+        ref wildcard = group.get_child(0)  # WILDCARD
 
         # Extract quantifier information
         var quantifier_min = wildcard.min
@@ -1288,9 +1288,9 @@ struct DFAEngine(Engine):
 
         # Navigate to the OR structure inside the group
         # Pattern structure: RE -> GROUP -> GROUP -> OR tree
-        var outer_group = ast.get_child(0)  # Outer GROUP
-        var inner_group = outer_group.get_child(0)  # Inner GROUP
-        var or_node = inner_group.get_child(0)  # OR node
+        ref outer_group = ast.get_child(0)  # Outer GROUP
+        ref inner_group = outer_group.get_child(0)  # Inner GROUP
+        ref or_node = inner_group.get_child(0)  # OR node
 
         # Extract all alternation branches
         var branches = List[String]()
@@ -1307,8 +1307,8 @@ struct DFAEngine(Engine):
 
         if node.type == OR:
             # Get left and right children
-            var left_child = node.get_child(0)
-            var right_child = node.get_child(1)
+            ref left_child = node.get_child(0)
+            ref right_child = node.get_child(1)
 
             # Recursively process both sides
             self._extract_all_prefix_branches(left_child, branches)
@@ -1317,9 +1317,9 @@ struct DFAEngine(Engine):
             # Extract string from GROUP of ELEMENTs
             var branch_text = String("")
             for i in range(node.get_children_len()):
-                var element = node.get_child(i)
+                ref element = node.get_child(i)
                 if element.type == ELEMENT:
-                    var char_value = element.get_value().value()
+                    ref char_value = element.get_value().value()
                     branch_text += String(char_value)
             branches.append(branch_text)
 
@@ -1329,7 +1329,7 @@ struct DFAEngine(Engine):
             return
 
         # Find the common prefix among all branches
-        var common_prefix = self._find_common_prefix(branches)
+        ref common_prefix = self._find_common_prefix(branches)
         var prefix_len = len(common_prefix)
 
         # Build states for the common prefix
@@ -1343,7 +1343,7 @@ struct DFAEngine(Engine):
 
         # Process each branch after common prefix
         for i in range(len(branches)):
-            var branch = branches[i]
+            ref branch = branches[i]
             if len(branch) == prefix_len:
                 # Branch ends at common prefix - make current state accepting
                 self.states[current_state].is_accepting = True
@@ -1375,7 +1375,7 @@ struct DFAEngine(Engine):
             return branches[0]
 
         var prefix = String("")
-        var first_branch = branches[0]
+        ref first_branch = branches[0]
         var min_length = len(first_branch)
 
         # Find minimum length
@@ -1429,9 +1429,9 @@ struct DFAEngine(Engine):
 
         # Navigate to the quantified group and alternation
         # Pattern structure: RE -> GROUP -> GROUP(quantified) -> OR
-        var outer_group = ast.get_child(0)  # Outer GROUP
-        var quantified_group = outer_group.get_child(0)  # Quantified GROUP
-        var or_node = quantified_group.get_child(0)  # OR node
+        ref outer_group = ast.get_child(0)  # Outer GROUP
+        ref quantified_group = outer_group.get_child(0)  # Quantified GROUP
+        ref or_node = quantified_group.get_child(0)  # OR node
 
         # Extract quantifier information
         var quantifier_min = quantified_group.min
@@ -1465,8 +1465,8 @@ struct DFAEngine(Engine):
 
         if node.type == OR:
             # Get left and right children
-            var left_child = node.get_child(0)
-            var right_child = node.get_child(1)
+            ref left_child = node.get_child(0)
+            ref right_child = node.get_child(1)
 
             # Recursively process both sides
             self._extract_all_alternation_branches_for_quantified(
@@ -1479,9 +1479,9 @@ struct DFAEngine(Engine):
             # Extract string from GROUP of ELEMENTs
             var branch_text = String("")
             for i in range(node.get_children_len()):
-                var element = node.get_child(i)
+                ref element = node.get_child(i)
                 if element.type == ELEMENT:
-                    var char_value = element.get_value().value()
+                    ref char_value = element.get_value().value()
                     branch_text += String(char_value)
             branches.append(branch_text)
 
@@ -1500,7 +1500,7 @@ struct DFAEngine(Engine):
 
         # Add paths for each branch
         for i in range(len(branches)):
-            var branch = branches[i]
+            ref branch = branches[i]
             var current_state = 0
 
             for j in range(len(branch)):
@@ -1527,7 +1527,7 @@ struct DFAEngine(Engine):
 
         # For each branch, create path that loops back to start
         for i in range(len(branches)):
-            var branch = branches[i]
+            ref branch = branches[i]
             var current_state = 0
 
             for j in range(len(branch)):
@@ -1554,7 +1554,7 @@ struct DFAEngine(Engine):
 
         # For each branch, create path to loop state
         for i in range(len(branches)):
-            var branch = branches[i]
+            ref branch = branches[i]
             var current_state = 0
 
             for j in range(len(branch)):
@@ -1573,7 +1573,7 @@ struct DFAEngine(Engine):
 
         # From loop state, can match any branch again (loop back through each branch)
         for i in range(len(branches)):
-            var branch = branches[i]
+            ref branch = branches[i]
             var current_state = loop_index
 
             for j in range(len(branch)):
@@ -1767,7 +1767,7 @@ struct DFAEngine(Engine):
 
         # Fast path for pure literal patterns using SIMD
         if self.is_pure_literal and self.simd_string_search:
-            var searcher = self.simd_string_search.value()
+            ref searcher = self.simd_string_search.value()
             if require_exact_position:
                 # For match_first, must match at exact position
                 if searcher._verify_match(text, start_pos):
@@ -1877,7 +1877,7 @@ struct DFAEngine(Engine):
             # Try to match at current position directly
             var match_result = self._try_match_at_position(text, pos)
             if match_result:
-                var match_obj = match_result.value()
+                ref match_obj = match_result.value()
                 matches.append(match_obj)
                 # Move past this match to find next one
                 if match_obj.end_idx == match_obj.start_idx:
@@ -1907,7 +1907,7 @@ struct DFAEngine(Engine):
         if not self.simd_char_matcher:
             return None
 
-        var simd_matcher = self.simd_char_matcher.value()
+        ref simd_matcher = self.simd_char_matcher.value()
         var text_len = len(text)
 
         if len(self.states) == 0:
@@ -2096,7 +2096,7 @@ fn compile_ast_pattern(ast: ASTNode[MutableAnyOrigin]) raises -> DFAEngine:
         var char_class, min_matches, max_matches, has_start, has_end, positive_logic = _extract_character_class_info(
             ast
         )
-        var char_class_str = char_class.value()
+        ref char_class_str = char_class.value()
         var expanded_char_class = expand_character_range(char_class_str)
         dfa.compile_character_class_with_logic(
             expanded_char_class,
@@ -2108,19 +2108,19 @@ fn compile_ast_pattern(ast: ASTNode[MutableAnyOrigin]) raises -> DFAEngine:
         dfa.has_end_anchor = has_end
     elif _is_multi_character_class_sequence(ast):
         # Handle multi-character class sequences like [a-z]+[0-9]+, \d+\w+
-        var sequence_info = _extract_multi_class_sequence_info(ast)
+        ref sequence_info = _extract_multi_class_sequence_info(ast)
         dfa.compile_multi_character_class_sequence(sequence_info)
         dfa.has_start_anchor = sequence_info.has_start_anchor
         dfa.has_end_anchor = sequence_info.has_end_anchor
     elif _is_sequential_character_class_pattern(ast):
         # Handle sequential character class patterns like [+]*\d+[-]*\d+
-        var sequence_info = _extract_sequential_pattern_info(ast)
+        ref sequence_info = _extract_sequential_pattern_info(ast)
         dfa.compile_sequential_pattern(sequence_info)
         dfa.has_start_anchor = sequence_info.has_start_anchor
         dfa.has_end_anchor = sequence_info.has_end_anchor
     elif _is_mixed_sequential_pattern(ast):
         # Handle mixed patterns like [0-9]+\.?[0-9]* (numbers with optional decimal)
-        var sequence_info = _extract_mixed_sequential_pattern_info(ast)
+        ref sequence_info = _extract_mixed_sequential_pattern_info(ast)
         dfa.compile_multi_character_class_sequence(sequence_info)
         dfa.has_start_anchor = sequence_info.has_start_anchor
         dfa.has_end_anchor = sequence_info.has_end_anchor
@@ -2205,12 +2205,12 @@ fn _is_simple_character_class_pattern(ast: ASTNode[MutableAnyOrigin]) -> Bool:
         return False
 
     if ast.type == RE and ast.get_children_len() == 1:
-        var child = ast.get_child(0)
+        ref child = ast.get_child(0)
         if child.type == DIGIT or child.type == RANGE:
             return True
         elif child.type == GROUP and child.get_children_len() == 1:
             # Check if group contains single digit or range element
-            var inner = child.get_child(0)
+            ref inner = child.get_child(0)
             return inner.type == DIGIT or inner.type == RANGE
     elif ast.type == DIGIT or ast.type == RANGE:
         return True
@@ -2324,13 +2324,13 @@ fn _is_sequential_character_class_pattern(
     if ast.type != RE or ast.get_children_len() != 1:
         return False
 
-    var child = ast.get_child(0)
+    ref child = ast.get_child(0)
     if child.type != GROUP:
         return False
 
     # Check if all children are character classes (RANGE or DIGIT)
     for i in range(child.get_children_len()):
-        var element = child.get_child(i)
+        ref element = child.get_child(i)
         if element.type != RANGE and element.type != DIGIT:
             return False
 
@@ -2357,11 +2357,11 @@ fn _extract_sequential_pattern_info(
     info.has_start_anchor, info.has_end_anchor = pattern_has_anchors(ast)
 
     if ast.type == RE and ast.get_children_len() == 1:
-        var child = ast.get_child(0)
+        ref child = ast.get_child(0)
         if child.type == GROUP:
             # Extract each character class element
             for i in range(child.get_children_len()):
-                var element = child.get_child(i)
+                ref element = child.get_child(i)
                 var char_class: String
 
                 if element.type == DIGIT:
@@ -2397,7 +2397,7 @@ fn _is_multi_character_class_sequence(ast: ASTNode[MutableAnyOrigin]) -> Bool:
     if ast.type != RE or ast.get_children_len() != 1:
         return False
 
-    var child = ast.get_child(0)
+    ref child = ast.get_child(0)
     if child.type != GROUP:
         return False
 
@@ -2451,7 +2451,7 @@ fn _extract_multi_class_sequence_info(
     info.has_start_anchor, info.has_end_anchor = pattern_has_anchors(ast)
 
     if ast.type == RE and ast.get_children_len() == 1:
-        var child = ast.get_child(0)
+        ref child = ast.get_child(0)
         if child.type == GROUP:
             # Extract each character class element
             for i in range(child.get_children_len()):
@@ -2504,7 +2504,7 @@ fn _is_mixed_sequential_pattern(ast: ASTNode[MutableAnyOrigin]) -> Bool:
     if ast.type != RE or ast.get_children_len() != 1:
         return False
 
-    var child = ast.get_child(0)
+    ref child = ast.get_child(0)
     if child.type != GROUP:
         return False
 
@@ -2667,7 +2667,7 @@ fn _find_or_node(
     # Recursively search children
     for i in range(ast.get_children_len()):
         var child = ast.get_child(i)
-        var found = _find_or_node(child)
+        ref found = _find_or_node(child)
         if found:
             return found
 
@@ -2712,7 +2712,7 @@ fn _is_quantified_group(ast: ASTNode[MutableAnyOrigin]) -> Bool:
 
     # Pattern should be RE -> GROUP -> GROUP (with quantifier)
     if ast.type == RE and ast.get_children_len() == 1:
-        var child = ast.get_child(0)
+        ref child = ast.get_child(0)
         if child.type == GROUP and child.get_children_len() == 1:
             var grandchild = child.get_child(0)
             if grandchild.type == GROUP:
@@ -2787,12 +2787,12 @@ fn _collect_all_alternation_branches(
 
         if branch.type == OR:
             # Nested OR - recursively collect its branches
-            var nested_branches = _collect_all_alternation_branches(branch)
+            ref nested_branches = _collect_all_alternation_branches(branch)
             for j in range(len(nested_branches)):
                 branches.append(nested_branches[j])
         else:
             # Leaf branch (ELEMENT or GROUP) - extract its text
-            var branch_text = _extract_branch_text(branch)
+            ref branch_text = _extract_branch_text(branch)
             if len(branch_text) > 0:
                 branches.append(branch_text)
 
@@ -2819,7 +2819,7 @@ fn _is_pure_alternation_pattern(ast: ASTNode[MutableAnyOrigin]) -> Bool:
     if ast.type != RE or ast.get_children_len() != 1:
         return False
 
-    var child = ast.get_child(0)
+    ref child = ast.get_child(0)
 
     # Case 1: RE -> OR (direct alternation)
     if child.type == OR:
@@ -2970,7 +2970,7 @@ fn _extract_literal_branches(
             var element = node.get_child(i)
             if element.type != ELEMENT:
                 return False  # Non-literal element found
-            var char_value = element.get_value().value()
+            ref char_value = element.get_value().value()
             branch_text += String(char_value)
         branches.append(branch_text)
         return True
@@ -2986,7 +2986,7 @@ fn _compute_common_prefix(branches: List[String]) -> String:
         return branches[0]
 
     var prefix = String("")
-    var first_branch = branches[0]
+    ref first_branch = branches[0]
     var min_length = len(first_branch)
 
     # Find minimum length
@@ -3071,7 +3071,7 @@ fn _extract_literal_alternation_branches(
             var element = node.get_child(i)
             if element.type != ELEMENT:
                 return False  # Non-literal element found
-            var char_value = element.get_value().value()
+            ref char_value = element.get_value().value()
             branch_text += String(char_value)
         branches.append(branch_text)
         return True

--- a/src/regex/dfa.mojo
+++ b/src/regex/dfa.mojo
@@ -798,11 +798,11 @@ struct DFAEngine(Engine):
         self.start_state = 0
 
         # Extract the OR node
-        var or_node_opt = _find_or_node(ast)
+        ref or_node_opt = _find_or_node(ast)
         if not or_node_opt:
             raise Error("No OR node found in alternation pattern")
 
-        var or_node = or_node_opt.value()
+        ref or_node = or_node_opt.value()
 
         # Create accepting state that all branches will lead to
         var accepting_state = DFAState(is_accepting=True, match_length=0)
@@ -810,11 +810,11 @@ struct DFAEngine(Engine):
         var accepting_index = len(self.states) - 1
 
         # Collect all branch texts (flattening nested OR structures)
-        var all_branches = _collect_all_alternation_branches(or_node)
+        ref all_branches = _collect_all_alternation_branches(or_node)
 
         # Build trie-like DFA structure to handle shared prefixes
         for i in range(len(all_branches)):
-            var branch_text = all_branches[i]
+            ref branch_text = all_branches[i]
             if len(branch_text) == 0:
                 continue
 
@@ -857,7 +857,7 @@ struct DFAEngine(Engine):
         self.start_state = 0
 
         # Navigate to the quantified group: RE -> GROUP -> GROUP (with quantifier)
-        var outer_group = ast.get_child(0)  # First GROUP
+        ref outer_group = ast.get_child(0)  # First GROUP
         var inner_group = outer_group.get_child(
             0
         )  # Second GROUP (with quantifier)
@@ -866,7 +866,7 @@ struct DFAEngine(Engine):
         var max_matches = inner_group.max
 
         # Extract the literal text from the group
-        var group_text = _extract_group_text(inner_group)
+        ref group_text = _extract_group_text(inner_group)
         if len(group_text) == 0:
             raise Error("Empty quantified group")
 

--- a/src/regex/nfa.mojo
+++ b/src/regex/nfa.mojo
@@ -226,7 +226,7 @@ struct NFAEngine(Engine):
                 )
                 if result[0]:  # Match found
                     var match_start = current_pos
-                    var match_end = result[1]
+                    ref match_end = result[1]
 
                     # Create match object
                     var matched = Match(0, match_start, match_end, text)
@@ -279,7 +279,7 @@ struct NFAEngine(Engine):
             required_start_pos=start,
         )
         if result[0]:  # Match found
-            var end_idx = result[1]
+            ref end_idx = result[1]
             # Create the match object
             return Match(0, str_i, end_idx, text)
 
@@ -370,7 +370,7 @@ struct NFAEngine(Engine):
                     required_start_pos=-1,
                 )
                 if result[0]:  # Match found
-                    var end_idx = result[1]
+                    ref end_idx = result[1]
                     return Match(0, search_pos, end_idx, text)
                 search_pos += 1
 

--- a/src/regex/nfa.mojo
+++ b/src/regex/nfa.mojo
@@ -74,7 +74,7 @@ struct NFAEngine(Engine):
             # Only apply literal optimization for patterns that benefit from it
             # Skip for simple patterns that will use DFA anyway
             if self.regex:
-                var ast = self.regex.value()
+                ref ast = self.regex.value()
                 var analyzer = PatternAnalyzer()
                 var complexity = analyzer.classify(ast)
 
@@ -87,7 +87,7 @@ struct NFAEngine(Engine):
                     # Use best literal if available and significant
                     ref best_literal = literal_set.get_best_literal()
                     if best_literal:
-                        var best = best_literal.value()
+                        ref best = best_literal.value()
                         # Require longer literals to justify overhead
                         if (
                             best.is_prefix
@@ -160,7 +160,7 @@ struct NFAEngine(Engine):
 
         # Use literal prefiltering if available
         if self.has_literal_optimization and self.literal_searcher:
-            var searcher = self.literal_searcher.value()
+            ref searcher = self.literal_searcher.value()
 
             while current_pos <= len(text):
                 # Find next occurrence of literal
@@ -193,7 +193,7 @@ struct NFAEngine(Engine):
                         required_start_pos=-1,
                     )
                     if result[0]:  # Match found
-                        var match_end = result[1]
+                        ref match_end = result[1]
                         if self._match_contains_literal(
                             text, try_pos, match_end
                         ):
@@ -313,7 +313,7 @@ struct NFAEngine(Engine):
 
         # Use literal prefiltering if available
         if self.has_literal_optimization and self.literal_searcher:
-            var searcher = self.literal_searcher.value()
+            ref searcher = self.literal_searcher.value()
 
             while search_pos <= len(text):
                 # Find next occurrence of literal
@@ -347,7 +347,7 @@ struct NFAEngine(Engine):
                         required_start_pos=-1,
                     )
                     if result[0]:  # Match found
-                        var match_end = result[1]
+                        ref match_end = result[1]
                         # Verify the match includes our literal
                         if self._match_contains_literal(
                             text, try_pos, match_end
@@ -652,7 +652,7 @@ struct NFAEngine(Engine):
         var ch_found = False
 
         if ast.get_value():
-            var range_pattern = ast.get_value().value()
+            ref range_pattern = ast.get_value().value()
 
             # Check for common patterns with specialized matchers
             if range_pattern == "[a-zA-Z0-9]":
@@ -1159,7 +1159,7 @@ struct NFAEngine(Engine):
                 whitespace_matcher, str, str_i, min_matches, max_matches
             )
         elif ast.type == RANGE and ast.get_value():
-            var range_pattern = String(ast.get_value().value())
+            ref range_pattern = String(ast.get_value().value())
 
             # Check for common patterns that should use RangeBasedMatcher
             if range_pattern == "[a-zA-Z0-9]":
@@ -1334,7 +1334,7 @@ struct NFAEngine(Engine):
 
                 var range_matcher = self._create_range_matcher(range_pattern)
                 if range_matcher:
-                    var matcher = range_matcher.value()
+                    ref matcher = range_matcher.value()
                     # Handle negated logic
                     if ast.positive_logic:
                         return apply_quantifier_simd_generic(

--- a/src/regex/optimizer.mojo
+++ b/src/regex/optimizer.mojo
@@ -150,7 +150,7 @@ struct PatternAnalyzer:
 
         # Check for required literals
         if literal_set.get_best_literal():
-            var best = literal_set.get_best_literal().value()
+            ref best = literal_set.get_best_literal().value()
             if best.is_required:
                 info.has_required_literal = True
                 info.required_literal_length = best.get_literal_len()
@@ -393,7 +393,7 @@ struct PatternAnalyzer:
             # Check if all children are literal elements or anchors
             var all_literal = True
             for i in range(ast.get_children_len()):
-                var child = ast.get_child(i)
+                ref child = ast.get_child(i)
                 if not (
                     (
                         child.type == ELEMENT
@@ -438,7 +438,7 @@ struct PatternAnalyzer:
         var literal_count = 0
 
         for i in range(ast.get_children_len()):
-            var element = ast.get_child(i)
+            ref element = ast.get_child(i)
             if (
                 element.type == RANGE
                 or element.type == DIGIT
@@ -486,7 +486,7 @@ struct PatternAnalyzer:
 
         # Check that all children are simple literal elements
         for i in range(ast.get_children_len()):
-            var child = ast.get_child(i)
+            ref child = ast.get_child(i)
             if child.type != ELEMENT or child.min != 1 or child.max != 1:
                 return False
 
@@ -536,10 +536,10 @@ struct PatternAnalyzer:
             # Extract literal string from GROUP of ELEMENTs
             var branch_text = String(capacity=String.INLINE_CAPACITY)
             for i in range(node.get_children_len()):
-                var element = node.get_child(i)
+                ref element = node.get_child(i)
                 if element.type != ELEMENT:
                     return False  # Non-literal element found
-                var char_value = element.get_value().value()
+                ref char_value = element.get_value().value()
                 branch_text += String(char_value)
             branches.append(branch_text)
             return True
@@ -556,7 +556,7 @@ struct PatternAnalyzer:
             return branches[0]
 
         var prefix = String(capacity=String.INLINE_CAPACITY)
-        var first_branch = branches[0]
+        ref first_branch = branches[0]
         var min_length = len(first_branch)
 
         # Find minimum length
@@ -604,7 +604,7 @@ struct PatternAnalyzer:
         if ast.get_children_len() != 1:
             return False
 
-        var or_node = ast.get_child(0)
+        ref or_node = ast.get_child(0)
         if or_node.type != OR:
             return False
 
@@ -629,10 +629,10 @@ struct PatternAnalyzer:
             # Extract literal string from GROUP of ELEMENTs
             var branch_text = String("")
             for i in range(node.get_children_len()):
-                var element = node.get_child(i)
+                ref element = node.get_child(i)
                 if element.type != ELEMENT:
                     return False  # Non-literal element found
-                var char_value = element.get_value().value()
+                ref char_value = element.get_value().value()
                 branch_text += String(char_value)
             branches.append(branch_text)
             return True
@@ -677,7 +677,7 @@ fn _is_literal_sequence(ast: ASTNode) -> Bool:
         # For literal pattern detection, check if this group contains nested GROUP nodes
         # If it does, it means there are explicit capturing groups, making it non-literal
         for i in range(ast.get_children_len()):
-            var child = ast.get_child(i)
+            ref child = ast.get_child(i)
             if child.type == GROUP:
                 # Nested groups make the pattern non-literal (explicit capturing groups)
                 return False
@@ -743,7 +743,7 @@ fn pattern_has_anchors(ast: ASTNode) -> Tuple[Bool, Bool]:
     var has_end = False
 
     if ast.type == RE and ast.has_children():
-        var child = ast.get_child(0)
+        ref child = ast.get_child(0)
         has_start, has_end = _check_anchors_recursive(child)
 
     return (has_start, has_end)

--- a/src/regex/parser.mojo
+++ b/src/regex/parser.mojo
@@ -52,7 +52,7 @@ fn check_for_quantifiers[
     regex_origin: ImmutableOrigin
 ](mut i: Int, mut elem: ASTNode[regex_origin], read tokens: List[Token]) raises:
     """Check for quantifiers after an element and set min/max accordingly."""
-    var next_token = tokens[i + 1]
+    ref next_token = tokens[i + 1]
     if next_token.type == Token.ASTERISK:
         elem.min = 0
         elem.max = -1  # -1 means unlimited
@@ -199,7 +199,7 @@ fn parse_token_list[
     var bracket_depth = 0
     var paren_depth_validation = 0
     for validation_i in range(len(tokens)):
-        var validation_token = tokens[validation_i]
+        ref validation_token = tokens[validation_i]
         if validation_token.type == Token.LEFTBRACKET:
             bracket_depth += 1
         elif validation_token.type == Token.RIGHTBRACKET:
@@ -226,7 +226,7 @@ fn parse_token_list[
     var i = 0
 
     while i < len(tokens):
-        var token = tokens[i]
+        ref token = tokens[i]
 
         if token.type == Token.ELEMENT:
             var elem = Element[regex_origin](


### PR DESCRIPTION
## Summary

This PR implements systematic var→ref optimizations across 6 core modules, preventing unnecessary copies and using references instead. 

## Key Optimization Patterns

```mojo
# Before
var outer_group = ast.get_child(0)
var branch_text = all_branches[i]
var char_value = element.get_value().value()
var ast = self.regex.value()

# After  
ref outer_group = ast.get_child(0)
ref branch_text = all_branches[i]
ref char_value = element.get_value().value()
ref ast = self.regex.value()
```
