### PR TITLE
Eliminate per-match String copies in DFA/NFA hot paths

### DIFF
--- a/src/regex/dfa.mojo
+++ b/src/regex/dfa.mojo
@@ -1778,7 +1778,7 @@ struct DFAEngine(Engine):
 
     @always_inline
     def get_pattern(self) -> String:
-        """Returns the pattern string.
+        """Returns the pattern string (Engine trait requirement).
 
         Returns:
             The pattern string.
@@ -1889,11 +1889,12 @@ struct DFAEngine(Engine):
         if start_pos > len(text):
             return None
 
-        # Fast path for pure literal patterns using SIMD
+        # Fast path for pure literal patterns using SIMD.
+        # Access literal_pattern directly to avoid the String copy that
+        # get_pattern() would produce on every match attempt.
         if self.is_pure_literal:
-            var pattern = self.get_pattern()
-            var pattern_bytes = pattern.as_bytes()
-            var pattern_len = len(pattern)
+            var pattern_bytes = self.literal_pattern.as_bytes()
+            var pattern_len = len(self.literal_pattern)
             if require_exact_position:
                 # For match_first, must match at exact position
                 if verify_match(

--- a/src/regex/nfa.mojo
+++ b/src/regex/nfa.mojo
@@ -127,7 +127,7 @@ struct NFAEngine(Copyable, Engine):
 
     @always_inline
     def get_pattern(self) -> String:
-        """Returns the pattern string.
+        """Returns the pattern string (Engine trait requirement).
 
         Returns:
             The pattern string.
@@ -135,6 +135,19 @@ struct NFAEngine(Copyable, Engine):
         if self.has_literal_optimization:
             return self.literal_prefix
         return self.pattern
+
+    @always_inline
+    def _get_search_literal_bytes(
+        self,
+    ) -> Span[Byte, ImmutAnyOrigin]:
+        """Returns a zero-copy byte view of the literal used for prefiltering.
+        Avoids the String copy that get_pattern() would produce.
+        """
+        if self.has_literal_optimization:
+            return rebind[Span[Byte, ImmutAnyOrigin]](
+                self.literal_prefix.as_bytes()
+            )
+        return rebind[Span[Byte, ImmutAnyOrigin]](self.pattern.as_bytes())
 
     def match_all(
         self,
@@ -224,7 +237,7 @@ struct NFAEngine(Copyable, Engine):
             while current_pos <= len(text):
                 # Find next occurrence of literal
                 var literal_pos = twoway_search(
-                    self.get_pattern().as_bytes(),
+                    self._get_search_literal_bytes(),
                     text,
                     current_pos,
                 )
@@ -415,7 +428,7 @@ struct NFAEngine(Copyable, Engine):
             while search_pos <= len(text):
                 # Find next occurrence of literal
                 var literal_pos = twoway_search(
-                    self.get_pattern().as_bytes(),
+                    self._get_search_literal_bytes(),
                     text,
                     search_pos,
                 )


### PR DESCRIPTION
## Summary

- **DFA**: `_try_match_at_position` called `get_pattern()` on every literal match attempt, copying `self.literal_pattern` (heap allocation per match). Now accesses `self.literal_pattern` directly for `.as_bytes()` and `len()`.
- **NFA**: `match_all` and `match_next` called `get_pattern().as_bytes()` in the literal prefilter loop, copying the String on each twoway_search iteration. Added `_get_search_literal_bytes()` which returns a zero-copy `Span[Byte]` view via `rebind` to `ImmutAnyOrigin`.
- The `Engine` trait's `get_pattern() -> String` signature is preserved for non-hot-path callers.

## Test plan

- [x] All 346 tests pass across 11 test files
- [x] `mojo format` clean