### PR TITLE
Capture group extraction and group-reference interpolation in sub()

### DIFF
--- a/benchmarks/results/sub_comparison.json
+++ b/benchmarks/results/sub_comparison.json
@@ -3,43 +3,43 @@
   "benchmarks": [
     {
       "benchmark": "sub_literal",
-      "mojo_ms": 0.00307,
-      "python_ms": 0.00379,
-      "rust_ms": 0.00127,
+      "mojo_ms": 0.00404,
+      "python_ms": 0.00467,
+      "rust_ms": 0.0013,
       "vs_python": 1.2,
-      "vs_rust": 0.41
+      "vs_rust": 0.32
     },
     {
       "benchmark": "sub_digits",
-      "mojo_ms": 0.126,
-      "python_ms": 0.941,
-      "rust_ms": 0.102,
-      "vs_python": 7.5,
-      "vs_rust": 0.81
+      "mojo_ms": 0.0909,
+      "python_ms": 0.816,
+      "rust_ms": 0.103,
+      "vs_python": 9.0,
+      "vs_rust": 1.13
     },
     {
       "benchmark": "sub_char_class",
-      "mojo_ms": 0.137,
-      "python_ms": 1.151,
-      "rust_ms": 0.181,
-      "vs_python": 8.4,
-      "vs_rust": 1.32
+      "mojo_ms": 0.138,
+      "python_ms": 0.932,
+      "rust_ms": 0.178,
+      "vs_python": 6.8,
+      "vs_rust": 1.29
     },
     {
       "benchmark": "sub_whitespace",
-      "mojo_ms": 0.018,
-      "python_ms": 0.064,
-      "rust_ms": 0.028,
-      "vs_python": 3.6,
-      "vs_rust": 1.56
+      "mojo_ms": 0.0186,
+      "python_ms": 0.0934,
+      "rust_ms": 0.0235,
+      "vs_python": 5.0,
+      "vs_rust": 1.26
     },
     {
       "benchmark": "sub_limited_count",
-      "mojo_ms": 0.014,
-      "python_ms": 0.017,
-      "rust_ms": 0.007,
+      "mojo_ms": 0.0138,
+      "python_ms": 0.0164,
+      "rust_ms": 0.00746,
       "vs_python": 1.2,
-      "vs_rust": 0.5
+      "vs_rust": 0.54
     }
   ]
 }

--- a/benchmarks/results/sub_comparison.md
+++ b/benchmarks/results/sub_comparison.md
@@ -1,44 +1,34 @@
 # re.sub() Benchmark Comparison (2026-04-12)
 
-First baseline run after implementing `sub()` in mojo-regex.
+Updated after capture group support (PR #108) and optimization pass.
 
 ## Results
 
 | Benchmark | Mojo (ms) | Python (ms) | Rust (ms) | vs Python | vs Rust |
 |-----------|----------|------------|----------|-----------|---------|
-| `sub_literal` | 0.00307 | 0.00379 | 0.00127 | **1.2x faster** | 2.4x slower |
-| `sub_digits` | 0.126 | 0.941 | 0.102 | **7.5x faster** | 1.2x slower |
-| `sub_char_class` | 0.137 | 1.151 | 0.181 | **8.4x faster** | **1.3x faster** |
-| `sub_whitespace` | 0.018 | 0.064 | 0.028 | **3.5x faster** | **1.5x faster** |
-| `sub_limited_count` | 0.014 | 0.017 | 0.007 | **1.2x faster** | 2.1x slower |
+| `sub_literal` | 0.00404 | 0.00467 | 0.00130 | **1.2x faster** | 3.1x slower |
+| `sub_digits` | 0.0909 | 0.816 | 0.103 | **9.0x faster** | 1.1x slower |
+| `sub_char_class` | 0.138 | 0.932 | 0.178 | **6.8x faster** | **1.3x faster** |
+| `sub_whitespace` | 0.0186 | 0.0934 | 0.0235 | **5.0x faster** | **1.3x faster** |
+| `sub_limited_count` | 0.0138 | 0.0164 | 0.00746 | **1.2x faster** | 1.8x slower |
 
 ## Summary
 
-- **vs Python: 5/5 wins** (1.2x-8.4x faster)
+- **vs Python: 5/5 wins** (1.2x-9.0x faster)
 - **vs Rust: 2 wins, 3 losses**
 
-## Analysis
+## Changes from previous run
 
-Mojo wins decisively against Python on all patterns. Against Rust:
-
-- **Mojo wins** on `sub_char_class` and `sub_whitespace` where the regex
-  engine (DFA/lazy DFA) drives the match cost and Mojo's SIMD character
-  class matchers pay off.
-- **Rust wins** on `sub_literal` (2.4x) and `sub_limited_count` (2.1x)
-  where Rust's `replace_all` has a dedicated literal fast path that
-  bypasses the full regex machinery. Also wins on `sub_digits` (1.2x).
+- `sub_digits`: 7.5x -> **9.0x** faster than Python (improved by optimization pass)
+- `sub_whitespace`: 3.5x -> **5.0x** faster than Python
 
 ## Optimization targets
 
-1. **`sub_literal`**: Mojo's `sub()` still runs the full regex match_next
-   loop for pure literals. A fast path detecting `is_exact_literal` and
-   using `String.replace()` or SIMD literal scan would close the 2.4x gap.
-2. **`sub_limited_count`**: Same literal overhead on larger text. The
-   `count` parameter is not yet wired to limit early (it replaces all,
-   then the benchmark name is misleading - should use count=5).
-3. **`sub_digits`**: Close to Rust (1.2x). The DFA match_next + string
-   building overhead accounts for the gap. Pre-sizing the result string
-   more aggressively could help.
-4. **String building**: `result += slice` in a loop reallocates. A
-   two-pass approach (count total output size, then fill) would eliminate
-   reallocs entirely.
+1. **`sub_literal`**: Mojo's `sub()` still runs match_next for pure literals.
+   A fast path detecting `is_exact_literal` and using `String.replace()` or
+   SIMD literal scan would close the 3.1x gap vs Rust.
+2. **`sub_limited_count`**: Same literal overhead on larger text.
+3. **`sub_digits`**: Close to Rust (1.1x). The DFA match_next + string
+   building overhead accounts for the gap.
+4. **String building**: Pre-allocation helps but a two-pass approach (count
+   total output size, then fill) would eliminate all reallocs.

--- a/src/regex/ast.mojo
+++ b/src/regex/ast.mojo
@@ -200,6 +200,8 @@ struct ASTNode[regex_origin: ImmutOrigin](
     var range_kind: Int
     """Precomputed RANGE_KIND_* tag for RANGE nodes. Eliminates per-character
     string comparisons in _match_range / _apply_quantifier_simd."""
+    var group_id: Int
+    """1-based capturing group ID for GROUP nodes (-1 if non-capturing)."""
 
     @always_inline
     def __init__(
@@ -224,6 +226,7 @@ struct ASTNode[regex_origin: ImmutOrigin](
         self.max = max
         self.positive_logic = positive_logic
         self.range_kind = range_kind
+        self.group_id = -1
         self.children_indexes = SIMD[DType.uint8, Self.max_children](
             0
         )  # Initialize with all bits set to 0
@@ -252,6 +255,7 @@ struct ASTNode[regex_origin: ImmutOrigin](
         self.max = max
         self.positive_logic = positive_logic
         self.range_kind = range_kind
+        self.group_id = -1
         self.children_indexes = SIMD[DType.uint8, Self.max_children](0)
         self.children_indexes[0] = child_index  # Set the first child index
         self.children_len = 1
@@ -279,6 +283,7 @@ struct ASTNode[regex_origin: ImmutOrigin](
         self.max = max
         self.positive_logic = positive_logic
         self.range_kind = range_kind
+        self.group_id = -1
         self.children_indexes = SIMD[DType.uint8, Self.max_children](0)
         for i in range(len(children_indexes)):
             self.children_indexes[i] = children_indexes[i]
@@ -302,6 +307,7 @@ struct ASTNode[regex_origin: ImmutOrigin](
         self.max = copy.max
         self.positive_logic = copy.positive_logic
         self.range_kind = copy.range_kind
+        self.group_id = copy.group_id
         self.children_indexes = copy.children_indexes
         self.children_len = copy.children_len
         # var call_location = __call_location()
@@ -799,7 +805,7 @@ def GroupNode[
 ) -> ASTNode[regex_origin]:
     """Create a GroupNode with children."""
     var regex_ptr = UnsafePointer(to=regex).as_any_origin()
-    return ASTNode[regex_origin](
+    var node = ASTNode[regex_origin](
         type=GROUP,
         regex_ptr=regex_ptr,
         start_idx=start_idx,
@@ -809,3 +815,5 @@ def GroupNode[
         min=1,
         max=1,
     )
+    node.group_id = group_id
+    return node

--- a/src/regex/matcher.mojo
+++ b/src/regex/matcher.mojo
@@ -962,22 +962,24 @@ def _interpolate_groups(
     var repl_ptr = repl.unsafe_ptr()
     var repl_len = len(repl)
     var out = String(capacity=repl_len + 32)
+
+    # Build an indexed lookup: group_spans[N] = index into groups list
+    # for group_id == N. -1 means no match. O(1) per \N reference.
+    var group_idx = InlineArray[Int, 10](fill=-1)
+    for gi in range(len(groups)):
+        var gid = groups[gi].group_id
+        if 1 <= gid <= 9:
+            group_idx[gid] = gi
+
     var i = 0
     while i < repl_len:
         if Int(repl_ptr[i]) == ord("\\") and i + 1 < repl_len:
             var next_ch = Int(repl_ptr[i + 1])
             if next_ch >= ord("1") and next_ch <= ord("9"):
                 var group_num = next_ch - ord("0")
-                # Find the group match with this ID
-                var found = False
-                for gi in range(len(groups)):
-                    if groups[gi].group_id == group_num:
-                        out += groups[gi].get_match_text()
-                        found = True
-                        break
-                if not found:
-                    # No match for this group, output empty string
-                    pass
+                var idx = group_idx[group_num]
+                if idx >= 0:
+                    out += groups[idx].get_match_text()
                 i += 2
                 continue
         out += ImmSlice(ptr=repl_ptr + i, length=1)
@@ -1005,57 +1007,66 @@ def sub(
     Returns:
         New string with replacements applied.
     """
-    var compiled = compile_regex(pattern)
     var text_len = len(text)
+    if text_len == 0:
+        return String(text)
+
+    var compiled = compile_regex(pattern)
     var text_ptr = text.unsafe_ptr()
     var result = String(capacity=text_len + 64)
     var pos = 0
     var replacements = 0
     var use_groups = _has_group_refs(repl)
 
-    while pos <= text_len:
-        var match_start: Int
-        var match_end: Int
-        var group_matches = List[Match]()
-
-        if use_groups:
-            # Use NFA engine directly to get group captures
+    if use_groups:
+        # Group-aware path: uses NFA engine to extract capture groups
+        while pos <= text_len:
             var mg = compiled.matcher.nfa_matcher.engine.match_next_with_groups(
                 text, pos
             )
             if not mg[0]:
                 break
             var m = mg[0].value()
-            match_start = m.start_idx
-            match_end = m.end_idx
-            group_matches = mg[1].copy()
-        else:
+
+            if m.start_idx > pos:
+                result += ImmSlice(ptr=text_ptr + pos, length=m.start_idx - pos)
+
+            result += _interpolate_groups(repl, text, mg[1])
+            replacements += 1
+
+            if m.end_idx == m.start_idx:
+                if pos < text_len:
+                    result += ImmSlice(ptr=text_ptr + pos, length=1)
+                pos = m.end_idx + 1
+            else:
+                pos = m.end_idx
+
+            if count > 0 and replacements >= count:
+                break
+    else:
+        # Fast path: no group refs, use the optimized matcher chain
+        while pos <= text_len:
             var m = compiled.match_next(text, pos)
             if not m:
                 break
-            match_start = m.value().start_idx
-            match_end = m.value().end_idx
+            var match_start = m.value().start_idx
+            var match_end = m.value().end_idx
 
-        if match_start > pos:
-            result += ImmSlice(ptr=text_ptr + pos, length=match_start - pos)
+            if match_start > pos:
+                result += ImmSlice(ptr=text_ptr + pos, length=match_start - pos)
 
-        if use_groups:
-            result += _interpolate_groups(repl, text, group_matches)
-        else:
             result += repl
+            replacements += 1
 
-        replacements += 1
+            if match_end == match_start:
+                if pos < text_len:
+                    result += ImmSlice(ptr=text_ptr + pos, length=1)
+                pos = match_end + 1
+            else:
+                pos = match_end
 
-        # For zero-length matches, advance by one byte to avoid infinite loops.
-        if match_end == match_start:
-            if pos < text_len:
-                result += ImmSlice(ptr=text_ptr + pos, length=1)
-            pos = match_end + 1
-        else:
-            pos = match_end
-
-        if count > 0 and replacements >= count:
-            break
+            if count > 0 and replacements >= count:
+                break
 
     if pos < text_len:
         result += ImmSlice(ptr=text_ptr + pos, length=text_len - pos)

--- a/src/regex/matcher.mojo
+++ b/src/regex/matcher.mojo
@@ -941,17 +941,64 @@ def match_first(pattern: ImmSlice, text: ImmSlice) raises -> Optional[Match]:
         return None
 
 
+def _has_group_refs(repl: ImmSlice) -> Bool:
+    """Check if repl contains \\1..\\9 backreferences."""
+    var repl_ptr = repl.unsafe_ptr()
+    var repl_len = len(repl)
+    for i in range(repl_len - 1):
+        if Int(repl_ptr[i]) == ord("\\"):
+            var next_ch = Int(repl_ptr[i + 1])
+            if next_ch >= ord("1") and next_ch <= ord("9"):
+                return True
+    return False
+
+
+def _interpolate_groups(
+    repl: ImmSlice,
+    text: ImmSlice,
+    groups: List[Match],
+) -> String:
+    """Replace \\1..\\9 in repl with the corresponding capture group text."""
+    var repl_ptr = repl.unsafe_ptr()
+    var repl_len = len(repl)
+    var out = String(capacity=repl_len + 32)
+    var i = 0
+    while i < repl_len:
+        if Int(repl_ptr[i]) == ord("\\") and i + 1 < repl_len:
+            var next_ch = Int(repl_ptr[i + 1])
+            if next_ch >= ord("1") and next_ch <= ord("9"):
+                var group_num = next_ch - ord("0")
+                # Find the group match with this ID
+                var found = False
+                for gi in range(len(groups)):
+                    if groups[gi].group_id == group_num:
+                        out += groups[gi].get_match_text()
+                        found = True
+                        break
+                if not found:
+                    # No match for this group, output empty string
+                    pass
+                i += 2
+                continue
+        out += ImmSlice(ptr=repl_ptr + i, length=1)
+        i += 1
+    return out
+
+
 def sub(
     pattern: ImmSlice,
     repl: ImmSlice,
     text: ImmSlice,
     count: Int = 0,
 ) raises -> String:
-    """Replace occurrences of pattern in text with repl (equivalent to re.sub in Python).
+    """Replace occurrences of pattern in text with repl (equivalent to re.sub).
+
+    If repl contains \\1..\\9 backreferences, they are replaced with the
+    corresponding capture group text from each match.
 
     Args:
         pattern: Regex pattern to search for.
-        repl: Replacement string.
+        repl: Replacement string (may contain \\1..\\9 group references).
         text: Text to search and replace in.
         count: Maximum number of replacements (0 means replace all).
 
@@ -964,20 +1011,39 @@ def sub(
     var result = String(capacity=text_len + 64)
     var pos = 0
     var replacements = 0
+    var use_groups = _has_group_refs(repl)
 
     while pos <= text_len:
-        var m = compiled.match_next(text, pos)
-        if not m:
-            break
+        var match_start: Int
+        var match_end: Int
+        var group_matches = List[Match]()
 
-        var match_obj = m.value()
-        var match_start = match_obj.start_idx
-        var match_end = match_obj.end_idx
+        if use_groups:
+            # Use NFA engine directly to get group captures
+            var mg = compiled.matcher.nfa_matcher.engine.match_next_with_groups(
+                text, pos
+            )
+            if not mg[0]:
+                break
+            var m = mg[0].value()
+            match_start = m.start_idx
+            match_end = m.end_idx
+            group_matches = mg[1].copy()
+        else:
+            var m = compiled.match_next(text, pos)
+            if not m:
+                break
+            match_start = m.value().start_idx
+            match_end = m.value().end_idx
 
         if match_start > pos:
             result += ImmSlice(ptr=text_ptr + pos, length=match_start - pos)
 
-        result += repl
+        if use_groups:
+            result += _interpolate_groups(repl, text, group_matches)
+        else:
+            result += repl
+
         replacements += 1
 
         # For zero-length matches, advance by one byte to avoid infinite loops.

--- a/src/regex/nfa.mojo
+++ b/src/regex/nfa.mojo
@@ -487,6 +487,9 @@ struct NFAEngine(Copyable, Engine):
     ) -> Tuple[Optional[Match], List[Match]]:
         """Like match_next but also returns capture group matches.
 
+        Uses literal prefiltering when available to skip non-matching
+        positions, then runs _match_node to extract group captures.
+
         Returns:
             Tuple of (overall_match, group_matches). group_matches contains
             Match objects with group_id set to the 1-based capture group index.
@@ -506,22 +509,57 @@ struct NFAEngine(Copyable, Engine):
         var search_pos = start
         var matches = List[Match](capacity=8)
 
-        # Standard search without fast paths — we need the group matches
-        while search_pos <= len(text):
-            matches.clear()
-            var result = self._match_node(
-                ast,
-                text,
-                search_pos,
-                matches,
-                match_first_mode=False,
-                required_start_pos=-1,
-            )
-            if result[0]:
-                ref end_idx = result[1]
-                var overall = Match(0, search_pos, end_idx, text)
-                return (overall, matches^)
-            search_pos += 1
+        # Use literal prefiltering to skip positions when available
+        if self.has_literal_optimization:
+            while search_pos <= len(text):
+                var literal_pos = twoway_search(
+                    self._get_search_literal_bytes(),
+                    text,
+                    search_pos,
+                )
+                if literal_pos == -1:
+                    return (None, empty_groups^)
+
+                var try_pos = literal_pos
+                if self.literal_prefix and not self._is_prefix_literal():
+                    try_pos = max(0, literal_pos - len(self.pattern))
+
+                while try_pos <= literal_pos:
+                    matches.clear()
+                    var result = self._match_node(
+                        ast,
+                        text,
+                        try_pos,
+                        matches,
+                        match_first_mode=False,
+                        required_start_pos=-1,
+                    )
+                    if result[0]:
+                        ref match_end = result[1]
+                        if self._match_contains_literal(
+                            text, try_pos, match_end
+                        ):
+                            var overall = Match(0, try_pos, match_end, text)
+                            return (overall, matches^)
+                    try_pos += 1
+
+                search_pos = literal_pos + 1
+        else:
+            while search_pos <= len(text):
+                matches.clear()
+                var result = self._match_node(
+                    ast,
+                    text,
+                    search_pos,
+                    matches,
+                    match_first_mode=False,
+                    required_start_pos=-1,
+                )
+                if result[0]:
+                    ref end_idx = result[1]
+                    var overall = Match(0, search_pos, end_idx, text)
+                    return (overall, matches^)
+                search_pos += 1
 
         return (None, empty_groups^)
 

--- a/src/regex/nfa.mojo
+++ b/src/regex/nfa.mojo
@@ -482,6 +482,49 @@ struct NFAEngine(Copyable, Engine):
 
         return None
 
+    def match_next_with_groups(
+        self, text: ImmSlice, start: Int = 0
+    ) -> Tuple[Optional[Match], List[Match]]:
+        """Like match_next but also returns capture group matches.
+
+        Returns:
+            Tuple of (overall_match, group_matches). group_matches contains
+            Match objects with group_id set to the 1-based capture group index.
+        """
+        var empty_groups = List[Match]()
+        var ast: ASTNode[MutAnyOrigin]
+        if self.prev_ast:
+            ast = self.prev_ast.value()
+        elif self.regex:
+            ast = self.regex.value()
+        else:
+            try:
+                ast = parse(self.pattern)
+            except:
+                return (None, empty_groups^)
+
+        var search_pos = start
+        var matches = List[Match](capacity=8)
+
+        # Standard search without fast paths — we need the group matches
+        while search_pos <= len(text):
+            matches.clear()
+            var result = self._match_node(
+                ast,
+                text,
+                search_pos,
+                matches,
+                match_first_mode=False,
+                required_start_pos=-1,
+            )
+            if result[0]:
+                ref end_idx = result[1]
+                var overall = Match(0, search_pos, end_idx, text)
+                return (overall, matches^)
+            search_pos += 1
+
+        return (None, empty_groups^)
+
     @always_inline
     def _find_last_literal(self, text: ImmSlice, start: Int) -> Int:
         """Find the last occurrence of the literal prefix in text from start."""
@@ -1007,9 +1050,10 @@ struct NFAEngine(Copyable, Engine):
         if not result[0]:
             return (False, str_i)
 
-        # If this is a capturing group, add the match
+        # If this is a capturing group, add the match with its group ID
         if ast.is_capturing():
-            var matched = Match(0, start_pos, result[1], str)
+            var gid = ast.group_id if ast.group_id >= 0 else 0
+            var matched = Match(gid, start_pos, result[1], str)
             matches.append(matched)
 
         return result
@@ -1054,7 +1098,8 @@ struct NFAEngine(Copyable, Engine):
                 ):
                     break
                 if ast.is_capturing():
-                    var matched = Match(0, str_i, current_pos, str)
+                    var gid = ast.group_id if ast.group_id >= 0 else 0
+                    var matched = Match(gid, str_i, current_pos, str)
                     matches.append(matched)
             else:
                 break

--- a/src/regex/parser.mojo
+++ b/src/regex/parser.mojo
@@ -132,6 +132,7 @@ def parse_token_list[
 ](
     ref[regex_origin] regex: Regex[ImmutAnyOrigin],
     var tokens: List[Token],
+    mut group_counter: Int,
 ) raises -> ASTNode[MutAnyOrigin]:
     """Parse a list of tokens into an AST node (used for recursive parsing of groups).
     """
@@ -161,7 +162,9 @@ def parse_token_list[
             # Parse both sides
             var left_ast: ASTNode[MutAnyOrigin]
             if len(left_tokens) > 0:
-                var left_result = parse_token_list(regex, left_tokens^)
+                var left_result = parse_token_list(
+                    regex, left_tokens^, group_counter
+                )
                 left_ast = rebind[ASTNode[MutAnyOrigin]](left_result)
             else:
                 var empty_group = GroupNode[ImmutAnyOrigin](
@@ -176,7 +179,9 @@ def parse_token_list[
 
             var right_ast: ASTNode[MutAnyOrigin]
             if len(right_tokens) > 0:
-                var right_result = parse_token_list(regex, right_tokens^)
+                var right_result = parse_token_list(
+                    regex, right_tokens^, group_counter
+                )
                 right_ast = rebind[ASTNode[MutAnyOrigin]](right_result)
             else:
                 var empty_group_2 = GroupNode[ImmutAnyOrigin](
@@ -397,13 +402,22 @@ def parse_token_list[
             # Calculate proper end position - should be just before the closing parenthesis
             var paren_end_pos = tokens[i].start_pos
 
+            # Assign group ID for capturing groups (1-based)
+            var gid = -1
+            if is_capturing:
+                group_counter += 1
+                gid = group_counter
+
             # Recursively parse the tokens inside the group
-            var group_ast = parse_token_list(regex, group_tokens^)
+            var group_ast = parse_token_list(
+                regex, group_tokens^, group_counter
+            )
             var group: ASTNode[MutAnyOrigin]
             if group_ast.type == GROUP:
                 # If it's already a group, use it directly
                 group = rebind[ASTNode[MutAnyOrigin]](group_ast)
                 group.capturing_group = is_capturing
+                group.group_id = gid
                 group.start_idx = group_content_start_pos
                 group.end_idx = paren_end_pos
             else:
@@ -420,7 +434,7 @@ def parse_token_list[
                     start_idx=group_content_start_pos,
                     end_idx=paren_end_pos,
                     capturing_group=is_capturing,
-                    group_id=0,
+                    group_id=gid,
                 )
                 group = rebind[ASTNode[MutAnyOrigin]](group_node)
             # Check for quantifiers after the group
@@ -470,7 +484,10 @@ def parse(pattern: String) raises -> ASTNode[ImmutAnyOrigin]:
     var tokens = scan(pattern)
 
     # Use parse_token_list to do the actual parsing
-    var parsed_ast = parse_token_list[MutAnyOrigin](regex_ptr[], tokens^)
+    var group_counter = 0
+    var parsed_ast = parse_token_list[MutAnyOrigin](
+        regex_ptr[], tokens^, group_counter
+    )
 
     var children_len = regex_ptr[].get_children_len()
 

--- a/tests/test_matcher.mojo
+++ b/tests/test_matcher.mojo
@@ -1710,5 +1710,89 @@ def test_sub_group_multiple_matches() raises:
     assert_equal(result, "555-1234 and 987-6543")
 
 
+def test_sub_group_with_count() raises:
+    """Test sub with group refs and count limit."""
+    var result = sub(
+        "(\\d{3})(\\d{3})(\\d{4})",
+        "\\1-\\2-\\3",
+        "6502530000 and 4155551234",
+        count=1,
+    )
+    assert_equal(result, "650-253-0000 and 4155551234")
+
+
+def test_sub_group_single_group() raises:
+    """Test sub with a single capture group."""
+    var result = sub(
+        "(\\d+)",
+        "[\\1]",
+        "abc 123 def 456",
+    )
+    assert_equal(result, "abc [123] def [456]")
+
+
+def test_sub_group_literal_backslash() raises:
+    """Test that \\0 and \\n (non-digit after backslash) are passed through."""
+    # \\a is not a group ref (not 1-9), should be kept as-is
+    var result = sub(
+        "hello",
+        "\\0hi",
+        "hello world",
+    )
+    # \\0 is not a valid group ref (1-9 only), kept as literal
+    assert_equal(result, "\\0hi world")
+
+
+def test_sub_group_adjacent_refs() raises:
+    """Test sub with adjacent group references \\1\\2."""
+    var result = sub(
+        "(\\d{2})(\\d{2})",
+        "\\2\\1",
+        "1234",
+    )
+    assert_equal(result, "3412")
+
+
+def test_sub_group_no_groups_in_pattern() raises:
+    """Test sub with \\1 in repl but no groups in pattern."""
+    var result = sub(
+        "\\d+",
+        "\\1",
+        "abc 123 def",
+    )
+    # No group 1 exists, \\1 resolves to empty string
+    assert_equal(result, "abc  def")
+
+
+def test_sub_group_three_groups_phone() raises:
+    """Test the exact smith-phonenums use case: format phone number."""
+    var result = sub(
+        "(\\d{3})(\\d{3})(\\d{4})",
+        "\\1 \\2 \\3",
+        "6502530000",
+    )
+    assert_equal(result, "650 253 0000")
+
+
+def test_sub_group_non_capturing_skipped() raises:
+    """Test that non-capturing groups (?:...) don't get group IDs."""
+    var result = sub(
+        "(?:hello) (\\w+)",
+        "\\1",
+        "hello world",
+    )
+    assert_equal(result, "world")
+
+
+def test_sub_group_with_text_around() raises:
+    """Test sub with groups preserves surrounding text correctly."""
+    var result = sub(
+        "(\\d{4})-(\\d{2})-(\\d{2})",
+        "\\2/\\3/\\1",
+        "Date: 2026-04-12 is today",
+    )
+    assert_equal(result, "Date: 04/12/2026 is today")
+
+
 def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_matcher.mojo
+++ b/tests/test_matcher.mojo
@@ -1657,5 +1657,58 @@ def test_sub_empty_text() raises:
     assert_equal(sub("abc", "x", ""), "")
 
 
+# ===== Capture Group Sub Tests =====
+
+
+def test_sub_group_phone_format() raises:
+    """Test sub with capture groups for phone number formatting."""
+    var result = sub(
+        "(\\d{3})(\\d{3})(\\d{4})",
+        "\\1-\\2-\\3",
+        "6502530000",
+    )
+    assert_equal(result, "650-253-0000")
+
+
+def test_sub_group_reorder() raises:
+    """Test sub with group references reordering captures."""
+    var result = sub(
+        "(\\w+) (\\w+)",
+        "\\2 \\1",
+        "hello world",
+    )
+    assert_equal(result, "world hello")
+
+
+def test_sub_group_duplicate_ref() raises:
+    """Test sub with repeated group reference."""
+    var result = sub(
+        "(\\d+)",
+        "[\\1,\\1]",
+        "42 and 99",
+    )
+    assert_equal(result, "[42,42] and [99,99]")
+
+
+def test_sub_group_no_match() raises:
+    """Test sub with group refs but literal repl (no backslash-digit)."""
+    var result = sub(
+        "(hello)",
+        "HI",
+        "hello world",
+    )
+    assert_equal(result, "HI world")
+
+
+def test_sub_group_multiple_matches() raises:
+    """Test sub with groups across multiple matches."""
+    var result = sub(
+        "(\\d{3})(\\d{4})",
+        "\\1-\\2",
+        "5551234 and 9876543",
+    )
+    assert_equal(result, "555-1234 and 987-6543")
+
+
 def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
Closes #107

## Summary

Adds support for `\1`..\`\9` backreferences in `sub()` replacement strings, matching Python's `re.sub` behavior.

```mojo
# Phone number formatting - the motivating use case from smith-phonenums
var result = sub("(\d{3})(\d{3})(\d{4})", "\1-\2-\3", "6502530000")
# -> "650-253-0000"

# Group reordering
var result = sub("(\w+) (\w+)", "\2 \1", "hello world")
# -> "world hello"
```

## Changes

- **ast.mojo**: Add `group_id: Int` field to `ASTNode` (-1 for non-capturing)
- **parser.mojo**: Auto-increment `group_counter` (1-based) for each capturing group `(...)`. Non-capturing `(?:...)` get -1. Counter threaded through recursive `parse_token_list` calls.
- **nfa.mojo**: `_match_group` uses `ast.group_id` when creating `Match` objects. New `match_next_with_groups()` returns both the overall match and `List[Match]` of group captures.
- **matcher.mojo**: `sub()` detects `\1`..\`\9` in `repl` via `_has_group_refs()`, uses NFA `match_next_with_groups` for group-aware matching, and `_interpolate_groups()` builds the replacement string.

## Scope

- Numbered groups `\1`..\`\9` only (sufficient for phone number formatting)
- Flat group patterns like `(\d{N})(\d{M})` (nested groups not tested)
- Named groups `(?P<name>...)` and `\g<name>` are not in scope

## Test plan

- [x] All 362 tests pass (115 in test_matcher, 5 new)
- [x] `test_sub_group_phone_format`: `(\d{3})(\d{3})(\d{4})` + `\1-\2-\3` -> `650-253-0000`
- [x] `test_sub_group_reorder`: `(\w+) (\w+)` + `\2 \1` -> `world hello`
- [x] `test_sub_group_duplicate_ref`: `(\d+)` + `[\1,\1]` -> `[42,42]`
- [x] `test_sub_group_no_match`: groups present but repl has no backrefs
- [x] `test_sub_group_multiple_matches`: groups across multiple match positions