### PR TITLE
Optimize check_for_quantifiers to eliminate string allocations

### DIFF
--- a/benchmarks/run_comparison_with.sh
+++ b/benchmarks/run_comparison_with.sh
@@ -60,7 +60,7 @@ run_and_parse_benchmarks() {
     echo "-----------------------------------------"
 
     # Run Mojo benchmarks and parse output
-    mojo run "benchmarks/${BENCHMARK_TYPE}.mojo" | tee "$output_txt" | python3 benchmarks/parse_mojo_output.py "$output_json"
+    mojo run -I src "benchmarks/${BENCHMARK_TYPE}.mojo" | tee "$output_txt" | python3 benchmarks/parse_mojo_output.py "$output_json"
 
     if [ -f "$output_json" ]; then
         echo "✓ Results saved to $output_json"

--- a/src/regex/parser.mojo
+++ b/src/regex/parser.mojo
@@ -1,4 +1,4 @@
-from regex.aliases import CHAR_COLON
+from regex.aliases import CHAR_COLON, CHAR_ZERO, CHAR_NINE
 from regex.lexer import scan
 from regex.tokens import (
     Token,
@@ -76,8 +76,8 @@ fn check_for_quantifiers[
         # Parse min value directly as integer
         while i < len(tokens) and tokens[i].type == Token.ELEMENT:
             var digit_char = tokens[i].char
-            if digit_char >= ord("0") and digit_char <= ord("9"):
-                min_val = min_val * 10 + (digit_char - ord("0"))
+            if digit_char >= CHAR_ZERO and digit_char <= CHAR_NINE:
+                min_val = min_val * 10 + (digit_char - CHAR_ZERO)
                 has_min = True
             else:
                 raise Error("Invalid digit in quantifier")

--- a/src/regex/parser.mojo
+++ b/src/regex/parser.mojo
@@ -68,28 +68,36 @@ fn check_for_quantifiers[
     elif next_token.type == Token.LEFTCURLYBRACE:
         # Parse curly brace quantifiers
         i += 2  # Skip element and {
-        var min_val = String(
-            capacity=String.INLINE_CAPACITY
-        )  # Pre-allocate for min value
-        var max_val = String(
-            capacity=String.INLINE_CAPACITY
-        )  # Pre-allocate for max value
+        var min_val = 0
+        var max_val = 0
+        var has_min = False
+        var has_max = False
 
-        # Parse min value
+        # Parse min value directly as integer
         while i < len(tokens) and tokens[i].type == Token.ELEMENT:
-            min_val += String(chr(tokens[i].char))
+            var digit_char = tokens[i].char
+            if digit_char >= ord("0") and digit_char <= ord("9"):
+                min_val = min_val * 10 + (digit_char - ord("0"))
+                has_min = True
+            else:
+                raise Error("Invalid digit in quantifier")
             i += 1
 
-        elem.min = atol(min_val) if min_val != "" else 0
+        elem.min = min_val if has_min else 0
 
         # Check for comma (range) or closing brace (exact)
         if i < len(tokens) and tokens[i].type == Token.COMMA:
             i += 1  # Skip comma
-            # Parse max value
+            # Parse max value directly as integer
             while i < len(tokens) and tokens[i].type == Token.ELEMENT:
-                max_val += String(chr(tokens[i].char))
+                var digit_char = tokens[i].char
+                if digit_char >= ord("0") and digit_char <= ord("9"):
+                    max_val = max_val * 10 + (digit_char - ord("0"))
+                    has_max = True
+                else:
+                    raise Error("Invalid digit in quantifier")
                 i += 1
-            elem.max = atol(max_val) if max_val != "" else -1
+            elem.max = max_val if has_max else -1
         else:
             # Exact quantifier {n}
             elem.max = elem.min


### PR DESCRIPTION
Replace inefficient string building with direct integer parsing in curly brace quantifier parsing. This eliminates N string allocations per quantifier where N is the number of digits, significantly improving performance.

Changes:
- Direct integer accumulation instead of string concatenation
- Remove atol() conversion calls
- Add digit validation with proper error handling
- Maintain full compatibility with existing functionality

Fixes #34