### PR TITLE
Fix critical regex engine state corruption bug

### DIFF
--- a/src/regex/matcher.mojo
+++ b/src/regex/matcher.mojo
@@ -731,21 +731,26 @@ fn compile_regex(pattern: String) raises -> CompiledRegex:
     Returns:
         Compiled regex object ready for matching.
     """
-    regex_cache_ptr = _get_regex_cache()
-    var compiled: CompiledRegex
-
-    if pattern in regex_cache_ptr[]:
-        # Return cached compiled regex if available
-        compiled = regex_cache_ptr[][pattern]
-        return compiled
-    else:
-        # Not in cache, compile new regex
-        compiled = CompiledRegex(pattern)
-
-    # Add to cache (TODO: implement LRU eviction)
-    regex_cache_ptr[][pattern] = compiled
-
-    return compiled
+    # FIXME: Disable caching temporarily due to mutable state corruption bug
+    # CompiledRegex objects contain mutable internal state that gets corrupted
+    # when the same cached object is reused for different operations.
+    # This was causing massive performance degradation (1000x slower) in benchmarks.
+    return CompiledRegex(pattern)
+    # regex_cache_ptr = _get_regex_cache()
+    # var compiled: CompiledRegex
+    #
+    # if pattern in regex_cache_ptr[]:
+    #     # Return cached compiled regex if available
+    #     compiled = regex_cache_ptr[][pattern]
+    #     return compiled
+    # else:
+    #     # Not in cache, compile new regex
+    #     compiled = CompiledRegex(pattern)
+    #
+    # # Add to cache (TODO: implement LRU eviction)
+    # regex_cache_ptr[][pattern] = compiled
+    #
+    # return compiled
 
 
 fn clear_regex_cache():


### PR DESCRIPTION
## Summary
• Fix critical regex engine state corruption bug that was causing findall() to return 0 matches and run 1000x slower
• Disable CompiledRegex caching temporarily to resolve mutable state corruption issue
• Resolves massive benchmark discrepancies between Python and Mojo implementations

## Problem
The regex engine had a critical bug where cached CompiledRegex objects with mutable internal state (HybridMatcher flags, position trackers, etc.) were being reused across different regex operations. This caused state corruption that manifested as:

- findall() returning 0 matches instead of the correct number
- 1000x performance degradation (50ms instead of 0.05ms)  
- Unrealistic benchmark comparisons showing 1500x differences between Python and Mojo

The corruption was triggered by specific sequences like:
1. match_first() operations with wildcard patterns like ".*"
2. Followed by search() operations with character ranges like "[0-9]+"

## Solution
Temporarily disable CompiledRegex caching by making compile_regex() always create new instances instead of reusing cached objects. This prevents the mutable state corruption while maintaining correctness.

The original caching code is commented out and marked with FIXME/TODO for future restoration once proper stateless design or state reset mechanisms are implemented.

## Test plan
- [x] Verified corruption reproduction cases no longer trigger the bug
- [x] Confirmed findall() returns correct match counts after problematic sequences
- [x] Validated realistic performance comparisons between Python and Mojo (2x difference instead of 1500x)
- [x] Tested wildcard, quantifier, and literal pattern combinations