### PR TITLE
Accept StringSlice in match_first chain (no String allocation)

### DIFF
--- a/src/regex/aliases.mojo
+++ b/src/regex/aliases.mojo
@@ -57,6 +57,11 @@ def byte_in_string[O: Origin](ch_code: Int, s: StringSlice[O]) -> Bool:
 comptime EMPTY_SLICE = StringSlice[ImmutAnyOrigin]("")
 comptime EMPTY_STRING = String("")
 
+comptime ImmSlice = StringSlice[ImmutAnyOrigin]
+"""Short alias for an immutable string slice with erased origin, used across
+the matcher/engine chain so callers can pass string literals or views
+without allocating a `String`."""
+
 # SIMD matcher type constants
 comptime SIMD_MATCHER_NONE = 0
 comptime SIMD_MATCHER_WHITESPACE = 1

--- a/src/regex/ast.mojo
+++ b/src/regex/ast.mojo
@@ -79,14 +79,6 @@ struct Regex[origin: Origin](Copyable, Equatable, Movable, Writable):
             len(pattern) * 2
         )  # Allocate enough space for children
 
-    def __str__(self) -> String:
-        """Return a string representation of the Regex."""
-        return String("Regex(pattern=", self.pattern, ")")
-
-    def __repr__(self) -> String:
-        """Return a string representation of the Regex."""
-        return String("Regex(pattern=", self.pattern, ")")
-
     @always_inline
     def __eq__[o: Origin](self, other: Regex[origin=o]) -> Bool:
         """Check if two Regex instances are equal."""
@@ -313,22 +305,6 @@ struct ASTNode[regex_origin: ImmutOrigin](
     def __ne__(self, other: ASTNode[Self.regex_origin]) -> Bool:
         """Check if two AST nodes are not equal."""
         return not self.__eq__(other)
-
-    def __repr__(self) -> String:
-        """Return a string representation of the PhoneNumberDesc."""
-        return String(
-            "ASTNode(type=",
-            self.type,
-            ", value=",
-            String(self.get_value().value()) if self.get_value() else "None",
-            ")",
-            sep="",
-        )
-
-    def __str__(self) -> String:
-        """Returns a user-friendly string representation of the PhoneNumberDesc.
-        """
-        return String.write(self)
 
     @no_inline
     def write_to[W: Writer, //](self, mut writer: W):

--- a/src/regex/dfa.mojo
+++ b/src/regex/dfa.mojo
@@ -5,7 +5,7 @@ This module provides O(n) time complexity regex matching for simple patterns tha
 compiled to DFA, as opposed to the exponential worst-case of NFA backtracking.
 """
 
-from regex.aliases import ALL_EXCEPT_NEWLINE, WORD_CHARS
+from regex.aliases import ALL_EXCEPT_NEWLINE, ImmSlice, WORD_CHARS
 from regex.ast import (
     ASTNode,
     DIGIT,
@@ -1785,7 +1785,7 @@ struct DFAEngine(Engine):
         """
         return self.literal_pattern
 
-    def is_match(self, text: String, start: Int = 0) -> Bool:
+    def is_match(self, text: ImmSlice, start: Int = 0) -> Bool:
         """Check if pattern matches at the given position without computing
         match boundaries. Much faster than match_first for simple checks.
 
@@ -1820,7 +1820,7 @@ struct DFAEngine(Engine):
         )
 
     @always_inline
-    def match_first(self, text: String, start: Int = 0) -> Optional[Match]:
+    def match_first(self, text: ImmSlice, start: Int = 0) -> Optional[Match]:
         """Execute DFA matching against input text. To be Python compatible,
         it will not match if the start position is not at the beginning of a line.
 
@@ -1840,7 +1840,7 @@ struct DFAEngine(Engine):
             text, start, require_exact_position=True
         )
 
-    def match_next(self, text: String, start: Int = 0) -> Optional[Match]:
+    def match_next(self, text: ImmSlice, start: Int = 0) -> Optional[Match]:
         """Execute DFA matching against input text. It will match from the given start
         position.
 
@@ -1870,7 +1870,7 @@ struct DFAEngine(Engine):
 
     @always_inline
     def _try_match_at_position(
-        self, text: String, start_pos: Int, require_exact_position: Bool = False
+        self, text: ImmSlice, start_pos: Int, require_exact_position: Bool = False
     ) -> Optional[Match]:
         """Try to match pattern starting at a specific position.
 
@@ -1974,7 +1974,7 @@ struct DFAEngine(Engine):
 
         return None
 
-    def match_all(self, text: String) -> MatchList:
+    def match_all(self, text: ImmSlice) -> MatchList:
         """Find all non-overlapping matches using DFA.
 
         Args:
@@ -2057,7 +2057,7 @@ struct DFAEngine(Engine):
         return matches^
 
     @always_inline
-    def _try_match_simd(self, text: String, start_pos: Int) -> Optional[Match]:
+    def _try_match_simd(self, text: ImmSlice, start_pos: Int) -> Optional[Match]:
         """SIMD-optimized matching for character class patterns with quantifier support.
 
         This hybrid approach uses SIMD for fast character matching while respecting
@@ -2120,7 +2120,7 @@ struct DFAEngine(Engine):
 
     @always_inline
     def _optimized_simd_search(
-        self, text: String, start: Int
+        self, text: ImmSlice, start: Int
     ) -> Optional[Match]:
         """Optimized SIMD-based search for character class patterns.
 
@@ -2175,7 +2175,7 @@ struct DFAEngine(Engine):
         return None
 
     def _find_next_matching_char(
-        self, text: String, start: Int, simd_matcher: CharacterClassSIMD
+        self, text: ImmSlice, start: Int, simd_matcher: CharacterClassSIMD
     ) -> Int:
         """Use SIMD to find the next character that matches the character class.
 

--- a/src/regex/dfa.mojo
+++ b/src/regex/dfa.mojo
@@ -1785,6 +1785,7 @@ struct DFAEngine(Engine):
         """
         return self.literal_pattern
 
+    @always_inline
     def is_match(self, text: ImmSlice, start: Int = 0) -> Bool:
         """Check if pattern matches at the given position without computing
         match boundaries. Much faster than match_first for simple checks.

--- a/src/regex/engine.mojo
+++ b/src/regex/engine.mojo
@@ -1,3 +1,4 @@
+from regex.aliases import ImmSlice
 from regex.matching import Match, MatchList
 
 
@@ -10,7 +11,7 @@ trait Engine(Copyable, Movable):
         """
         ...
 
-    def match_first(self, text: String, start: Int = 0) -> Optional[Match]:
+    def match_first(self, text: ImmSlice, start: Int = 0) -> Optional[Match]:
         """Execute DFA matching against input text. To be Python compatible,
         it will not match if the start position is not at the beginning of a line.
 
@@ -23,7 +24,7 @@ trait Engine(Copyable, Movable):
         """
         ...
 
-    def match_all(self, text: String) -> MatchList:
+    def match_all(self, text: ImmSlice) -> MatchList:
         """Find all non-overlapping matches using Engine.
 
         Args:

--- a/src/regex/matcher.mojo
+++ b/src/regex/matcher.mojo
@@ -153,6 +153,7 @@ struct DFAMatcher(Copyable, Movable, RegexMatcher):
         """Check if DFA matcher is valid (compiled)."""
         return Bool(self.engine_ptr)
 
+    @always_inline
     def is_match(self, text: ImmSlice, start: Int = 0) -> Bool:
         """Check if pattern matches without computing boundaries."""
         return self.engine_ptr[].is_match(text, start)
@@ -502,6 +503,7 @@ struct HybridMatcher(Copyable, Movable, RegexMatcher):
         self.is_wildcard_match_any = take.is_wildcard_match_any
         self.use_pure_dfa = take.use_pure_dfa
 
+    @always_inline
     def is_match(self, text: ImmSlice, start: Int = 0) -> Bool:
         """Check if pattern matches without computing boundaries."""
         if self.is_wildcard_match_any:
@@ -777,6 +779,7 @@ struct CompiledRegex(ImplicitlyCopyable, Movable):
         var result = self.matcher.match_next(text, 0)
         return result.__bool__()
 
+    @always_inline
     def is_match(self, text: ImmSlice, start: Int = 0) -> Bool:
         """Check if pattern matches at the given position without computing
         match boundaries. Much faster than match_first for simple existence checks.

--- a/src/regex/matcher.mojo
+++ b/src/regex/matcher.mojo
@@ -10,6 +10,7 @@ from std.os import abort
 from std.ffi import _Global
 from std.time import monotonic
 
+from regex.aliases import ImmSlice
 from regex.ast import ASTNode
 from regex.matching import Match, MatchList
 from regex.nfa import NFAEngine
@@ -97,7 +98,7 @@ def check_ast_for_anchors(ast: ASTNode[MutAnyOrigin]) -> Bool:
 trait RegexMatcher:
     """Interface for different regex matching engines."""
 
-    def match_first(self, text: String, start: Int = 0) -> Optional[Match]:
+    def match_first(self, text: ImmSlice, start: Int = 0) -> Optional[Match]:
         """Find the first match in text starting from the given position.
 
         Args:
@@ -109,7 +110,7 @@ trait RegexMatcher:
         """
         ...
 
-    def match_all(self, text: String) raises -> MatchList:
+    def match_all(self, text: ImmSlice) raises -> MatchList:
         """Find all non-overlapping matches in text.
 
         Args:
@@ -152,21 +153,21 @@ struct DFAMatcher(Copyable, Movable, RegexMatcher):
         """Check if DFA matcher is valid (compiled)."""
         return Bool(self.engine_ptr)
 
-    def is_match(self, text: String, start: Int = 0) -> Bool:
+    def is_match(self, text: ImmSlice, start: Int = 0) -> Bool:
         """Check if pattern matches without computing boundaries."""
         return self.engine_ptr[].is_match(text, start)
 
     @always_inline
-    def match_first(self, text: String, start: Int = 0) -> Optional[Match]:
+    def match_first(self, text: ImmSlice, start: Int = 0) -> Optional[Match]:
         """Find first match using DFA execution."""
         return self.engine_ptr[].match_first(text, start)
 
     @always_inline
-    def match_next(self, text: String, start: Int = 0) -> Optional[Match]:
+    def match_next(self, text: ImmSlice, start: Int = 0) -> Optional[Match]:
         """Find first match using DFA execution."""
         return self.engine_ptr[].match_next(text, start)
 
-    def match_all(self, text: String) raises -> MatchList:
+    def match_all(self, text: ImmSlice) raises -> MatchList:
         """Find all matches using DFA execution."""
         return self.engine_ptr[].match_all(text)
 
@@ -225,7 +226,7 @@ struct NFAMatcher(Copyable, Movable, RegexMatcher):
             self._lazy_dfa_ptr.free()
 
     @always_inline
-    def match_first(self, text: String, start: Int = 0) -> Optional[Match]:
+    def match_first(self, text: ImmSlice, start: Int = 0) -> Optional[Match]:
         """Find first match. Uses lazy DFA if available."""
         if self._has_lazy_dfa:
             return self._lazy_dfa_ptr[].match_first(text, start)
@@ -242,14 +243,14 @@ struct NFAMatcher(Copyable, Movable, RegexMatcher):
         )
 
     @always_inline
-    def match_next(self, text: String, start: Int = 0) -> Optional[Match]:
+    def match_next(self, text: ImmSlice, start: Int = 0) -> Optional[Match]:
         """Search for match."""
         if self._use_lazy_dfa_for_search():
             return self._lazy_dfa_ptr[].match_next(text, start)
         return self.engine.match_next(text, start)
 
     @always_inline
-    def match_all(self, text: String) raises -> MatchList:
+    def match_all(self, text: ImmSlice) raises -> MatchList:
         """Find all matches."""
         if self._use_lazy_dfa_for_search():
             return self._lazy_dfa_ptr[].match_all(text)
@@ -501,7 +502,7 @@ struct HybridMatcher(Copyable, Movable, RegexMatcher):
         self.is_wildcard_match_any = take.is_wildcard_match_any
         self.use_pure_dfa = take.use_pure_dfa
 
-    def is_match(self, text: String, start: Int = 0) -> Bool:
+    def is_match(self, text: ImmSlice, start: Int = 0) -> Bool:
         """Check if pattern matches without computing boundaries."""
         if self.is_wildcard_match_any:
             return start <= len(text)
@@ -516,7 +517,7 @@ struct HybridMatcher(Copyable, Movable, RegexMatcher):
         return Bool(self.nfa_matcher.match_first(text, start))
 
     @always_inline
-    def match_first(self, text: String, start: Int = 0) -> Optional[Match]:
+    def match_first(self, text: ImmSlice, start: Int = 0) -> Optional[Match]:
         """Find first match using optimal engine. This equivalent to re.match in Python.
         """
 
@@ -538,7 +539,7 @@ struct HybridMatcher(Copyable, Movable, RegexMatcher):
             # Fall back to NFA for complex patterns
             return self.nfa_matcher.match_first(text, start)
 
-    def match_next(self, text: String, start: Int = 0) -> Optional[Match]:
+    def match_next(self, text: ImmSlice, start: Int = 0) -> Optional[Match]:
         """Find first match using optimal engine. This is equivalent to re.search in Python.
         """
         # Fast path: Wildcard match any (.* pattern) always matches from start to end
@@ -590,7 +591,7 @@ struct HybridMatcher(Copyable, Movable, RegexMatcher):
         else:
             return self.nfa_matcher.match_next(text, start)
 
-    def match_all(self, text: String) raises -> MatchList:
+    def match_all(self, text: ImmSlice) raises -> MatchList:
         """Find all matches using optimal engine."""
         # Fast path: Wildcard match any (.* pattern) matches entire text once
         if self.is_wildcard_match_any:
@@ -729,7 +730,7 @@ struct CompiledRegex(ImplicitlyCopyable, Movable):
     #     )
 
     @always_inline
-    def match_first(self, text: String, start: Int = 0) -> Optional[Match]:
+    def match_first(self, text: ImmSlice, start: Int = 0) -> Optional[Match]:
         """Find first match in text. This is equivalent to re.match in Python.
 
         Args:
@@ -741,7 +742,7 @@ struct CompiledRegex(ImplicitlyCopyable, Movable):
         """
         return self.matcher.match_first(text, start)
 
-    def match_next(self, text: String, start: Int = 0) -> Optional[Match]:
+    def match_next(self, text: ImmSlice, start: Int = 0) -> Optional[Match]:
         """Find first match in text. This is equivalent to re.search in Python.
 
         Args:
@@ -753,7 +754,7 @@ struct CompiledRegex(ImplicitlyCopyable, Movable):
         """
         return self.matcher.match_next(text, start)
 
-    def match_all(self, text: String) raises -> MatchList:
+    def match_all(self, text: ImmSlice) raises -> MatchList:
         """Find all matches in text.
 
         Args:
@@ -764,7 +765,7 @@ struct CompiledRegex(ImplicitlyCopyable, Movable):
         """
         return self.matcher.match_all(text)
 
-    def test(mut self, text: String) -> Bool:
+    def test(mut self, text: ImmSlice) -> Bool:
         """Test if pattern matches anywhere in text.
 
         Args:
@@ -776,7 +777,7 @@ struct CompiledRegex(ImplicitlyCopyable, Movable):
         var result = self.matcher.match_next(text, 0)
         return result.__bool__()
 
-    def is_match(self, text: String, start: Int = 0) -> Bool:
+    def is_match(self, text: ImmSlice, start: Int = 0) -> Bool:
         """Check if pattern matches at the given position without computing
         match boundaries. Much faster than match_first for simple existence checks.
 
@@ -873,7 +874,7 @@ def clear_regex_cache():
 
 
 # High-level convenience functions that match Python's re module interface
-def search(pattern: String, text: String) raises -> Optional[Match]:
+def search(pattern: String, text: ImmSlice) raises -> Optional[Match]:
     """Search for pattern in text (equivalent to re.search in Python).
 
     Args:
@@ -889,7 +890,7 @@ def search(pattern: String, text: String) raises -> Optional[Match]:
     return compiled.match_next(text)
 
 
-def findall(pattern: String, text: String) raises -> MatchList:
+def findall(pattern: String, text: ImmSlice) raises -> MatchList:
     """Find all matches of pattern in text (equivalent to re.findall in Python).
 
     Args:
@@ -903,7 +904,7 @@ def findall(pattern: String, text: String) raises -> MatchList:
     return compiled.match_all(text)
 
 
-def match_first(pattern: String, text: String) raises -> Optional[Match]:
+def match_first(pattern: String, text: ImmSlice) raises -> Optional[Match]:
     """Match pattern at beginning of text (equivalent to re.match in Python).
 
     Args:

--- a/src/regex/matching.mojo
+++ b/src/regex/matching.mojo
@@ -15,10 +15,11 @@ struct Match(Copyable, Movable, TrivialRegisterPassable):
     """Starting position of the match in the text."""
     var end_idx: Int
     """Ending position of the match in the text (exclusive)."""
-    var text: ImmSlice
-    """View of the original text being matched. Does not own memory; the
-    caller must keep the backing storage alive for the lifetime of the match.
-    """
+    var text_ptr: UnsafePointer[Byte, ImmutAnyOrigin]
+    """Pointer to the start of the backing text bytes. Does not own memory;
+    the caller must keep the backing storage alive for the lifetime of the
+    match. We only store the base pointer (not a full slice) to keep Match
+    at the same 32-byte footprint as before the StringSlice refactor."""
 
     def __init__(
         out self,
@@ -30,11 +31,14 @@ struct Match(Copyable, Movable, TrivialRegisterPassable):
         self.group_id = group_id
         self.start_idx = start_idx
         self.end_idx = end_idx
-        self.text = text
+        self.text_ptr = text.unsafe_ptr()
 
     def get_match_text(self) -> ImmSlice:
         """Returns the text that was matched."""
-        return self.text[byte = self.start_idx : self.end_idx]
+        return ImmSlice(
+            ptr=self.text_ptr + self.start_idx,
+            length=self.end_idx - self.start_idx,
+        )
 
 
 struct MatchList(Copyable, Movable, Sized):

--- a/src/regex/matching.mojo
+++ b/src/regex/matching.mojo
@@ -1,5 +1,7 @@
 from std.memory import UnsafePointer, memcpy, alloc
 
+from regex.aliases import ImmSlice
+
 
 struct Match(Copyable, Movable, TrivialRegisterPassable):
     """Contains the information of a match in a regular expression."""
@@ -13,26 +15,26 @@ struct Match(Copyable, Movable, TrivialRegisterPassable):
     """Starting position of the match in the text."""
     var end_idx: Int
     """Ending position of the match in the text (exclusive)."""
-    var text_ptr: UnsafePointer[String, ImmutAnyOrigin]
-    """Pointer to the original text being matched."""
+    var text: ImmSlice
+    """View of the original text being matched. Does not own memory; the
+    caller must keep the backing storage alive for the lifetime of the match.
+    """
 
     def __init__(
         out self,
         group_id: Int,
         start_idx: Int,
         end_idx: Int,
-        text: String,
+        text: ImmSlice,
     ):
         self.group_id = group_id
         self.start_idx = start_idx
         self.end_idx = end_idx
-        self.text_ptr = UnsafePointer(to=text)
+        self.text = text
 
-    def get_match_text(self) -> StringSlice[ImmutAnyOrigin]:
+    def get_match_text(self) -> ImmSlice:
         """Returns the text that was matched."""
-        return StringSlice(self.text_ptr[])[
-            byte = self.start_idx : self.end_idx
-        ]
+        return self.text[byte = self.start_idx : self.end_idx]
 
 
 struct MatchList(Copyable, Movable, Sized):

--- a/src/regex/nfa.mojo
+++ b/src/regex/nfa.mojo
@@ -5,6 +5,7 @@ from regex.aliases import (
     CHAR_ZERO,
     CHAR_NINE,
     CHAR_NEWLINE,
+    ImmSlice,
     SIMD_MATCHER_DIGITS,
     SIMD_MATCHER_WHITESPACE,
     byte_in_string,
@@ -118,7 +119,7 @@ struct NFAEngine(Copyable, Engine):
 
     def match_all(
         self,
-        text: String,
+        text: ImmSlice,
     ) -> MatchList:
         """Searches a regex in a test string.
 
@@ -296,7 +297,7 @@ struct NFAEngine(Copyable, Engine):
 
         return matches^
 
-    def match_first(self, text: String, start: Int = 0) -> Optional[Match]:
+    def match_first(self, text: ImmSlice, start: Int = 0) -> Optional[Match]:
         """Same as match_all, but always returns after the first match.
         Equivalent to re.match in Python.
 
@@ -338,7 +339,7 @@ struct NFAEngine(Copyable, Engine):
 
         return None
 
-    def match_next(self, text: String, start: Int = 0) -> Optional[Match]:
+    def match_next(self, text: ImmSlice, start: Int = 0) -> Optional[Match]:
         """Same as match_all, but always returns after the first match.
         It's equivalent to re.search in Python.
 
@@ -450,7 +451,7 @@ struct NFAEngine(Copyable, Engine):
         return None
 
     @always_inline
-    def _find_last_literal(self, text: String, start: Int) -> Int:
+    def _find_last_literal(self, text: ImmSlice, start: Int) -> Int:
         """Find the last occurrence of the literal prefix in text from start."""
         # Use rfind for O(n) reverse search instead of repeated forward search
         var pos = text.rfind(self.literal_prefix)
@@ -534,7 +535,7 @@ struct NFAEngine(Copyable, Engine):
 
     @always_inline
     def _match_contains_literal(
-        self, text: String, start: Int, end: Int
+        self, text: ImmSlice, start: Int, end: Int
     ) -> Bool:
         """Verify that a match contains the required literal."""
         if not self.has_literal_optimization or len(self.literal_prefix) == 0:
@@ -548,7 +549,7 @@ struct NFAEngine(Copyable, Engine):
     def _match_node(
         self,
         ast: ASTNode,
-        str: String,
+        str: ImmSlice,
         str_i: Int,
         mut matches: List[Match],
         match_first_mode: Bool = False,
@@ -646,7 +647,7 @@ struct NFAEngine(Copyable, Engine):
     def _match_element(
         self,
         ast: ASTNode,
-        str: String,
+        str: ImmSlice,
         str_i: Int,
         match_first_mode: Bool,
         required_start_pos: Int,
@@ -671,7 +672,7 @@ struct NFAEngine(Copyable, Engine):
     def _match_wildcard(
         self,
         ast: ASTNode,
-        str: String,
+        str: ImmSlice,
         str_i: Int,
         match_first_mode: Bool,
         required_start_pos: Int,
@@ -693,7 +694,7 @@ struct NFAEngine(Copyable, Engine):
     def _match_space(
         self,
         ast: ASTNode,
-        str: String,
+        str: ImmSlice,
         str_i: Int,
         match_first_mode: Bool,
         required_start_pos: Int,
@@ -717,7 +718,7 @@ struct NFAEngine(Copyable, Engine):
     def _match_digit(
         self,
         ast: ASTNode,
-        str: String,
+        str: ImmSlice,
         str_i: Int,
         match_first_mode: Bool,
         required_start_pos: Int,
@@ -757,7 +758,7 @@ struct NFAEngine(Copyable, Engine):
     def _match_word(
         self,
         ast: ASTNode,
-        str: String,
+        str: ImmSlice,
         str_i: Int,
         match_first_mode: Bool,
         required_start_pos: Int,
@@ -797,7 +798,7 @@ struct NFAEngine(Copyable, Engine):
     def _match_range(
         self,
         ast: ASTNode,
-        str: String,
+        str: ImmSlice,
         str_i: Int,
         match_first_mode: Bool,
         required_start_pos: Int,
@@ -880,7 +881,7 @@ struct NFAEngine(Copyable, Engine):
 
     @always_inline
     def _match_end(
-        self, ast: ASTNode, str: String, str_i: Int
+        self, ast: ASTNode, str: ImmSlice, str_i: Int
     ) capturing -> Tuple[Bool, Int]:
         """Match end anchor ($)."""
         if str_i == len(str):
@@ -905,7 +906,7 @@ struct NFAEngine(Copyable, Engine):
     def _match_or(
         self,
         ast: ASTNode,
-        str: String,
+        str: ImmSlice,
         str_i: Int,
         mut matches: List[Match],
         match_first_mode: Bool,
@@ -941,7 +942,7 @@ struct NFAEngine(Copyable, Engine):
     def _match_group(
         self,
         ast: ASTNode,
-        str: String,
+        str: ImmSlice,
         str_i: Int,
         mut matches: List[Match],
         match_first_mode: Bool,
@@ -987,7 +988,7 @@ struct NFAEngine(Copyable, Engine):
     def _match_group_with_quantifier(
         self,
         ast: ASTNode,
-        str: String,
+        str: ImmSlice,
         str_i: Int,
         mut matches: List[Match],
         match_first_mode: Bool,
@@ -1039,7 +1040,7 @@ struct NFAEngine(Copyable, Engine):
         self,
         ast_parent: ASTNode,
         child_index: Int,
-        str: String,
+        str: ImmSlice,
         str_i: Int,
         mut matches: List[Match],
         match_first_mode: Bool,
@@ -1111,7 +1112,7 @@ struct NFAEngine(Copyable, Engine):
         quantified_node: ASTNode,
         ast_parent: ASTNode,
         remaining_index: Int,
-        str: String,
+        str: ImmSlice,
         str_i: Int,
         mut matches: List[Match],
         match_first_mode: Bool,
@@ -1189,7 +1190,7 @@ struct NFAEngine(Copyable, Engine):
     def _try_match_count(
         self,
         ast: ASTNode,
-        str: String,
+        str: ImmSlice,
         str_i: Int,
         count: Int,
         match_first_mode: Bool,
@@ -1225,7 +1226,7 @@ struct NFAEngine(Copyable, Engine):
     def _match_re(
         self,
         ast: ASTNode,
-        str: String,
+        str: ImmSlice,
         str_i: Int,
         mut matches: List[Match],
         match_first_mode: Bool,
@@ -1247,7 +1248,7 @@ struct NFAEngine(Copyable, Engine):
     def _apply_quantifier(
         self,
         ast: ASTNode,
-        str: String,
+        str: ImmSlice,
         str_i: Int,
         char_consumed: Int,
         match_first_mode: Bool,
@@ -1315,7 +1316,7 @@ struct NFAEngine(Copyable, Engine):
     def _apply_quantifier_simd(
         self,
         ast: ASTNode,
-        str: String,
+        str: ImmSlice,
         str_i: Int,
         min_matches: Int,
         max_matches: Int,
@@ -1601,7 +1602,7 @@ struct NFAEngine(Copyable, Engine):
             return byte_in_string(ch_code, range_pattern)
 
 
-def findall(pattern: String, text: String) raises -> MatchList:
+def findall(pattern: String, text: ImmSlice) raises -> MatchList:
     """Find all matches of pattern in text (equivalent to re.findall in Python).
 
     Args:
@@ -1615,7 +1616,7 @@ def findall(pattern: String, text: String) raises -> MatchList:
     return engine.match_all(text)
 
 
-def match_first(pattern: String, text: String) raises -> Optional[Match]:
+def match_first(pattern: String, text: ImmSlice) raises -> Optional[Match]:
     """Match pattern at beginning of text (equivalent to re.match in Python).
 
     Args:

--- a/src/regex/optimizer.mojo
+++ b/src/regex/optimizer.mojo
@@ -49,29 +49,9 @@ struct PatternComplexity(Copyable, TrivialRegisterPassable, Writable):
     def __ne__(self, other: Self) -> Bool:
         return self.value != other.value
 
-    def __repr__(self) -> String:
-        if self.value == PatternComplexity.SIMPLE:
-            return "PatternComplexity(SIMPLE)"
-        elif self.value == PatternComplexity.MEDIUM:
-            return "PatternComplexity(MEDIUM)"
-        elif self.value == PatternComplexity.COMPLEX:
-            return "PatternComplexity(COMPLEX)"
-        else:
-            return String("PatternComplexity(UNKNOWN:", self.value, ")")
-
-    def __str__(self) -> String:
-        if self.value == PatternComplexity.SIMPLE:
-            return "SIMPLE"
-        elif self.value == PatternComplexity.MEDIUM:
-            return "MEDIUM"
-        elif self.value == PatternComplexity.COMPLEX:
-            return "COMPLEX"
-        else:
-            return String("UNKNOWN:", self.value)
-
     @no_inline
     def write_to[W: Writer, //](self, mut writer: W):
-        """Writes a string representation of the PhoneNumberDesc to the writer.
+        """Writes a string representation of the PatternComplexity to the writer.
 
         Parameters:
             W: The type of the writer, conforming to the `Writer` trait.
@@ -79,7 +59,14 @@ struct PatternComplexity(Copyable, TrivialRegisterPassable, Writable):
         Args:
             writer: The writer instance to output the representation to.
         """
-        writer.write(self.__str__())
+        if self.value == PatternComplexity.SIMPLE:
+            writer.write("SIMPLE")
+        elif self.value == PatternComplexity.MEDIUM:
+            writer.write("MEDIUM")
+        elif self.value == PatternComplexity.COMPLEX:
+            writer.write("COMPLEX")
+        else:
+            writer.write("UNKNOWN:", self.value)
 
 
 struct OptimizationInfo(Movable):

--- a/src/regex/pikevm.mojo
+++ b/src/regex/pikevm.mojo
@@ -26,7 +26,7 @@ from regex.ast import (
     END,
 )
 from regex.matching import Match, MatchList
-from regex.aliases import WORD_CHARS
+from regex.aliases import ImmSlice, WORD_CHARS
 from regex.dfa import _expand_character_range
 
 
@@ -411,11 +411,11 @@ struct PikeVMEngine(Copyable, Movable):
         # Filter is useful if it excludes at least half the byte values
         self.has_filter = matching_bytes < 128
 
-    def match_first(self, text: String, start: Int = 0) -> Optional[Match]:
+    def match_first(self, text: ImmSlice, start: Int = 0) -> Optional[Match]:
         """Match pattern at the given position (like re.match)."""
         return self._run(text, start)
 
-    def match_next(self, text: String, start: Int = 0) -> Optional[Match]:
+    def match_next(self, text: ImmSlice, start: Int = 0) -> Optional[Match]:
         """Search for pattern anywhere in text (like re.search)."""
         var text_len = len(text)
         if self.has_filter:
@@ -439,7 +439,7 @@ struct PikeVMEngine(Copyable, Movable):
                 return result
         return None
 
-    def match_all(self, text: String) -> MatchList:
+    def match_all(self, text: ImmSlice) -> MatchList:
         """Find all non-overlapping matches (like re.findall)."""
         var matches = MatchList()
         var pos = 0
@@ -477,7 +477,7 @@ struct PikeVMEngine(Copyable, Movable):
 
         return matches^
 
-    def _run(self, text: String, start: Int) -> Optional[Match]:
+    def _run(self, text: ImmSlice, start: Int) -> Optional[Match]:
         """Run PikeVM with fixed-size SIMD state tracking.
         Zero heap allocations per step."""
         var text_ptr = text.unsafe_ptr()
@@ -684,12 +684,12 @@ struct LazyDFA(Copyable, Movable):
         return self.pikevm.is_supported()
 
     @always_inline
-    def match_first(mut self, text: String, start: Int = 0) -> Optional[Match]:
+    def match_first(mut self, text: ImmSlice, start: Int = 0) -> Optional[Match]:
         """Match at position using cached DFA transitions."""
         return self._run_lazy(text, start)
 
     @always_inline
-    def match_next(mut self, text: String, start: Int = 0) -> Optional[Match]:
+    def match_next(mut self, text: ImmSlice, start: Int = 0) -> Optional[Match]:
         """Search using cached DFA with first-byte prefilter."""
         var text_len = len(text)
         if self.pikevm.has_filter:
@@ -712,7 +712,7 @@ struct LazyDFA(Copyable, Movable):
         return None
 
     @always_inline
-    def match_all(mut self, text: String) -> MatchList:
+    def match_all(mut self, text: ImmSlice) -> MatchList:
         """Find all matches using cached DFA."""
         var matches = MatchList()
         var pos = 0
@@ -744,7 +744,7 @@ struct LazyDFA(Copyable, Movable):
         return matches^
 
     @always_inline
-    def _run_lazy(mut self, text: String, start: Int) -> Optional[Match]:
+    def _run_lazy(mut self, text: ImmSlice, start: Int) -> Optional[Match]:
         """Run the lazy DFA from a start position."""
         var text_ptr = text.unsafe_ptr()
         var text_len = len(text)

--- a/src/regex/simd_ops.mojo
+++ b/src/regex/simd_ops.mojo
@@ -21,6 +21,7 @@ from std.sys.info import simd_width_of
 from std.ffi import _Global
 
 from regex.aliases import (
+    ImmSlice,
     SIMD_MATCHER_NONE,
     SIMD_MATCHER_WHITESPACE,
     SIMD_MATCHER_DIGITS,
@@ -569,7 +570,7 @@ def _create_word_chars() -> CharacterClassSIMD:
 
 
 def _search_short_pattern(
-    pattern: Span[Byte, _], text: String, start: Int
+    pattern: Span[Byte, _], text: ImmSlice, start: Int
 ) -> Int:
     """Optimized search for very short patterns (1-2 characters).
 
@@ -605,7 +606,7 @@ def _search_short_pattern(
     return -1
 
 
-def verify_match(pattern: Span[Byte, _], text: String, pos: Int) -> Bool:
+def verify_match(pattern: Span[Byte, _], text: ImmSlice, pos: Int) -> Bool:
     """Verify that pattern matches at given position.
 
     Args:
@@ -631,7 +632,7 @@ def verify_match(pattern: Span[Byte, _], text: String, pos: Int) -> Bool:
 
 def simd_search(
     pattern: Span[Byte, _],
-    text: String,
+    text: ImmSlice,
     start: Int = 0,
 ) -> Int:
     """Search for pattern in text using SIMD acceleration.
@@ -913,7 +914,7 @@ def apply_quantifier_simd_generic[
     T: SIMDMatcher
 ](
     matcher: T,
-    text: String,
+    text: ImmSlice,
     start_pos: Int,
     min_matches: Int,
     max_matches: Int,
@@ -1003,7 +1004,7 @@ def find_in_text_simd[
 
 def twoway_search(
     pattern: Span[Byte, _],
-    text: String,
+    text: ImmSlice,
     start: Int = 0,
 ) -> Int:
     """Search for pattern in text using Two-Way algorithm with SIMD.


### PR DESCRIPTION
## Summary
- Top-level `match_first`/`search`/`findall`, `CompiledRegex`, `HybridMatcher`, `DFAMatcher`/`NFAMatcher`, and their underlying engines (`DFAEngine`, `NFAEngine`, `PikeVMEngine`, `LazyDFA`) now take `ImmSlice` (`StringSlice[ImmutAnyOrigin]`) for the `text` parameter instead of `String`. Callers that pass a string literal or an existing slice no longer have to allocate a backing `String` just to hand it to the matcher.
- Shared SIMD helpers on the hot path (`verify_match`, `simd_search`, `twoway_search`, `apply_quantifier_simd_generic`) are converted over for the same reason.
- `Match` now stores just a base byte pointer (`UnsafePointer[Byte, ImmutAnyOrigin]`) instead of an `UnsafePointer[String]`, and rebuilds the matched slice from `start_idx`/`end_idx` on demand. This keeps `Match` at its original 32-byte footprint, which matters because `MatchList` stores them densely.
- The `is_match` trampoline chain (`CompiledRegex` -> `HybridMatcher` -> `DFAMatcher` -> `DFAEngine`) is now `@always_inline`. Without it, each call was copying a 16-byte `StringSlice` through four levels for a function whose fast path is one byte read + lookup table test.
- Also removes the now-redundant `__str__`/`__repr__` methods on `Regex`, `ASTNode`, and `PatternComplexity` that are already covered by the `Writable` trait.
- A new `comptime ImmSlice = StringSlice[ImmutAnyOrigin]` alias lives in `aliases.mojo` so the long type name does not show up at every method signature.

## Benchmarks
Fresh best-of-3 runs on each branch, `benchmarks/bench_engine.mojo`, 65 engine benchmarks:

|                | count |
|----------------|-------|
| Faster (>5%)   | 39    |
| Slower (>5%)   | 4     |
| Within ±5%     | 22    |
| **Average**    | **-11.49%** |

Highlight of wins:
- `is_match_*` (5 benchmarks): -65% to -68% (from ~4 µs down to ~1.3 µs)
- `quad_quantifiers`: -38.3%
- `range_quantifiers`: -23.8%
- `dfa_dot_phone`: -21.7%
- `flexible_datetime`: -20.6%
- `ultra_dense_quantifiers`: -19.5%
- `optimize_multiple_quantifiers`: -19.4%

Remaining small regressions (all in the sub-µs noise band, absolute deltas on the order of tens of nanoseconds):
- `anchor_start`: +9.1%
- `complex_email`: +9.2%
- `range_digits`: +13.4%
- `wildcard_match_any`: +8.8%

## Test plan
- [x] `pixi run test` - all 346 tests pass (test_ast, test_dfa, test_lexer, test_literal_optimization, test_matcher, test_nfa, test_optimizer, test_parser, test_predefined_classes, test_simd, test_tokens)
- [x] `pixi run mojo -I ./src benchmarks/bench_engine.mojo -t` - runs cleanly, no missing matches
