### PR TITLE
Implement re.sub() for regex pattern substitution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Performance tuning release. Mojo vs Rust win rate improved from 57% to 64%.
 
 - Added `range_kind: Int` field to `ASTNode` with 8 classification constants, computed once at AST build time by `classify_range_kind()`. Replaces per-character string comparison chains in `_match_range` and `_apply_quantifier_simd` (up to 5 equality checks + `startswith`/`endswith`/`in` per char) with a single integer switch. Extracted `_quantifier_negated_loop` and `_quantifier_range_loop` helpers (net -14% code in nfa.mojo). Moved `COMPLEX_CHAR_CLASS_THRESHOLD` to ast.mojo as shared constant.
 
+### `re.sub()` pattern substitution (PR #103)
+
+- Added `sub(pattern, repl, text, count=0)` function equivalent to Python's `re.sub()`. Replaces all non-overlapping matches of `pattern` in `text` with `repl`. Optional `count` parameter limits the number of replacements. Handles zero-length matches by advancing one byte to avoid infinite loops.
+
 ### Inline NFA per-character range checks (PR #102)
 
 - Replaced per-character `get_digit_matcher()`/`get_word_matcher()`/`get_whitespace_matcher()`/`get_alnum_matcher()`/`get_alpha_matcher()` Dict lookups in `_match_digit`, `_match_word`, `_match_space`, and `_match_range` with direct O(1) comptime `CHAR_*` constant comparisons, matching the pattern already used by `ast.is_match_char`.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This software is in an early stage of development. Even though it is functional,
 - ✅ **SIMD Optimization** - Vectorized character class matching
 - ✅ **Pattern Compilation Caching** - Pre-compiled patterns for reuse
 - ✅ **Match Position Tracking** - Precise start_idx, end_idx reporting
-- ✅ **Simple API**: `match_first(pattern, text) -> Optional[Match]`
+- ✅ **Simple API**: `match_first`, `search`, `findall`, `sub`
 
 
 ## Installation
@@ -71,7 +71,7 @@ This software is in an early stage of development. Even though it is functional,
 ## Example Usage
 
 ```mojo
-from regex import match_first, findall
+from regex import match_first, findall, sub
 
 # Basic matching
 var result = match_first("hello", "hello world")
@@ -102,6 +102,17 @@ for i in range(len(numbers)):
 var phones = findall("[0-9]{3}-[0-9]{3}-[0-9]{4}", "Call 555-123-4567 or 800-555-9999")
 for i in range(len(phones)):
     print("Phone found:", phones[i].get_match_text())
+
+# Pattern substitution (re.sub equivalent)
+var cleaned = sub("\\s+", " ", "hello   world")
+print(cleaned)  # "hello world"
+
+var redacted = sub("[0-9]{3}-[0-9]{4}", "***-****", "Call 555-123-4567")
+print(redacted)  # "Call 555-***-****"
+
+# Limit replacements with count
+var result2 = sub("o", "0", "hello world", count=1)
+print(result2)  # "hell0 world"
 ```
 
 ## Performance
@@ -164,7 +175,7 @@ mojo test -I src/ tests/test_simd_integration.mojo
 - [ ] Non-capturing groups (`(?:...)`)
 - [ ] Named groups (`(?<name>...)` or `(?P<name>...)`)
 - [ ] Case insensitive matching options
-- [ ] Match replacement (`sub()`, `gsub()`)
+- [x] Match replacement (`sub()`)
 - [ ] String splitting (`split()`)
 
 ### Medium Priority

--- a/src/regex/__init__.mojo
+++ b/src/regex/__init__.mojo
@@ -1,1 +1,1 @@
-from .matcher import match_first, findall, search, Match
+from .matcher import match_first, findall, search, sub, Match

--- a/src/regex/matcher.mojo
+++ b/src/regex/matcher.mojo
@@ -939,3 +939,59 @@ def match_first(pattern: ImmSlice, text: ImmSlice) raises -> Optional[Match]:
         return result
     else:
         return None
+
+
+def sub(
+    pattern: ImmSlice,
+    repl: ImmSlice,
+    text: ImmSlice,
+    count: Int = 0,
+) raises -> String:
+    """Replace occurrences of pattern in text with repl (equivalent to re.sub in Python).
+
+    Args:
+        pattern: Regex pattern to search for.
+        repl: Replacement string.
+        text: Text to search and replace in.
+        count: Maximum number of replacements (0 means replace all).
+
+    Returns:
+        New string with replacements applied.
+    """
+    var compiled = compile_regex(pattern)
+    var text_len = len(text)
+    var text_ptr = text.unsafe_ptr()
+    var result = String()
+    var pos = 0
+    var replacements = 0
+
+    while pos <= text_len:
+        var m = compiled.match_next(text, pos)
+        if not m:
+            break
+
+        var match_obj = m.value()
+        var match_start = match_obj.start_idx
+        var match_end = match_obj.end_idx
+
+        if match_start > pos:
+            result += ImmSlice(ptr=text_ptr + pos, length=match_start - pos)
+
+        result += repl
+        replacements += 1
+
+        # For zero-length matches, advance by one byte to avoid infinite loops.
+        if match_end == match_start:
+            if pos < text_len:
+                result += ImmSlice(ptr=text_ptr + pos, length=1)
+            pos = match_end + 1
+        else:
+            pos = match_end
+
+        if count > 0 and replacements >= count:
+            break
+
+    if pos < text_len:
+        result += ImmSlice(ptr=text_ptr + pos, length=text_len - pos)
+
+    return result

--- a/tests/test_matcher.mojo
+++ b/tests/test_matcher.mojo
@@ -7,6 +7,7 @@ from regex.matcher import (
     search,
     findall,
     match_first,
+    sub,
     clear_regex_cache,
 )
 from regex.optimizer import PatternComplexity
@@ -1597,6 +1598,63 @@ def test_fixed_quantifier_in_sequence() raises:
     assert_equal(m3.value().get_match_text(), "ABC1234")
     assert_false(r3.match_first("AB1234"))  # Letters too short
     assert_false(r3.match_first("ABC123"))  # Digits too short
+
+
+def test_sub_basic_replacement() raises:
+    """Test basic string replacement."""
+    assert_equal(sub("world", "mojo", "hello world"), "hello mojo")
+
+
+def test_sub_multiple_replacements() raises:
+    """Test replacing multiple occurrences."""
+    assert_equal(sub("o", "0", "hello world"), "hell0 w0rld")
+
+
+def test_sub_no_match() raises:
+    """Test that no match returns the original string."""
+    assert_equal(sub("xyz", "abc", "hello"), "hello")
+
+
+def test_sub_count_parameter() raises:
+    """Test limiting replacements with count."""
+    assert_equal(sub("o", "0", "hello world", count=1), "hell0 world")
+
+
+def test_sub_regex_pattern() raises:
+    """Test replacement with regex patterns."""
+    assert_equal(sub("[0-9]+", "NUM", "abc 123 def 456"), "abc NUM def NUM")
+
+
+def test_sub_regex_with_count() raises:
+    """Test regex replacement with count limit."""
+    assert_equal(
+        sub("[0-9]+", "NUM", "abc 123 def 456", count=1), "abc NUM def 456"
+    )
+
+
+def test_sub_pattern_at_start() raises:
+    """Test replacing pattern anchored at start."""
+    assert_equal(sub("^hello", "hi", "hello world"), "hi world")
+
+
+def test_sub_pattern_at_end() raises:
+    """Test replacing pattern anchored at end."""
+    assert_equal(sub("world$", "mojo", "hello world"), "hello mojo")
+
+
+def test_sub_replace_with_empty() raises:
+    """Test replacing with empty string removes matches."""
+    assert_equal(sub("[0-9]", "", "a1b2c3"), "abc")
+
+
+def test_sub_whitespace_collapse() raises:
+    """Test collapsing whitespace with character classes."""
+    assert_equal(sub("\\s+", " ", "hello   world"), "hello world")
+
+
+def test_sub_empty_text() raises:
+    """Test sub with empty text returns empty string."""
+    assert_equal(sub("abc", "x", ""), "")
 
 
 def main() raises:


### PR DESCRIPTION
## Summary
- Add `sub(pattern, repl, text, count=0)` function equivalent to Python's `re.sub()`
- Replaces all non-overlapping matches of `pattern` in `text` with `repl`, with optional `count` limit
- Handles zero-length matches correctly by advancing one byte to avoid infinite loops

## Test plan
- [x] Basic literal replacement (`sub("world", "mojo", "hello world")`)
- [x] Multiple replacements in one string
- [x] No-match returns original text unchanged
- [x] `count` parameter limits number of replacements
- [x] Regex patterns (`[0-9]+`, `\s+`, `[0-9]`)
- [x] Anchored patterns (`^hello`, `world$`)
- [x] Replace with empty string (deletion)
- [x] Whitespace collapsing (`\s+` -> single space)
- [x] Empty text input
- [x] All 110 tests pass (11 new + 99 existing)