### PR TITLE
Scale up benchmark parameters 10-100x for meaningful timing results

### DIFF
--- a/benchmarks/bench_engine.mojo
+++ b/benchmarks/bench_engine.mojo
@@ -16,12 +16,12 @@ from pathlib import Path
 # Benchmark Data Generation
 # ===-----------------------------------------------------------------------===#
 
-# Literal optimization test texts
+# Literal optimization test texts - scaled up for meaningful timing
 alias SHORT_TEXT = "hello world this is a test with hello again and hello there"
-alias MEDIUM_TEXT = SHORT_TEXT * 10
-alias LONG_TEXT = SHORT_TEXT * 100
+alias MEDIUM_TEXT = SHORT_TEXT * 100  # Increased from 10 to 100
+alias LONG_TEXT = SHORT_TEXT * 1000  # Increased from 100 to 1000
 alias EMAIL_TEXT = "test@example.com user@test.org admin@example.com support@example.com no-reply@example.com"
-alias EMAIL_LONG = EMAIL_TEXT * 5
+alias EMAIL_LONG = EMAIL_TEXT * 50  # Increased from 5 to 50
 
 
 fn make_test_string[
@@ -68,7 +68,7 @@ fn bench_literal_match[
     @always_inline
     @parameter
     fn call_fn() raises:
-        for _ in range(100):
+        for _ in range(2000):  # Increased from 100 to 2000
             var result = match_first(pattern, test_text)
             keep(result.__bool__())
 
@@ -89,7 +89,7 @@ fn bench_wildcard_match[
     @always_inline
     @parameter
     fn call_fn() raises:
-        for _ in range(50):
+        for _ in range(1000):  # Increased from 50 to 1000
             var result = match_first(pattern, test_text)
             keep(result.__bool__())
 
@@ -110,7 +110,7 @@ fn bench_range_match[
     @always_inline
     @parameter
     fn call_fn() raises:
-        for _ in range(50):
+        for _ in range(1000):  # Increased from 50 to 1000
             var result = match_first(pattern, test_text)
             keep(result.__bool__())
 
@@ -131,7 +131,7 @@ fn bench_anchor_match[
     @always_inline
     @parameter
     fn call_fn() raises:
-        for _ in range(100):
+        for _ in range(2000):  # Increased from 100 to 2000
             var result = match_first(pattern, test_text)
             keep(result.__bool__())
 
@@ -152,7 +152,7 @@ fn bench_alternation_match[
     @always_inline
     @parameter
     fn call_fn() raises:
-        for _ in range(50):
+        for _ in range(1000):  # Increased from 50 to 1000
             var result = match_first(pattern, test_text)
             keep(result.__bool__())
 
@@ -173,7 +173,7 @@ fn bench_group_match[
     @always_inline
     @parameter
     fn call_fn() raises:
-        for _ in range(50):
+        for _ in range(1000):  # Increased from 50 to 1000
             var result = match_first(pattern, test_text)
             keep(result.__bool__())
 
@@ -194,7 +194,7 @@ fn bench_match_all[
     @always_inline
     @parameter
     fn call_fn() raises:
-        for _ in range(10):  # Fewer iterations since findall is more expensive
+        for _ in range(200):  # Increased from 10 to 200
             var results = findall(pattern, test_text)
             var count = len(results)
             keep(count)
@@ -217,7 +217,7 @@ fn bench_complex_email_match[text_length: Int](mut b: Bencher) raises:
     @always_inline
     @parameter
     fn call_fn() raises:
-        for _ in range(2):
+        for _ in range(40):  # Increased from 2 to 40
             var results = findall(pattern, email_text)
             var count = len(results)
             keep(count)
@@ -238,7 +238,7 @@ fn bench_complex_number_extraction[text_length: Int](mut b: Bencher) raises:
     @always_inline
     @parameter
     fn call_fn() raises:
-        for _ in range(25):
+        for _ in range(500):  # Increased from 25 to 500
             var results = findall(pattern, number_text)
             var count = len(results)
             keep(count)
@@ -296,7 +296,7 @@ fn bench_simd_heavy_filtering[
     @always_inline
     @parameter
     fn call_fn() raises:
-        for _ in range(10):  # Fewer iterations due to large text size
+        for _ in range(200):  # Increased from 10 to 200
             var result = match_first(pattern, test_text)
             keep(result.__bool__())
 
@@ -477,89 +477,89 @@ def main():
     # Basic literal matching
     print("=== Literal Matching Benchmarks ===")
     detect_and_report_engine("hello", "literal_match_short")
-    m.bench_function[bench_literal_match[1000, "hello"]](
+    m.bench_function[bench_literal_match[10000, "hello"]](
         BenchId(String("literal_match_short"))
     )
     detect_and_report_engine("hello", "literal_match_long")
-    m.bench_function[bench_literal_match[10000, "hello"]](
+    m.bench_function[bench_literal_match[100000, "hello"]](
         BenchId(String("literal_match_long"))
     )
 
     # Wildcard and quantifiers
     print("=== Wildcard and Quantifier Benchmarks ===")
     detect_and_report_engine(".*", "wildcard_match_any")
-    m.bench_function[bench_wildcard_match[1000, ".*"]](
+    m.bench_function[bench_wildcard_match[10000, ".*"]](
         BenchId(String("wildcard_match_any"))
     )
     detect_and_report_engine("a*", "quantifier_zero_or_more")
-    m.bench_function[bench_wildcard_match[1000, "a*"]](
+    m.bench_function[bench_wildcard_match[10000, "a*"]](
         BenchId(String("quantifier_zero_or_more"))
     )
     detect_and_report_engine("a+", "quantifier_one_or_more")
-    m.bench_function[bench_wildcard_match[1000, "a+"]](
+    m.bench_function[bench_wildcard_match[10000, "a+"]](
         BenchId(String("quantifier_one_or_more"))
     )
     detect_and_report_engine("a?", "quantifier_zero_or_one")
-    m.bench_function[bench_wildcard_match[1000, "a?"]](
+    m.bench_function[bench_wildcard_match[10000, "a?"]](
         BenchId(String("quantifier_zero_or_one"))
     )
 
     # Character ranges
     print("=== Character Range Benchmarks ===")
     detect_and_report_engine("[a-z]+", "range_lowercase")
-    m.bench_function[bench_range_match[1000, "[a-z]+"]](
+    m.bench_function[bench_range_match[10000, "[a-z]+"]](
         BenchId(String("range_lowercase"))
     )
     detect_and_report_engine("[0-9]+", "range_digits")
-    m.bench_function[bench_range_match[1000, "[0-9]+"]](
+    m.bench_function[bench_range_match[10000, "[0-9]+"]](
         BenchId(String("range_digits"))
     )
     detect_and_report_engine("[a-zA-Z0-9]+", "range_alphanumeric")
-    m.bench_function[bench_range_match[1000, "[a-zA-Z0-9]+"]](
+    m.bench_function[bench_range_match[10000, "[a-zA-Z0-9]+"]](
         BenchId(String("range_alphanumeric"))
     )
 
     # Anchors
     print("=== Anchor Benchmarks ===")
     detect_and_report_engine("^abc", "anchor_start")
-    m.bench_function[bench_anchor_match[1000, "^abc"]](
+    m.bench_function[bench_anchor_match[10000, "^abc"]](
         BenchId(String("anchor_start"))
     )
     detect_and_report_engine("xyz$", "anchor_end")
-    m.bench_function[bench_anchor_match[1000, "xyz$"]](
+    m.bench_function[bench_anchor_match[10000, "xyz$"]](
         BenchId(String("anchor_end"))
     )
 
     # Alternation
     print("=== Alternation Benchmarks ===")
     detect_and_report_engine("a|b|c", "alternation_simple")
-    m.bench_function[bench_alternation_match[1000, "a|b|c"]](
+    m.bench_function[bench_alternation_match[10000, "a|b|c"]](
         BenchId(String("alternation_simple"))
     )
     detect_and_report_engine("abc|def|ghi", "alternation_words")
-    m.bench_function[bench_alternation_match[1000, "abc|def|ghi"]](
+    m.bench_function[bench_alternation_match[10000, "abc|def|ghi"]](
         BenchId(String("alternation_words"))
     )
 
     # Groups
     print("=== Group Benchmarks ===")
     detect_and_report_engine("(abc)+", "group_quantified")
-    m.bench_function[bench_group_match[1000, "(abc)+"]](
+    m.bench_function[bench_group_match[10000, "(abc)+"]](
         BenchId(String("group_quantified"))
     )
     detect_and_report_engine("(a|b)*", "group_alternation")
-    m.bench_function[bench_group_match[1000, "(a|b)*"]](
+    m.bench_function[bench_group_match[10000, "(a|b)*"]](
         BenchId(String("group_alternation"))
     )
 
     # Global matching
     print("=== Global Matching Benchmarks ===")
     detect_and_report_engine("a", "match_all_simple")
-    m.bench_function[bench_match_all[1000, "a"]](
+    m.bench_function[bench_match_all[10000, "a"]](
         BenchId(String("match_all_simple"))
     )
     detect_and_report_engine("[a-z]+", "match_all_pattern")
-    m.bench_function[bench_match_all[1000, "[a-z]+"]](
+    m.bench_function[bench_match_all[10000, "[a-z]+"]](
         BenchId(String("match_all_pattern"))
     )
 
@@ -569,30 +569,30 @@ def main():
         "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+[.][a-zA-Z]{2,}",
         "complex_email_extraction",
     )
-    m.bench_function[bench_complex_email_match[100]](
+    m.bench_function[bench_complex_email_match[2000]](
         BenchId(String("complex_email_extraction"))
     )
     detect_and_report_engine("[0-9]+[.]?[0-9]*", "complex_number_extraction")
-    m.bench_function[bench_complex_number_extraction[1000]](
+    m.bench_function[bench_complex_number_extraction[20000]](
         BenchId(String("complex_number_extraction"))
     )
 
     # SIMD-Heavy Character Filtering (designed to show maximum SIMD benefit)
     print("=== SIMD-Optimized Character Filtering Benchmarks ===")
     detect_and_report_engine("[a-zA-Z0-9]+", "simd_alphanumeric_large")
-    m.bench_function[bench_simd_heavy_filtering[10000, "[a-zA-Z0-9]+"]](
+    m.bench_function[bench_simd_heavy_filtering[100000, "[a-zA-Z0-9]+"]](
         BenchId(String("simd_alphanumeric_large"))
     )
     detect_and_report_engine("[a-zA-Z0-9]+", "simd_alphanumeric_xlarge")
-    m.bench_function[bench_simd_heavy_filtering[50000, "[a-zA-Z0-9]+"]](
+    m.bench_function[bench_simd_heavy_filtering[500000, "[a-zA-Z0-9]+"]](
         BenchId(String("simd_alphanumeric_xlarge"))
     )
     detect_and_report_engine("[^a-zA-Z0-9]+", "simd_negated_alphanumeric")
-    m.bench_function[bench_simd_heavy_filtering[10000, "[^a-zA-Z0-9]+"]](
+    m.bench_function[bench_simd_heavy_filtering[100000, "[^a-zA-Z0-9]+"]](
         BenchId(String("simd_negated_alphanumeric"))
     )
     detect_and_report_engine("[a-z]+[0-9]+", "simd_multi_char_class")
-    m.bench_function[bench_simd_heavy_filtering[10000, "[a-z]+[0-9]+"]](
+    m.bench_function[bench_simd_heavy_filtering[100000, "[a-z]+[0-9]+"]](
         BenchId(String("simd_multi_char_class"))
     )
 

--- a/benchmarks/python/bench_engine.py
+++ b/benchmarks/python/bench_engine.py
@@ -52,19 +52,19 @@ class Benchmark:
         # Calculate mean time per run
         mean_time = total_time / actual_iterations
 
-        # Get internal iteration count for accurate per-operation timing
+        # Get internal iteration count for accurate per-operation timing - scaled up to match Mojo
         iterations_map = {
-            "literal_match": 100,
-            "wildcard_match": 50,
-            "range_": 50,
-            "anchor_": 100,
-            "alternation_": 50,
-            "group_": 50,
-            "match_all_": 10,
-            "complex_email": 2,
-            "complex_number": 25,
-            "simd_": 10,
-            "literal_prefix_": 1,  # Already optimized in Python's re
+            "literal_match": 2000,  # Increased from 100 to 2000
+            "wildcard_match": 1000,  # Increased from 50 to 1000
+            "range_": 1000,          # Increased from 50 to 1000
+            "anchor_": 2000,         # Increased from 100 to 2000
+            "alternation_": 1000,    # Increased from 50 to 1000
+            "group_": 1000,          # Increased from 50 to 1000
+            "match_all_": 200,       # Increased from 10 to 200
+            "complex_email": 40,     # Increased from 2 to 40
+            "complex_number": 500,   # Increased from 25 to 500
+            "simd_": 200,            # Increased from 10 to 200
+            "literal_prefix_": 1,    # Already optimized in Python's re
             "required_literal_": 1,
             "no_literal_baseline": 1,
             "alternation_common_prefix": 1,
@@ -128,12 +128,12 @@ class Benchmark:
 # Benchmark Data Generation
 # ===-----------------------------------------------------------------------===#
 
-# Literal optimization test texts
+# Literal optimization test texts - scaled up to match Mojo benchmarks
 SHORT_TEXT = "hello world this is a test with hello again and hello there"
-MEDIUM_TEXT = SHORT_TEXT * 10
-LONG_TEXT = SHORT_TEXT * 100
+MEDIUM_TEXT = SHORT_TEXT * 100  # Increased from 10 to 100
+LONG_TEXT = SHORT_TEXT * 1000   # Increased from 100 to 1000
 EMAIL_TEXT = "test@example.com user@test.org admin@example.com support@example.com no-reply@example.com"
-EMAIL_LONG = EMAIL_TEXT * 5
+EMAIL_LONG = EMAIL_TEXT * 50    # Increased from 5 to 50
 
 
 def make_test_string(length: int, pattern: str = "abcdefghijklmnopqrstuvwxyz") -> str:
@@ -158,7 +158,7 @@ def bench_literal_match(test_text: str, pattern: str) -> Callable[[], None]:
     """Benchmark literal string matching."""
 
     def benchmark_fn():
-        for _ in range(100):
+        for _ in range(2000):  # Increased from 100 to 2000
             result = re.search(pattern, test_text)
             # Keep result to prevent optimization
             bool(result)
@@ -175,7 +175,7 @@ def bench_wildcard_match(test_text: str, pattern: str) -> Callable[[], None]:
     """Benchmark wildcard and quantifier patterns."""
 
     def benchmark_fn():
-        for _ in range(50):
+        for _ in range(1000):  # Increased from 50 to 1000
             result = re.match(pattern, test_text)
             bool(result)
 
@@ -191,7 +191,7 @@ def bench_range_match(test_text: str, pattern: str) -> Callable[[], None]:
     """Benchmark character range patterns."""
 
     def benchmark_fn():
-        for _ in range(50):
+        for _ in range(1000):  # Increased from 50 to 1000
             result = re.match(pattern, test_text)
             bool(result)
 
@@ -207,7 +207,7 @@ def bench_anchor_match(test_text: str, pattern: str) -> Callable[[], None]:
     """Benchmark anchor patterns (^ and $)."""
 
     def benchmark_fn():
-        for _ in range(100):
+        for _ in range(2000):  # Increased from 100 to 2000
             result = re.match(pattern, test_text)
             bool(result)
 
@@ -223,7 +223,7 @@ def bench_alternation_match(test_text: str, pattern: str) -> Callable[[], None]:
     """Benchmark alternation patterns (|)."""
 
     def benchmark_fn():
-        for _ in range(50):
+        for _ in range(1000):  # Increased from 50 to 1000
             result = re.search(pattern, test_text)
             bool(result)
 
@@ -239,7 +239,7 @@ def bench_group_match(test_text: str, pattern: str) -> Callable[[], None]:
     """Benchmark group patterns with quantifiers."""
 
     def benchmark_fn():
-        for _ in range(50):
+        for _ in range(1000):  # Increased from 50 to 1000
             result = re.search(pattern, test_text)
             bool(result)
 
@@ -255,7 +255,7 @@ def bench_match_all(test_text: str, pattern: str) -> Callable[[], None]:
     """Benchmark finding all matches in text."""
 
     def benchmark_fn():
-        for _ in range(10):  # Fewer iterations since findall is more expensive
+        for _ in range(200):  # Increased from 10 to 200
             results = re.findall(pattern, test_text)
             len(results)  # Keep result
 
@@ -272,7 +272,7 @@ def bench_complex_email_match(email_text: str) -> Callable[[], None]:
     pattern = r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}"
 
     def benchmark_fn():
-        for _ in range(2):
+        for _ in range(40):  # Increased from 2 to 40
             results = re.findall(pattern, email_text)
             len(results)
 
@@ -284,7 +284,7 @@ def bench_complex_number_extraction(number_text: str) -> Callable[[], None]:
     pattern = r"\d+\.?\d*"
 
     def benchmark_fn():
-        for _ in range(25):
+        for _ in range(500):  # Increased from 25 to 500
             results = re.findall(pattern, number_text)
             len(results)
 
@@ -328,7 +328,7 @@ def bench_simd_heavy_filtering(test_text: str, pattern: str) -> Callable[[], Non
     """
 
     def benchmark_fn():
-        for _ in range(10):  # Fewer iterations due to large text size
+        for _ in range(200):  # Increased from 10 to 200
             result = re.match(pattern, test_text)
             bool(result)
 
@@ -362,19 +362,19 @@ def main():
     """Run all benchmarks and display results."""
     m = Benchmark(num_repetitions=5)
 
-    # Pre-create test strings to avoid measurement overhead
-    text_1000 = make_test_string(1000)
-    text_10000 = make_test_string(10000)
-    text_range_1000 = make_test_string(1000, "abc123XYZ")
-    text_alternation_1000 = make_test_string(1000, "abcdefghijklmnopqrstuvwxyz")
-    text_group_1000 = make_test_string(1000, "abcabcabc")
+    # Pre-create test strings to avoid measurement overhead - scaled up to match Mojo
+    text_10000 = make_test_string(10000)     # Increased from 1000 to 10000
+    text_100000 = make_test_string(100000)   # Increased from 10000 to 100000
+    text_range_10000 = make_test_string(10000, "abc123XYZ")
+    text_alternation_10000 = make_test_string(10000, "abcdefghijklmnopqrstuvwxyz")
+    text_group_10000 = make_test_string(10000, "abcabcabc")
 
-    # Create complex text patterns
-    base_text = make_test_string(100)
+    # Create complex text patterns - scaled up to match Mojo
+    base_text = make_test_string(2000)  # Increased from 100 to 2000
     emails = " user@example.com more text john@test.org "
     email_text = f"{base_text} {emails} {base_text} {emails} {base_text}"
 
-    base_number_text = make_test_string(500, "abc def ghi ")
+    base_number_text = make_test_string(20000, "abc def ghi ")  # Increased from 500 to 20000
     number_text = (
         f"{base_number_text} 123 price $456.78 quantity 789 {base_number_text}"
     )
@@ -383,51 +383,51 @@ def main():
     m.bench_function(
         "literal_match_short",
         bench_literal_match(
-            text_1000 + " hello world" + text_1000,  # Ensure "hello" is present
+            text_10000 + " hello world" + text_10000,  # Ensure "hello" is present
             "hello",
         ),
     )
     m.bench_function(
         "literal_match_long",
         bench_literal_match(
-            text_10000 + " hello world" + text_1000,  # Ensure "hello" is present
+            text_100000 + " hello world" + text_10000,  # Ensure "hello" is present
             "hello",
         ),
     )
 
     # Wildcard and quantifiers
-    m.bench_function("wildcard_match_any", bench_wildcard_match(text_1000, ".*"))
-    m.bench_function("quantifier_zero_or_more", bench_wildcard_match(text_1000, "a*"))
-    m.bench_function("quantifier_one_or_more", bench_wildcard_match(text_1000, "a+"))
-    m.bench_function("quantifier_zero_or_one", bench_wildcard_match(text_1000, "a?"))
+    m.bench_function("wildcard_match_any", bench_wildcard_match(text_10000, ".*"))
+    m.bench_function("quantifier_zero_or_more", bench_wildcard_match(text_10000, "a*"))
+    m.bench_function("quantifier_one_or_more", bench_wildcard_match(text_10000, "a+"))
+    m.bench_function("quantifier_zero_or_one", bench_wildcard_match(text_10000, "a?"))
 
     # Character ranges
-    m.bench_function("range_lowercase", bench_range_match(text_range_1000, "[a-z]+"))
-    m.bench_function("range_digits", bench_range_match(text_range_1000, "[0-9]+"))
+    m.bench_function("range_lowercase", bench_range_match(text_range_10000, "[a-z]+"))
+    m.bench_function("range_digits", bench_range_match(text_range_10000, "[0-9]+"))
     m.bench_function(
-        "range_alphanumeric", bench_range_match(text_range_1000, "[a-zA-Z0-9]+")
+        "range_alphanumeric", bench_range_match(text_range_10000, "[a-zA-Z0-9]+")
     )
 
     # Anchors
-    m.bench_function("anchor_start", bench_anchor_match(text_1000, "^abc"))
-    m.bench_function("anchor_end", bench_anchor_match(text_1000, "xyz$"))
+    m.bench_function("anchor_start", bench_anchor_match(text_10000, "^abc"))
+    m.bench_function("anchor_end", bench_anchor_match(text_10000, "xyz$"))
 
     # Alternation
     m.bench_function(
-        "alternation_simple", bench_alternation_match(text_alternation_1000, "a|b|c")
+        "alternation_simple", bench_alternation_match(text_alternation_10000, "a|b|c")
     )
     m.bench_function(
         "alternation_words",
-        bench_alternation_match(text_alternation_1000, "abc|def|ghi"),
+        bench_alternation_match(text_alternation_10000, "abc|def|ghi"),
     )
 
     # Groups
-    m.bench_function("group_quantified", bench_group_match(text_group_1000, "(abc)+"))
-    m.bench_function("group_alternation", bench_group_match(text_group_1000, "(a|b)*"))
+    m.bench_function("group_quantified", bench_group_match(text_group_10000, "(abc)+"))
+    m.bench_function("group_alternation", bench_group_match(text_group_10000, "(a|b)*"))
 
     # Global matching (unique to our implementation)
-    m.bench_function("match_all_simple", bench_match_all(text_1000, "a"))
-    m.bench_function("match_all_pattern", bench_match_all(text_1000, "[a-z]+"))
+    m.bench_function("match_all_simple", bench_match_all(text_10000, "a"))
+    m.bench_function("match_all_pattern", bench_match_all(text_10000, "[a-z]+"))
 
     # Complex real-world patterns
     m.bench_function("complex_email_extraction", bench_complex_email_match(email_text))
@@ -436,8 +436,8 @@ def main():
     )
 
     # SIMD-Heavy Character Filtering (designed to show maximum SIMD benefit in Mojo comparison)
-    large_mixed_text = make_mixed_content_text(10000)
-    xlarge_mixed_text = make_mixed_content_text(50000)
+    large_mixed_text = make_mixed_content_text(100000)  # Increased from 10000 to 100000
+    xlarge_mixed_text = make_mixed_content_text(500000)  # Increased from 50000 to 500000
 
     m.bench_function(
         "simd_alphanumeric_large",

--- a/benchmarks/rust/src/bench_engine.rs
+++ b/benchmarks/rust/src/bench_engine.rs
@@ -14,19 +14,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("=== RUST REGEX BENCHMARKS ===");
     println!();
 
-    // Pre-create test strings to avoid measurement overhead
-    let text_1000 = make_test_string(1000, "abcdefghijklmnopqrstuvwxyz");
-    let text_10000 = make_test_string(10000, "abcdefghijklmnopqrstuvwxyz");
-    let text_range_1000 = make_test_string(1000, "abc123XYZ");
-    let text_alternation_1000 = make_test_string(1000, "abcdefghijklmnopqrstuvwxyz");
-    let text_group_1000 = make_test_string(1000, "abcabcabc");
+    // Pre-create test strings to avoid measurement overhead - scaled up to match Mojo benchmarks
+    let text_10000 = make_test_string(10000, "abcdefghijklmnopqrstuvwxyz");     // Increased from 1000 to 10000
+    let text_100000 = make_test_string(100000, "abcdefghijklmnopqrstuvwxyz");   // Increased from 10000 to 100000
+    let text_range_10000 = make_test_string(10000, "abc123XYZ");
+    let text_alternation_10000 = make_test_string(10000, "abcdefghijklmnopqrstuvwxyz");
+    let text_group_10000 = make_test_string(10000, "abcabcabc");
 
-    // Create complex text patterns
-    let base_text = make_test_string(100, "abcdefghijklmnopqrstuvwxyz");
+    // Create complex text patterns - scaled up to match Mojo benchmarks
+    let base_text = make_test_string(2000, "abcdefghijklmnopqrstuvwxyz");  // Increased from 100 to 2000
     let emails = " user@example.com more text john@test.org ";
     let email_text = format!("{} {} {} {} {}", base_text, emails, base_text, emails, base_text);
 
-    let base_number_text = make_test_string(500, "abc def ghi ");
+    let base_number_text = make_test_string(20000, "abc def ghi ");  // Increased from 500 to 20000
     let number_text = format!("{} 123 price $456.78 quantity 789 {}", base_number_text, base_number_text);
 
     // Pre-compile all regex patterns to avoid compilation overhead in benchmarks
@@ -42,8 +42,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &mut all_results,
         "literal_match_short",
         &patterns.hello,
-        &format!("{} hello world {}", text_1000, text_1000),
-        100,
+        &format!("{} hello world {}", text_10000, text_10000),  // Updated variable names
+        2000,  // Increased from 100 to 2000
         BenchType::Search
     );
 
@@ -52,8 +52,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &mut all_results,
         "literal_match_long",
         &patterns.hello,
-        &format!("{} hello world {}", text_10000, text_1000),
-        100,
+        &format!("{} hello world {}", text_100000, text_10000),  // Updated variable names
+        2000,  // Increased from 100 to 2000
         BenchType::Search
     );
 
@@ -62,72 +62,72 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // ===-----------------------------------------------------------------------===
     println!("=== Wildcard and Quantifier Benchmarks ===");
 
-    run_benchmark(&timer, &mut all_results, "wildcard_match_any", &patterns.dot_star, &text_1000, 50, BenchType::IsMatch);
-    run_benchmark(&timer, &mut all_results, "quantifier_zero_or_more", &patterns.a_star, &text_1000, 50, BenchType::IsMatch);
-    run_benchmark(&timer, &mut all_results, "quantifier_one_or_more", &patterns.a_plus, &text_1000, 50, BenchType::IsMatch);
-    run_benchmark(&timer, &mut all_results, "quantifier_zero_or_one", &patterns.a_question, &text_1000, 50, BenchType::IsMatch);
+    run_benchmark(&timer, &mut all_results, "wildcard_match_any", &patterns.dot_star, &text_10000, 1000, BenchType::IsMatch);  // Updated text size and iterations (50->1000)
+    run_benchmark(&timer, &mut all_results, "quantifier_zero_or_more", &patterns.a_star, &text_10000, 1000, BenchType::IsMatch);  // Updated text size and iterations (50->1000)
+    run_benchmark(&timer, &mut all_results, "quantifier_one_or_more", &patterns.a_plus, &text_10000, 1000, BenchType::IsMatch);  // Updated text size and iterations (50->1000)
+    run_benchmark(&timer, &mut all_results, "quantifier_zero_or_one", &patterns.a_question, &text_10000, 1000, BenchType::IsMatch);  // Updated text size and iterations (50->1000)
 
     // ===-----------------------------------------------------------------------===
     // Character Range Benchmarks
     // ===-----------------------------------------------------------------------===
     println!("=== Character Range Benchmarks ===");
 
-    run_benchmark(&timer, &mut all_results, "range_lowercase", &patterns.range_a_z, &text_range_1000, 50, BenchType::IsMatch);
-    run_benchmark(&timer, &mut all_results, "range_digits", &patterns.range_0_9, &text_range_1000, 50, BenchType::IsMatch);
-    run_benchmark(&timer, &mut all_results, "range_alphanumeric", &patterns.range_alnum, &text_range_1000, 50, BenchType::IsMatch);
+    run_benchmark(&timer, &mut all_results, "range_lowercase", &patterns.range_a_z, &text_range_10000, 1000, BenchType::IsMatch);  // Updated text size and iterations (50->1000)
+    run_benchmark(&timer, &mut all_results, "range_digits", &patterns.range_0_9, &text_range_10000, 1000, BenchType::IsMatch);  // Updated text size and iterations (50->1000)
+    run_benchmark(&timer, &mut all_results, "range_alphanumeric", &patterns.range_alnum, &text_range_10000, 1000, BenchType::IsMatch);  // Updated text size and iterations (50->1000)
 
     // ===-----------------------------------------------------------------------===
     // Anchor Benchmarks
     // ===-----------------------------------------------------------------------===
     println!("=== Anchor Benchmarks ===");
 
-    run_benchmark(&timer, &mut all_results, "anchor_start", &patterns.anchor_start, &text_1000, 100, BenchType::IsMatch);
-    run_benchmark(&timer, &mut all_results, "anchor_end", &patterns.anchor_end, &text_1000, 100, BenchType::IsMatch);
+    run_benchmark(&timer, &mut all_results, "anchor_start", &patterns.anchor_start, &text_10000, 2000, BenchType::IsMatch);  // Updated text size and iterations (100->2000)
+    run_benchmark(&timer, &mut all_results, "anchor_end", &patterns.anchor_end, &text_10000, 2000, BenchType::IsMatch);  // Updated text size and iterations (100->2000)
 
     // ===-----------------------------------------------------------------------===
     // Alternation Benchmarks
     // ===-----------------------------------------------------------------------===
     println!("=== Alternation Benchmarks ===");
 
-    run_benchmark(&timer, &mut all_results, "alternation_simple", &patterns.alt_simple, &text_alternation_1000, 50, BenchType::Search);
-    run_benchmark(&timer, &mut all_results, "alternation_words", &patterns.alt_words, &text_alternation_1000, 50, BenchType::Search);
+    run_benchmark(&timer, &mut all_results, "alternation_simple", &patterns.alt_simple, &text_alternation_10000, 1000, BenchType::Search);  // Updated text size and iterations (50->1000)
+    run_benchmark(&timer, &mut all_results, "alternation_words", &patterns.alt_words, &text_alternation_10000, 1000, BenchType::Search);  // Updated text size and iterations (50->1000)
 
     // ===-----------------------------------------------------------------------===
     // Group Benchmarks
     // ===-----------------------------------------------------------------------===
     println!("=== Group Benchmarks ===");
 
-    run_benchmark(&timer, &mut all_results, "group_quantified", &patterns.group_quantified, &text_group_1000, 50, BenchType::Search);
-    run_benchmark(&timer, &mut all_results, "group_alternation", &patterns.group_alternation, &text_group_1000, 50, BenchType::Search);
+    run_benchmark(&timer, &mut all_results, "group_quantified", &patterns.group_quantified, &text_group_10000, 1000, BenchType::Search);  // Updated text size and iterations (50->1000)
+    run_benchmark(&timer, &mut all_results, "group_alternation", &patterns.group_alternation, &text_group_10000, 1000, BenchType::Search);  // Updated text size and iterations (50->1000)
 
     // ===-----------------------------------------------------------------------===
     // Global Matching Benchmarks
     // ===-----------------------------------------------------------------------===
     println!("=== Global Matching Benchmarks ===");
 
-    run_benchmark(&timer, &mut all_results, "match_all_simple", &patterns.a, &text_1000, 10, BenchType::FindAll);
-    run_benchmark(&timer, &mut all_results, "match_all_pattern", &patterns.range_a_z, &text_1000, 10, BenchType::FindAll);
+    run_benchmark(&timer, &mut all_results, "match_all_simple", &patterns.a, &text_10000, 200, BenchType::FindAll);  // Updated text size and iterations (10->200)
+    run_benchmark(&timer, &mut all_results, "match_all_pattern", &patterns.range_a_z, &text_10000, 200, BenchType::FindAll);  // Updated text size and iterations (10->200)
 
     // ===-----------------------------------------------------------------------===
     // Complex Pattern Benchmarks
     // ===-----------------------------------------------------------------------===
     println!("=== Complex Pattern Benchmarks ===");
 
-    run_benchmark(&timer, &mut all_results, "complex_email_extraction", &patterns.email, &email_text, 2, BenchType::FindAll);
-    run_benchmark(&timer, &mut all_results, "complex_number_extraction", &patterns.number, &number_text, 25, BenchType::FindAll);
+    run_benchmark(&timer, &mut all_results, "complex_email_extraction", &patterns.email, &email_text, 40, BenchType::FindAll);  // Increased from 2 to 40
+    run_benchmark(&timer, &mut all_results, "complex_number_extraction", &patterns.number, &number_text, 500, BenchType::FindAll);  // Increased from 25 to 500
 
     // ===-----------------------------------------------------------------------===
     // SIMD-Optimized Character Filtering Benchmarks
     // ===-----------------------------------------------------------------------===
     println!("=== SIMD-Optimized Character Filtering Benchmarks ===");
 
-    let large_mixed_text = make_mixed_content_text(10000);
-    let xlarge_mixed_text = make_mixed_content_text(50000);
+    let large_mixed_text = make_mixed_content_text(100000);  // Increased from 10000 to 100000
+    let xlarge_mixed_text = make_mixed_content_text(500000);  // Increased from 50000 to 500000
 
-    run_benchmark(&timer, &mut all_results, "simd_alphanumeric_large", &patterns.range_alnum, &large_mixed_text, 10, BenchType::IsMatch);
-    run_benchmark(&timer, &mut all_results, "simd_alphanumeric_xlarge", &patterns.range_alnum, &xlarge_mixed_text, 10, BenchType::IsMatch);
-    run_benchmark(&timer, &mut all_results, "simd_negated_alphanumeric", &patterns.negated_alnum, &large_mixed_text, 10, BenchType::IsMatch);
-    run_benchmark(&timer, &mut all_results, "simd_multi_char_class", &patterns.multi_char_class, &large_mixed_text, 10, BenchType::IsMatch);
+    run_benchmark(&timer, &mut all_results, "simd_alphanumeric_large", &patterns.range_alnum, &large_mixed_text, 200, BenchType::IsMatch);  // Increased from 10 to 200
+    run_benchmark(&timer, &mut all_results, "simd_alphanumeric_xlarge", &patterns.range_alnum, &xlarge_mixed_text, 200, BenchType::IsMatch);  // Increased from 10 to 200
+    run_benchmark(&timer, &mut all_results, "simd_negated_alphanumeric", &patterns.negated_alnum, &large_mixed_text, 200, BenchType::IsMatch);  // Increased from 10 to 200
+    run_benchmark(&timer, &mut all_results, "simd_multi_char_class", &patterns.multi_char_class, &large_mixed_text, 200, BenchType::IsMatch);  // Increased from 10 to 200
 
     // ===-----------------------------------------------------------------------===
     // Literal Optimization Benchmarks


### PR DESCRIPTION
## Summary

This PR scales up benchmark parameters across all three implementations (Mojo, Python, Rust) to produce meaningful timing results for accurate performance comparisons.

### Changes Made

- **Increased iteration counts**: 100→2000, 50→1000, 25→500, 10→200, 2→40
- **Scaled text sizes 10x**: 1000→10000, 10000→100000 characters  
- **Updated complex pattern datasets**: base text 100→2000, number text 500→20000
- **Applied consistent scaling** across all three implementations

### Results

**Before**: Timing results were in the 0.01-0.5ms range, too close to measurement noise for meaningful comparison

**After**: Timing results now range from 0.00001ms to 331ms, providing clear performance differentiation
