### PR TITLE
Precompute range classification tag, eliminate per-char string comparisons

### DIFF
--- a/src/regex/ast.mojo
+++ b/src/regex/ast.mojo
@@ -658,9 +658,12 @@ def classify_range_kind(pattern: StringSlice) -> Int:
     # Check for complex alphanumeric patterns like [a-zA-Z0-9._%+-]
     if pattern.startswith("[") and pattern.endswith("]"):
         var inner = pattern[byte=1:-1]
-        if "a-z" in inner and "A-Z" in inner and "0-9" in inner and len(
-            inner
-        ) > COMPLEX_CHAR_CLASS_THRESHOLD:
+        if (
+            "a-z" in inner
+            and "A-Z" in inner
+            and "0-9" in inner
+            and len(inner) > COMPLEX_CHAR_CLASS_THRESHOLD
+        ):
             return RANGE_KIND_COMPLEX_ALNUM
     return RANGE_KIND_OTHER
 

--- a/src/regex/ast.mojo
+++ b/src/regex/ast.mojo
@@ -46,6 +46,10 @@ comptime RANGE_KIND_ALPHA = 5  # [a-zA-Z]
 comptime RANGE_KIND_COMPLEX_ALNUM = 6  # [a-zA-Z0-9...] with extra chars
 comptime RANGE_KIND_OTHER = 7  # anything else
 
+# Threshold for complex character class patterns (e.g. [a-zA-Z0-9._%+-]).
+# Shared between classify_range_kind() and nfa.mojo's _match_range fallback.
+comptime COMPLEX_CHAR_CLASS_THRESHOLD = 10
+
 comptime LEAF_ELEMS: SIMD[DType.int8, 8] = [
     Int8(ELEMENT),
     Int8(WILDCARD),
@@ -656,7 +660,7 @@ def classify_range_kind(pattern: StringSlice) -> Int:
         var inner = pattern[byte=1:-1]
         if "a-z" in inner and "A-Z" in inner and "0-9" in inner and len(
             inner
-        ) > 10:
+        ) > COMPLEX_CHAR_CLASS_THRESHOLD:
             return RANGE_KIND_COMPLEX_ALNUM
     return RANGE_KIND_OTHER
 

--- a/src/regex/ast.mojo
+++ b/src/regex/ast.mojo
@@ -34,6 +34,18 @@ comptime OR = 9
 comptime NOT = 10
 comptime GROUP = 11
 
+# Range classification tags, precomputed at AST build time so that
+# _match_range / _apply_quantifier_simd can switch on an Int instead
+# of doing per-character string comparisons.
+comptime RANGE_KIND_NONE = 0  # not a RANGE node
+comptime RANGE_KIND_LOWERCASE = 1  # [a-z]
+comptime RANGE_KIND_UPPERCASE = 2  # [A-Z]
+comptime RANGE_KIND_DIGITS = 3  # [0-9]
+comptime RANGE_KIND_ALNUM = 4  # [a-zA-Z0-9]
+comptime RANGE_KIND_ALPHA = 5  # [a-zA-Z]
+comptime RANGE_KIND_COMPLEX_ALNUM = 6  # [a-zA-Z0-9...] with extra chars
+comptime RANGE_KIND_OTHER = 7  # anything else
+
 comptime LEAF_ELEMS: SIMD[DType.int8, 8] = [
     Int8(ELEMENT),
     Int8(WILDCARD),
@@ -181,6 +193,9 @@ struct ASTNode[regex_origin: ImmutOrigin](
     """Maximum number of matches for quantifiers (-1 for unlimited)."""
     var positive_logic: Bool
     """For character ranges: True for [abc], False for [^abc]."""
+    var range_kind: Int
+    """Precomputed RANGE_KIND_* tag for RANGE nodes. Eliminates per-character
+    string comparisons in _match_range / _apply_quantifier_simd."""
 
     @always_inline
     def __init__(
@@ -193,6 +208,7 @@ struct ASTNode[regex_origin: ImmutOrigin](
         min: Int = 0,
         max: Int = 0,
         positive_logic: Bool = True,
+        range_kind: Int = RANGE_KIND_NONE,
     ):
         """Initialize an ASTNode with a specific type and match string."""
         self.type = type
@@ -203,6 +219,7 @@ struct ASTNode[regex_origin: ImmutOrigin](
         self.min = min
         self.max = max
         self.positive_logic = positive_logic
+        self.range_kind = range_kind
         self.children_indexes = SIMD[DType.uint8, Self.max_children](
             0
         )  # Initialize with all bits set to 0
@@ -219,6 +236,7 @@ struct ASTNode[regex_origin: ImmutOrigin](
         min: Int = 0,
         max: Int = 0,
         positive_logic: Bool = True,
+        range_kind: Int = RANGE_KIND_NONE,
     ):
         """Initialize an ASTNode with a specific type and match string."""
         self.regex_ptr = regex_ptr
@@ -229,6 +247,7 @@ struct ASTNode[regex_origin: ImmutOrigin](
         self.min = min
         self.max = max
         self.positive_logic = positive_logic
+        self.range_kind = range_kind
         self.children_indexes = SIMD[DType.uint8, Self.max_children](0)
         self.children_indexes[0] = child_index  # Set the first child index
         self.children_len = 1
@@ -244,6 +263,7 @@ struct ASTNode[regex_origin: ImmutOrigin](
         min: Int = 0,
         max: Int = 0,
         positive_logic: Bool = True,
+        range_kind: Int = RANGE_KIND_NONE,
     ):
         """Initialize an ASTNode with a specific type and match string."""
         self.regex_ptr = regex_ptr
@@ -254,6 +274,7 @@ struct ASTNode[regex_origin: ImmutOrigin](
         self.min = min
         self.max = max
         self.positive_logic = positive_logic
+        self.range_kind = range_kind
         self.children_indexes = SIMD[DType.uint8, Self.max_children](0)
         for i in range(len(children_indexes)):
             self.children_indexes[i] = children_indexes[i]
@@ -276,6 +297,7 @@ struct ASTNode[regex_origin: ImmutOrigin](
         self.min = copy.min
         self.max = copy.max
         self.positive_logic = copy.positive_logic
+        self.range_kind = copy.range_kind
         self.children_indexes = copy.children_indexes
         self.children_len = copy.children_len
         # var call_location = __call_location()
@@ -613,6 +635,33 @@ def WordElement[
 
 
 @always_inline
+def classify_range_kind(pattern: StringSlice) -> Int:
+    """Classify a RANGE pattern into a RANGE_KIND_* tag at build time.
+
+    This runs once when the AST is constructed so that per-character matching
+    can switch on an Int instead of doing string comparisons.
+    """
+    if pattern == "[a-z]":
+        return RANGE_KIND_LOWERCASE
+    if pattern == "[A-Z]":
+        return RANGE_KIND_UPPERCASE
+    if pattern == "[0-9]":
+        return RANGE_KIND_DIGITS
+    if pattern == "[a-zA-Z0-9]" or pattern == "[0-9a-zA-Z]":
+        return RANGE_KIND_ALNUM
+    if pattern == "[a-zA-Z]":
+        return RANGE_KIND_ALPHA
+    # Check for complex alphanumeric patterns like [a-zA-Z0-9._%+-]
+    if pattern.startswith("[") and pattern.endswith("]"):
+        var inner = pattern[byte=1:-1]
+        if "a-z" in inner and "A-Z" in inner and "0-9" in inner and len(
+            inner
+        ) > 10:
+            return RANGE_KIND_COMPLEX_ALNUM
+    return RANGE_KIND_OTHER
+
+
+@always_inline
 def RangeElement[
     regex_origin: ImmutOrigin,
 ](
@@ -623,6 +672,16 @@ def RangeElement[
 ) -> ASTNode[regex_origin]:
     """Create a RangeElement node."""
     var regex_ptr = UnsafePointer(to=regex).as_any_origin()
+    # Classify the range pattern once at build time.
+    var kind = RANGE_KIND_OTHER
+    if start_idx < end_idx:
+        var pat = StringSlice(
+            unsafe_from_utf8=Span[Byte, origin_of(regex.pattern)](
+                ptr=regex.pattern.unsafe_ptr() + start_idx,
+                length=end_idx - start_idx,
+            )
+        )
+        kind = classify_range_kind(pat)
     return ASTNode[regex_origin](
         type=RANGE,
         regex_ptr=regex_ptr,
@@ -631,6 +690,7 @@ def RangeElement[
         min=1,
         max=1,
         positive_logic=is_positive_logic,
+        range_kind=kind,
     )
 
 

--- a/src/regex/nfa.mojo
+++ b/src/regex/nfa.mojo
@@ -1383,17 +1383,34 @@ struct NFAEngine(Copyable, Engine):
                     )
                 else:
                     return self._quantifier_negated_loop(
-                        alnum_matcher, str_ptr, str, str_i, min_matches, max_matches
+                        alnum_matcher,
+                        str_ptr,
+                        str,
+                        str_i,
+                        min_matches,
+                        max_matches,
                     )
             elif kind == RANGE_KIND_LOWERCASE:
                 return self._quantifier_range_loop(
-                    CHAR_A, CHAR_Z, ast.positive_logic,
-                    str_ptr, str, str_i, min_matches, max_matches,
+                    CHAR_A,
+                    CHAR_Z,
+                    ast.positive_logic,
+                    str_ptr,
+                    str,
+                    str_i,
+                    min_matches,
+                    max_matches,
                 )
             elif kind == RANGE_KIND_UPPERCASE:
                 return self._quantifier_range_loop(
-                    CHAR_A_UPPER, CHAR_Z_UPPER, ast.positive_logic,
-                    str_ptr, str, str_i, min_matches, max_matches,
+                    CHAR_A_UPPER,
+                    CHAR_Z_UPPER,
+                    ast.positive_logic,
+                    str_ptr,
+                    str,
+                    str_i,
+                    min_matches,
+                    max_matches,
                 )
             elif kind == RANGE_KIND_DIGITS:
                 var digit_matcher = get_digit_matcher()
@@ -1403,7 +1420,12 @@ struct NFAEngine(Copyable, Engine):
                     )
                 else:
                     return self._quantifier_negated_loop(
-                        digit_matcher, str_ptr, str, str_i, min_matches, max_matches
+                        digit_matcher,
+                        str_ptr,
+                        str,
+                        str_i,
+                        min_matches,
+                        max_matches,
                     )
             elif kind == RANGE_KIND_ALPHA:
                 var alpha_matcher = get_alpha_matcher()
@@ -1413,7 +1435,12 @@ struct NFAEngine(Copyable, Engine):
                     )
                 else:
                     return self._quantifier_negated_loop(
-                        alpha_matcher, str_ptr, str, str_i, min_matches, max_matches
+                        alpha_matcher,
+                        str_ptr,
+                        str,
+                        str_i,
+                        min_matches,
+                        max_matches,
                     )
             elif kind == RANGE_KIND_COMPLEX_ALNUM:
                 var inner = range_pattern[byte=1:-1]

--- a/src/regex/nfa.mojo
+++ b/src/regex/nfa.mojo
@@ -1,6 +1,18 @@
 from std.memory import UnsafePointer
 
-from regex.ast import ASTNode, DIGIT, WORD, SPACE
+from regex.ast import (
+    ASTNode,
+    DIGIT,
+    WORD,
+    SPACE,
+    RANGE_KIND_LOWERCASE,
+    RANGE_KIND_UPPERCASE,
+    RANGE_KIND_DIGITS,
+    RANGE_KIND_ALNUM,
+    RANGE_KIND_ALPHA,
+    RANGE_KIND_COMPLEX_ALNUM,
+    RANGE_KIND_OTHER,
+)
 from regex.aliases import (
     CHAR_A,
     CHAR_A_UPPER,
@@ -831,62 +843,45 @@ struct NFAEngine(Copyable, Engine):
         var ch_code = Int(str_ptr[str_i])
         var ch_found = False
 
-        if ast.get_value():
-            ref range_pattern = ast.get_value().value()
-
-            # Common patterns use inline range checks to avoid a per-character
-            # Dict lookup through `get_alnum_matcher()`/`get_alpha_matcher()`.
-            if range_pattern == "[a-zA-Z0-9]":
-                ch_found = (
-                    (CHAR_A <= ch_code <= CHAR_Z)
-                    or (CHAR_A_UPPER <= ch_code <= CHAR_Z_UPPER)
-                    or (CHAR_ZERO <= ch_code <= CHAR_NINE)
+        # Switch on the precomputed range_kind tag instead of doing
+        # per-character string comparisons. The tag was set at AST
+        # build time by classify_range_kind() in ast.mojo.
+        var kind = ast.range_kind
+        if kind == RANGE_KIND_ALNUM:
+            ch_found = (
+                (CHAR_A <= ch_code <= CHAR_Z)
+                or (CHAR_A_UPPER <= ch_code <= CHAR_Z_UPPER)
+                or (CHAR_ZERO <= ch_code <= CHAR_NINE)
+            )
+        elif kind == RANGE_KIND_LOWERCASE:
+            ch_found = CHAR_A <= ch_code <= CHAR_Z
+        elif kind == RANGE_KIND_UPPERCASE:
+            ch_found = CHAR_A_UPPER <= ch_code <= CHAR_Z_UPPER
+        elif kind == RANGE_KIND_DIGITS:
+            ch_found = CHAR_ZERO <= ch_code <= CHAR_NINE
+        elif kind == RANGE_KIND_ALPHA:
+            ch_found = (CHAR_A <= ch_code <= CHAR_Z) or (
+                CHAR_A_UPPER <= ch_code <= CHAR_Z_UPPER
+            )
+        elif kind == RANGE_KIND_COMPLEX_ALNUM:
+            # Check alphanumeric first (common case), then special chars
+            if (
+                (CHAR_A <= ch_code <= CHAR_Z)
+                or (CHAR_A_UPPER <= ch_code <= CHAR_Z_UPPER)
+                or (CHAR_ZERO <= ch_code <= CHAR_NINE)
+            ):
+                ch_found = True
+            elif ast.get_value():
+                ref range_pattern = ast.get_value().value()
+                var inner = range_pattern[byte=1:-1]
+                ch_found = byte_in_string(ch_code, inner)
+        else:
+            # RANGE_KIND_OTHER: fall back to SIMD or general matcher
+            if ast.get_value():
+                ref range_pattern = ast.get_value().value()
+                ch_found = self._match_with_simd_or_fallback(
+                    ast, range_pattern, ch_code
                 )
-            elif range_pattern == "[a-z]":
-                ch_found = CHAR_A <= ch_code <= CHAR_Z
-            elif range_pattern == "[A-Z]":
-                ch_found = CHAR_A_UPPER <= ch_code <= CHAR_Z_UPPER
-            elif range_pattern == "[0-9]":
-                ch_found = CHAR_ZERO <= ch_code <= CHAR_NINE
-            elif range_pattern == "[a-zA-Z]":
-                ch_found = (CHAR_A <= ch_code <= CHAR_Z) or (
-                    CHAR_A_UPPER <= ch_code <= CHAR_Z_UPPER
-                )
-            else:
-                # Check if it's a complex pattern with alphanumeric + special chars
-                if range_pattern.startswith("[") and range_pattern.endswith(
-                    "]"
-                ):
-                    var inner = range_pattern[byte=1:-1]
-                    var has_lower = "a-z" in inner
-                    var has_upper = "A-Z" in inner
-                    var has_digits = "0-9" in inner
-                    var has_alnum = has_lower and has_upper and has_digits
-
-                    if has_alnum and len(inner) > COMPLEX_CHAR_CLASS_THRESHOLD:
-                        # Complex pattern like [a-zA-Z0-9._%+-]
-                        # Check alphanumeric first (common case) via inline
-                        # range check, then fall back to the special-char
-                        # byte scan.
-                        if (
-                            (CHAR_A <= ch_code <= CHAR_Z)
-                            or (CHAR_A_UPPER <= ch_code <= CHAR_Z_UPPER)
-                            or (CHAR_ZERO <= ch_code <= CHAR_NINE)
-                        ):
-                            ch_found = True
-                        else:
-                            # Not alphanumeric, check special chars
-                            ch_found = byte_in_string(ch_code, inner)
-                    else:
-                        # Try to use SIMD matcher for other patterns
-                        ch_found = self._match_with_simd_or_fallback(
-                            ast, range_pattern, ch_code
-                        )
-                else:
-                    # Not a bracketed pattern, try SIMD matcher
-                    ch_found = self._match_with_simd_or_fallback(
-                        ast, range_pattern, ch_code
-                    )
 
         if ch_found == ast.positive_logic:
             return self._apply_quantifier(
@@ -1382,207 +1377,109 @@ struct NFAEngine(Copyable, Engine):
         elif ast.type == RANGE and ast.get_value():
             ref range_pattern = ast.get_value().value()
 
-            # Check for common patterns that should use RangeBasedMatcher
-            if range_pattern == "[a-zA-Z0-9]":
+            # Switch on precomputed range_kind tag instead of per-invocation
+            # string comparisons. Classification done at AST build time.
+            var kind = ast.range_kind
+            if kind == RANGE_KIND_ALNUM:
                 var alnum_matcher = get_alnum_matcher()
                 if ast.positive_logic:
                     return apply_quantifier_simd_generic(
                         alnum_matcher, str, str_i, min_matches, max_matches
                     )
                 else:
-                    # For negated alphanumeric, use custom logic
-                    var pos = str_i
-                    var match_count = 0
-                    var actual_max = max_matches
-                    if actual_max == -1:
-                        actual_max = len(str) - str_i
-
-                    while pos < len(str) and match_count < actual_max:
-                        var ch_code = Int(str_ptr[pos])
-                        if not alnum_matcher.contains(ch_code):  # Negated
-                            match_count += 1
-                            pos += 1
-                        else:
-                            break
-
-                    if match_count >= min_matches:
-                        return (True, pos)
-                    else:
-                        return (False, str_i)
-            elif range_pattern == "[a-z]":
-                # Use optimized path for simple lowercase range
-                var pos = str_i
-                var match_count = 0
-                var actual_max = max_matches
-                if actual_max == -1:
-                    actual_max = len(str) - str_i
-
-                while pos < len(str) and match_count < actual_max:
-                    var ch_code = Int(str_ptr[pos])
-                    var is_match = ch_code >= ord("a") and ch_code <= ord("z")
-                    if is_match == ast.positive_logic:
-                        match_count += 1
-                        pos += 1
-                    else:
-                        break
-
-                if match_count >= min_matches:
-                    return (True, pos)
-                else:
-                    return (False, str_i)
-            elif range_pattern == "[A-Z]":
-                # Use optimized path for simple uppercase range
-                var pos = str_i
-                var match_count = 0
-                var actual_max = max_matches
-                if actual_max == -1:
-                    actual_max = len(str) - str_i
-
-                while pos < len(str) and match_count < actual_max:
-                    var ch_code = Int(str_ptr[pos])
-                    var is_match = ch_code >= ord("A") and ch_code <= ord("Z")
-                    if is_match == ast.positive_logic:
-                        match_count += 1
-                        pos += 1
-                    else:
-                        break
-
-                if match_count >= min_matches:
-                    return (True, pos)
-                else:
-                    return (False, str_i)
-            elif range_pattern == "[0-9]":
-                # Use digit matcher for digit range
+                    return self._quantifier_negated_loop(
+                        alnum_matcher, str_ptr, str, str_i, min_matches, max_matches
+                    )
+            elif kind == RANGE_KIND_LOWERCASE:
+                return self._quantifier_range_loop(
+                    CHAR_A, CHAR_Z, ast.positive_logic,
+                    str_ptr, str, str_i, min_matches, max_matches,
+                )
+            elif kind == RANGE_KIND_UPPERCASE:
+                return self._quantifier_range_loop(
+                    CHAR_A_UPPER, CHAR_Z_UPPER, ast.positive_logic,
+                    str_ptr, str, str_i, min_matches, max_matches,
+                )
+            elif kind == RANGE_KIND_DIGITS:
                 var digit_matcher = get_digit_matcher()
                 if ast.positive_logic:
                     return apply_quantifier_simd_generic(
                         digit_matcher, str, str_i, min_matches, max_matches
                     )
                 else:
-                    # For negated digits, use custom logic
-                    var pos = str_i
-                    var match_count = 0
-                    var actual_max = max_matches
-                    if actual_max == -1:
-                        actual_max = len(str) - str_i
-
-                    while pos < len(str) and match_count < actual_max:
-                        var ch_code = Int(str_ptr[pos])
-                        if not digit_matcher.contains(ch_code):  # Negated
-                            match_count += 1
-                            pos += 1
-                        else:
-                            break
-
-                    if match_count >= min_matches:
-                        return (True, pos)
-                    else:
-                        return (False, str_i)
-            elif range_pattern == "[a-zA-Z]":
-                # Use alpha matcher for alphabetic range
+                    return self._quantifier_negated_loop(
+                        digit_matcher, str_ptr, str, str_i, min_matches, max_matches
+                    )
+            elif kind == RANGE_KIND_ALPHA:
                 var alpha_matcher = get_alpha_matcher()
                 if ast.positive_logic:
                     return apply_quantifier_simd_generic(
                         alpha_matcher, str, str_i, min_matches, max_matches
                     )
                 else:
-                    # For negated alpha, use custom logic
-                    var pos = str_i
-                    var match_count = 0
-                    var actual_max = max_matches
-                    if actual_max == -1:
-                        actual_max = len(str) - str_i
-
-                    while pos < len(str) and match_count < actual_max:
-                        var ch_code = Int(str_ptr[pos])
-                        if not alpha_matcher.contains(ch_code):  # Negated
-                            match_count += 1
-                            pos += 1
-                        else:
-                            break
-
-                    if match_count >= min_matches:
-                        return (True, pos)
-                    else:
-                        return (False, str_i)
-            else:
-                # Check if it's a complex pattern with alphanumeric + special chars
-                var is_complex_pattern = False
-                if range_pattern.startswith("[") and range_pattern.endswith(
-                    "]"
-                ):
-                    var inner = range_pattern[byte=1:-1]
-                    var has_lower = "a-z" in inner
-                    var has_upper = "A-Z" in inner
-                    var has_digits = "0-9" in inner
-                    var has_alnum = has_lower and has_upper and has_digits
-                    is_complex_pattern = (
-                        has_alnum and len(inner) > COMPLEX_CHAR_CLASS_THRESHOLD
+                    return self._quantifier_negated_loop(
+                        alpha_matcher, str_ptr, str, str_i, min_matches, max_matches
                     )
+            elif kind == RANGE_KIND_COMPLEX_ALNUM:
+                var inner = range_pattern[byte=1:-1]
+                var pos = str_i
+                var match_count = 0
+                var actual_max = max_matches
+                if actual_max == -1:
+                    actual_max = len(str) - str_i
 
-                if is_complex_pattern:
-                    # Handle complex patterns like [a-zA-Z0-9._%+-] efficiently
-                    var alnum_matcher = get_alnum_matcher()
-                    var inner = range_pattern[byte=1:-1]
-                    var pos = str_i
-                    var match_count = 0
-                    var actual_max = max_matches
-                    if actual_max == -1:
-                        actual_max = len(str) - str_i
-
-                    while pos < len(str) and match_count < actual_max:
-                        var ch_code = Int(str_ptr[pos])
-                        var is_match: Bool
-
-                        # Check alphanumeric first (common case)
-                        if alnum_matcher.contains(ch_code):
-                            is_match = True
-                        else:
-                            # Check special characters via direct byte scan
-                            is_match = byte_in_string(ch_code, inner)
-
-                        if is_match == ast.positive_logic:
-                            match_count += 1
-                            pos += 1
-                        else:
-                            break
-
-                    if match_count >= min_matches:
-                        return (True, pos)
+                while pos < len(str) and match_count < actual_max:
+                    var ch_code = Int(str_ptr[pos])
+                    var is_match: Bool
+                    if (
+                        (CHAR_A <= ch_code <= CHAR_Z)
+                        or (CHAR_A_UPPER <= ch_code <= CHAR_Z_UPPER)
+                        or (CHAR_ZERO <= ch_code <= CHAR_NINE)
+                    ):
+                        is_match = True
                     else:
-                        return (False, str_i)
+                        is_match = byte_in_string(ch_code, inner)
 
+                    if is_match == ast.positive_logic:
+                        match_count += 1
+                        pos += 1
+                    else:
+                        break
+
+                if match_count >= min_matches:
+                    return (True, pos)
+                else:
+                    return (False, str_i)
+            else:
+                # RANGE_KIND_OTHER: try SIMD matcher, then general fallback
                 var range_matcher = self._create_range_matcher(range_pattern)
                 if range_matcher:
                     ref matcher = range_matcher.value()
-                    # Handle negated logic
                     if ast.positive_logic:
                         return apply_quantifier_simd_generic(
                             matcher, str, str_i, min_matches, max_matches
                         )
                     else:
-                        # For negated ranges, we need custom logic
+                        # CharacterClassSIMD negated loop (can't use
+                        # _quantifier_negated_loop which takes RangeBasedMatcher)
                         var pos = str_i
                         var match_count = 0
                         var actual_max = max_matches
                         if actual_max == -1:
                             actual_max = len(str) - str_i
-
                         while pos < len(str) and match_count < actual_max:
                             var ch_code = Int(str_ptr[pos])
-                            if not matcher.contains(ch_code):  # Negated
+                            if not matcher.contains(ch_code):
                                 match_count += 1
                                 pos += 1
                             else:
                                 break
-
                         if match_count >= min_matches:
                             return (True, pos)
                         else:
                             return (False, str_i)
 
-                # Fallback for simple ranges like [c-n] that don't use SIMD
-                # Use character-by-character matching
+                # Scalar fallback for ranges without SIMD matchers
                 var pos = str_i
                 var match_count = 0
                 var actual_max = max_matches
@@ -1626,6 +1523,63 @@ struct NFAEngine(Copyable, Engine):
             return byte_in_string(ch_code, inner)
         else:
             return byte_in_string(ch_code, range_pattern)
+
+    @always_inline
+    def _quantifier_negated_loop(
+        self,
+        matcher: RangeBasedMatcher,
+        str_ptr: UnsafePointer[Byte, ImmutAnyOrigin],
+        str: ImmSlice,
+        str_i: Int,
+        min_matches: Int,
+        max_matches: Int,
+    ) -> Tuple[Bool, Int]:
+        """Run a quantifier loop for negated character classes."""
+        var pos = str_i
+        var match_count = 0
+        var actual_max = max_matches
+        if actual_max == -1:
+            actual_max = len(str) - str_i
+        while pos < len(str) and match_count < actual_max:
+            var ch_code = Int(str_ptr[pos])
+            if not matcher.contains(ch_code):
+                match_count += 1
+                pos += 1
+            else:
+                break
+        if match_count >= min_matches:
+            return (True, pos)
+        return (False, str_i)
+
+    @always_inline
+    def _quantifier_range_loop(
+        self,
+        range_start: Int,
+        range_end: Int,
+        positive_logic: Bool,
+        str_ptr: UnsafePointer[Byte, ImmutAnyOrigin],
+        str: ImmSlice,
+        str_i: Int,
+        min_matches: Int,
+        max_matches: Int,
+    ) -> Tuple[Bool, Int]:
+        """Run a quantifier loop for a single contiguous range."""
+        var pos = str_i
+        var match_count = 0
+        var actual_max = max_matches
+        if actual_max == -1:
+            actual_max = len(str) - str_i
+        while pos < len(str) and match_count < actual_max:
+            var ch_code = Int(str_ptr[pos])
+            var is_match = range_start <= ch_code <= range_end
+            if is_match == positive_logic:
+                match_count += 1
+                pos += 1
+            else:
+                break
+        if match_count >= min_matches:
+            return (True, pos)
+        return (False, str_i)
 
 
 def findall(pattern: String, text: ImmSlice) raises -> MatchList:

--- a/src/regex/nfa.mojo
+++ b/src/regex/nfa.mojo
@@ -12,6 +12,7 @@ from regex.ast import (
     RANGE_KIND_ALPHA,
     RANGE_KIND_COMPLEX_ALNUM,
     RANGE_KIND_OTHER,
+    COMPLEX_CHAR_CLASS_THRESHOLD,
 )
 from regex.aliases import (
     CHAR_A,
@@ -53,10 +54,7 @@ from regex.literal_optimizer import extract_literals, extract_literal_prefix
 from regex.optimizer import PatternAnalyzer, PatternComplexity
 
 
-# Threshold for complex character class patterns (e.g. [a-zA-Z0-9._%+-])
-# When a pattern has alphanumeric ranges plus more than this many characters,
-# use optimized two-phase matching (check alphanumeric first, then special chars)
-comptime COMPLEX_CHAR_CLASS_THRESHOLD = 10
+# COMPLEX_CHAR_CLASS_THRESHOLD is now imported from regex.ast
 
 # Minimum literal length thresholds for optimization.
 # Even single-char prefixes (like '8' in '8(?:00|33)...') are valuable
@@ -843,9 +841,6 @@ struct NFAEngine(Copyable, Engine):
         var ch_code = Int(str_ptr[str_i])
         var ch_found = False
 
-        # Switch on the precomputed range_kind tag instead of doing
-        # per-character string comparisons. The tag was set at AST
-        # build time by classify_range_kind() in ast.mojo.
         var kind = ast.range_kind
         if kind == RANGE_KIND_ALNUM:
             ch_found = (


### PR DESCRIPTION
## Summary

- Add `range_kind: Int` field to `ASTNode` with 8 classification constants (`RANGE_KIND_NONE` through `RANGE_KIND_OTHER`), computed once at AST build time by `classify_range_kind()`
- Replace per-character string comparison chains in `_match_range` (5 equality checks + `startswith`/`endswith`/`in` substring searches per character) with a single integer switch on `ast.range_kind`
- Replace duplicate string comparison chains in `_apply_quantifier_simd` with the same `range_kind` switch
- Extract `_quantifier_negated_loop` and `_quantifier_range_loop` helpers to deduplicate repeated loop patterns (net -14% code in nfa.mojo)

## How it works

`classify_range_kind()` runs once when `RangeElement()` constructs the AST node. It maps the range pattern string to one of: `LOWERCASE` ([a-z]), `UPPERCASE` ([A-Z]), `DIGITS` ([0-9]), `ALNUM` ([a-zA-Z0-9]), `ALPHA` ([a-zA-Z]), `COMPLEX_ALNUM` ([a-zA-Z0-9...] with extra chars), or `OTHER`. The per-character matching code then switches on the integer tag instead of re-comparing strings on every character.

## Test plan

- [x] All 346 tests pass across 11 test files
- [x] No new dependencies or API changes