### PR TITLE
Release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,38 @@
 # Changelog
 
-## v0.10.0 (unreleased)
+## v0.10.0 (2026-04-11)
 
 Performance tuning release. Mojo vs Rust win rate improved from 57% to 64%.
+
+### `StringSlice` in the matcher chain (PR #95)
+
+- **No more `String` allocation at the call site**: `match_first`, `search`,
+  `findall`, `CompiledRegex`, `HybridMatcher`, `DFAMatcher`/`NFAMatcher`, and
+  their underlying engines (`DFAEngine`, `NFAEngine`, `PikeVMEngine`,
+  `LazyDFA`) now take `ImmSlice` (`StringSlice[ImmutAnyOrigin]`) for the
+  `text` parameter. Callers passing a string literal or an existing slice no
+  longer allocate a backing `String` just to hand it to the matcher. Shared
+  SIMD helpers (`verify_match`, `simd_search`, `twoway_search`,
+  `apply_quantifier_simd_generic`) take the same type.
+- **Match stays 32 bytes**: `Match` stores just the base byte pointer
+  (`UnsafePointer[Byte, ImmutAnyOrigin]`) and rebuilds the matched slice from
+  `start_idx`/`end_idx` on demand, keeping the struct at its original
+  footprint so `MatchList` iteration stays cache-friendly.
+- **`@always_inline` on the `is_match` chain**: The four-level trampoline
+  (`CompiledRegex` -> `HybridMatcher` -> `DFAMatcher` -> `DFAEngine`) now
+  inlines end-to-end. Without it, each level was copying a 16-byte
+  `StringSlice` by value for a fast path whose real work is a single byte
+  read plus a lookup-table test.
+- **Cleanup**: Removed redundant `__str__`/`__repr__` methods on `Regex`,
+  `ASTNode`, and `PatternComplexity` that are already covered by `Writable`.
+- Key results (best-of-3 on each branch, 65 engine benchmarks, 39 faster
+  >5%, 4 slower >5%, average **-11.49%**):
+  - `is_match_*` (5 benchmarks): **-65% to -68%** (~4 µs -> ~1.3 µs)
+  - `quad_quantifiers`: **-38.3%**
+  - `range_quantifiers`: **-23.8%**
+  - `dfa_dot_phone`: **-21.7%**
+  - `flexible_datetime`: **-20.6%**
+  - `ultra_dense_quantifiers`: **-19.5%**
 
 ### DFA inner loop optimization (PR #94)
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -9,11 +9,11 @@ license-file = "LICENSE"
 name = "mojo-regex"
 platforms = ["linux-64", "osx-arm64"]
 preview = ["pixi-build"]
-version = "0.9.0"
+version = "0.10.0"
 
 [package]
 name = "mojo-regex"
-version = "0.9.0"
+version = "0.10.0"
 
 [package.build]
 backend = { name = "pixi-build-rattler-build", version = "*" }

--- a/src/regex/dfa.mojo
+++ b/src/regex/dfa.mojo
@@ -1871,7 +1871,10 @@ struct DFAEngine(Engine):
 
     @always_inline
     def _try_match_at_position(
-        self, text: ImmSlice, start_pos: Int, require_exact_position: Bool = False
+        self,
+        text: ImmSlice,
+        start_pos: Int,
+        require_exact_position: Bool = False,
     ) -> Optional[Match]:
         """Try to match pattern starting at a specific position.
 
@@ -2058,7 +2061,9 @@ struct DFAEngine(Engine):
         return matches^
 
     @always_inline
-    def _try_match_simd(self, text: ImmSlice, start_pos: Int) -> Optional[Match]:
+    def _try_match_simd(
+        self, text: ImmSlice, start_pos: Int
+    ) -> Optional[Match]:
         """SIMD-optimized matching for character class patterns with quantifier support.
 
         This hybrid approach uses SIMD for fast character matching while respecting

--- a/src/regex/pikevm.mojo
+++ b/src/regex/pikevm.mojo
@@ -684,7 +684,9 @@ struct LazyDFA(Copyable, Movable):
         return self.pikevm.is_supported()
 
     @always_inline
-    def match_first(mut self, text: ImmSlice, start: Int = 0) -> Optional[Match]:
+    def match_first(
+        mut self, text: ImmSlice, start: Int = 0
+    ) -> Optional[Match]:
         """Match at position using cached DFA transitions."""
         return self._run_lazy(text, start)
 


### PR DESCRIPTION
## Summary
- Bump package version from 0.9.0 to 0.10.0 in `pixi.toml` (both `[workspace]` and `[package]`).
- Add the PR #95 entry (StringSlice in the matcher chain, `@always_inline` on the `is_match` trampoline) to the v0.10.0 `CHANGELOG.md` section and drop the "unreleased" tag.

## Test plan
- [x] `pixi run test` - all 346 tests pass