### PR TITLE
DFA fast path for sub() on fixed-width capture groups

### DIFF
--- a/benchmarks/bench_engine.mojo
+++ b/benchmarks/bench_engine.mojo
@@ -796,3 +796,30 @@ def main() raises:
         short_text * 100,
         100,
     )
+    # Group-reference substitution (exercises fixed-width DFA fast path)
+    var phone_numbers = String()
+    for _ in range(100):
+        phone_numbers += "Call 6502530000 or 4155551234 today. "
+    benchmark_sub(
+        "sub_group_phone_fmt",
+        "(\\d{3})(\\d{3})(\\d{4})",
+        "\\1-\\2-\\3",
+        phone_numbers,
+        10,
+    )
+    # Group-reference with literals between groups
+    benchmark_sub(
+        "sub_group_date_fmt",
+        "(\\d{4})-(\\d{2})-(\\d{2})",
+        "\\2/\\3/\\1",
+        "Event on 2026-04-12 and 2025-12-25 and 2024-01-01. " * 50,
+        20,
+    )
+    # General group path (not fixed-width, falls through to NFA)
+    benchmark_sub(
+        "sub_group_word_swap",
+        "(\\w+) (\\w+)",
+        "\\2 \\1",
+        "hello world foo bar baz qux " * 50,
+        20,
+    )

--- a/benchmarks/python/bench_engine.py
+++ b/benchmarks/python/bench_engine.py
@@ -760,6 +760,29 @@ def main():
         short_text * 100,
         100,
     )
+    # Group-reference substitution
+    phone_numbers = "Call 6502530000 or 4155551234 today. " * 100
+    benchmark_sub(
+        "sub_group_phone_fmt",
+        r"(\d{3})(\d{3})(\d{4})",
+        r"\1-\2-\3",
+        phone_numbers,
+        10,
+    )
+    benchmark_sub(
+        "sub_group_date_fmt",
+        r"(\d{4})-(\d{2})-(\d{2})",
+        r"\2/\3/\1",
+        "Event on 2026-04-12 and 2025-12-25 and 2024-01-01. " * 50,
+        20,
+    )
+    benchmark_sub(
+        "sub_group_word_swap",
+        r"(\w+) (\w+)",
+        r"\2 \1",
+        "hello world foo bar baz qux " * 50,
+        20,
+    )
 
     print()
     export_json_results()

--- a/benchmarks/rust/src/bench_engine.rs
+++ b/benchmarks/rust/src/bench_engine.rs
@@ -283,6 +283,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     run_sub_benchmark(&timer, &mut all_results, "sub_whitespace", &sub_whitespace, " ", &whitespace_text, 50);
     run_sub_benchmark(&timer, &mut all_results, "sub_limited_count", &sub_hello, "HI", &short_text_100, 100);
 
+    // Group-reference substitution benchmarks
+    let phone_numbers = "Call 6502530000 or 4155551234 today. ".repeat(100);
+    let sub_group_phone = Regex::new(r"(\d{3})(\d{3})(\d{4})")?;
+    let sub_group_date = Regex::new(r"(\d{4})-(\d{2})-(\d{2})")?;
+    let sub_group_word = Regex::new(r"(\w+) (\w+)")?;
+
+    run_sub_benchmark(&timer, &mut all_results, "sub_group_phone_fmt", &sub_group_phone, "$1-$2-$3", &phone_numbers, 10);
+    run_sub_benchmark(&timer, &mut all_results, "sub_group_date_fmt", &sub_group_date, "$2/$3/$1", &("Event on 2026-04-12 and 2025-12-25 and 2024-01-01. ".repeat(50)), 20);
+    run_sub_benchmark(&timer, &mut all_results, "sub_group_word_swap", &sub_group_word, "$2 $1", &("hello world foo bar baz qux ".repeat(50)), 20);
+
     // ===-----------------------------------------------------------------------===
     // Results Summary
     // ===-----------------------------------------------------------------------===

--- a/src/regex/matcher.mojo
+++ b/src/regex/matcher.mojo
@@ -953,6 +953,97 @@ def _has_group_refs(repl: ImmSlice) -> Bool:
     return False
 
 
+def _detect_fixed_width_groups(
+    pattern: ImmSlice,
+) -> Optional[List[Int]]:
+    """Detect if pattern is a sequence of fixed-width \\d{N} capture groups
+    with optional fixed-width literals/escapes between them.
+
+    Returns a list encoding the pattern structure: positive values are
+    capture group widths (in order), negative values are inter-group
+    literal byte counts to skip. Example: `(\\d{3})-(\\d{4})` returns
+    [3, -1, 4].
+
+    Returns None if the pattern doesn't qualify (alternation, variable
+    quantifiers, nested groups, non-\\d groups, character classes).
+    """
+    var p = pattern.unsafe_ptr()
+    var plen = len(pattern)
+    var segments = List[Int]()
+    var i = 0
+    var literal_run = 0  # track bytes of literal content between groups
+
+    while i < plen:
+        if Int(p[i]) == ord("("):
+            # Flush any literal run
+            if literal_run > 0:
+                segments.append(-literal_run)
+                literal_run = 0
+
+            # Check for non-capturing (?:...)
+            if i + 1 < plen and Int(p[i + 1]) == ord("?"):
+                return None
+
+            i += 1  # skip (
+
+            # Expect \d or \d{N}
+            if (
+                i + 1 >= plen
+                or Int(p[i]) != ord("\\")
+                or Int(p[i + 1]) != ord("d")
+            ):
+                return None
+            i += 2  # skip \d
+
+            # Check for {N}
+            if i < plen and Int(p[i]) == ord("{"):
+                i += 1  # skip {
+                var num_start = i
+                while (
+                    i < plen and Int(p[i]) >= ord("0") and Int(p[i]) <= ord("9")
+                ):
+                    i += 1
+                if i == num_start or i >= plen or Int(p[i]) != ord("}"):
+                    return None
+                var width = 0
+                for j in range(num_start, i):
+                    width = width * 10 + (Int(p[j]) - ord("0"))
+                i += 1  # skip }
+                segments.append(width)
+            elif i < plen and Int(p[i]) == ord(")"):
+                # Bare \d: width 1
+                segments.append(1)
+            else:
+                return None  # Variable quantifier
+
+            # Expect closing )
+            if i >= plen or Int(p[i]) != ord(")"):
+                return None
+            i += 1  # skip )
+        elif Int(p[i]) == ord("|") or Int(p[i]) == ord("["):
+            return None
+        else:
+            # Literal or escape between groups
+            if Int(p[i]) == ord("\\") and i + 1 < plen:
+                literal_run += (
+                    1  # the escaped char takes 1 byte in matched text
+                )
+                i += 2
+            else:
+                literal_run += 1
+                i += 1
+
+    # Check we found at least one group
+    var has_group = False
+    for si in range(len(segments)):
+        if segments[si] > 0:
+            has_group = True
+            break
+    if not has_group:
+        return None
+    return segments^
+
+
 def _interpolate_groups(
     repl: ImmSlice,
     text: ImmSlice,
@@ -980,6 +1071,58 @@ def _interpolate_groups(
                 var idx = group_idx[group_num]
                 if idx >= 0:
                     out += groups[idx].get_match_text()
+                i += 2
+                continue
+        out += ImmSlice(ptr=repl_ptr + i, length=1)
+        i += 1
+    return out
+
+
+@always_inline
+def _interpolate_fixed_groups(
+    repl: ImmSlice,
+    text_ptr: UnsafePointer[Byte, ImmutAnyOrigin],
+    match_start: Int,
+    segments: List[Int],
+) -> String:
+    """Interpolate \\1..\\9 using precomputed fixed-width group offsets.
+
+    `segments` encodes the pattern structure: positive = group width,
+    negative = literal skip bytes. Group numbering is 1-based in order
+    of positive segments.
+    """
+    var repl_ptr = repl.unsafe_ptr()
+    var repl_len = len(repl)
+    var out = String(capacity=repl_len + 32)
+
+    # Precompute group start offsets and widths from segments.
+    # Walk segments accumulating byte offset from match_start.
+    var group_starts = InlineArray[Int, 10](fill=0)
+    var group_widths = InlineArray[Int, 10](fill=0)
+    var num_groups = 0
+    var offset = match_start
+    for si in range(len(segments)):
+        var seg = segments[si]
+        if seg > 0:
+            # Capture group
+            num_groups += 1
+            group_starts[num_groups] = offset
+            group_widths[num_groups] = seg
+            offset += seg
+        else:
+            # Literal skip
+            offset += -seg
+
+    var i = 0
+    while i < repl_len:
+        if Int(repl_ptr[i]) == ord("\\") and i + 1 < repl_len:
+            var next_ch = Int(repl_ptr[i + 1])
+            if next_ch >= ord("1") and next_ch <= ord("9"):
+                var group_num = next_ch - ord("0")
+                if group_num <= num_groups:
+                    var gs = group_starts[group_num]
+                    var gw = group_widths[group_num]
+                    out += ImmSlice(ptr=text_ptr + gs, length=gw)
                 i += 2
                 continue
         out += ImmSlice(ptr=repl_ptr + i, length=1)
@@ -1019,30 +1162,69 @@ def sub(
     var use_groups = _has_group_refs(repl)
 
     if use_groups:
-        # Group-aware path: uses NFA engine to extract capture groups
-        while pos <= text_len:
-            var mg = compiled.matcher.nfa_matcher.engine.match_next_with_groups(
-                text, pos
-            )
-            if not mg[0]:
-                break
-            var m = mg[0].value()
+        # Check for fixed-width groups fast path: if all groups are \d{N},
+        # we can compute group boundaries from match position + widths
+        # without running the NFA at all.
+        var fixed_widths = _detect_fixed_width_groups(pattern)
+        if fixed_widths:
+            var segments = fixed_widths.value().copy()
+            # Fixed-width fast path: use optimized matcher for finding
+            # matches, compute groups from offsets (no NFA needed)
+            while pos <= text_len:
+                var m = compiled.match_next(text, pos)
+                if not m:
+                    break
+                var match_start = m.value().start_idx
+                var match_end = m.value().end_idx
 
-            if m.start_idx > pos:
-                result += ImmSlice(ptr=text_ptr + pos, length=m.start_idx - pos)
+                if match_start > pos:
+                    result += ImmSlice(
+                        ptr=text_ptr + pos, length=match_start - pos
+                    )
 
-            result += _interpolate_groups(repl, text, mg[1])
-            replacements += 1
+                result += _interpolate_fixed_groups(
+                    repl, text_ptr, match_start, segments
+                )
+                replacements += 1
 
-            if m.end_idx == m.start_idx:
-                if pos < text_len:
-                    result += ImmSlice(ptr=text_ptr + pos, length=1)
-                pos = m.end_idx + 1
-            else:
-                pos = m.end_idx
+                if match_end == match_start:
+                    if pos < text_len:
+                        result += ImmSlice(ptr=text_ptr + pos, length=1)
+                    pos = match_end + 1
+                else:
+                    pos = match_end
 
-            if count > 0 and replacements >= count:
-                break
+                if count > 0 and replacements >= count:
+                    break
+        else:
+            # General group path: uses NFA engine to extract captures
+            while pos <= text_len:
+                var mg = (
+                    compiled.matcher.nfa_matcher.engine.match_next_with_groups(
+                        text, pos
+                    )
+                )
+                if not mg[0]:
+                    break
+                var m = mg[0].value()
+
+                if m.start_idx > pos:
+                    result += ImmSlice(
+                        ptr=text_ptr + pos, length=m.start_idx - pos
+                    )
+
+                result += _interpolate_groups(repl, text, mg[1])
+                replacements += 1
+
+                if m.end_idx == m.start_idx:
+                    if pos < text_len:
+                        result += ImmSlice(ptr=text_ptr + pos, length=1)
+                    pos = m.end_idx + 1
+                else:
+                    pos = m.end_idx
+
+                if count > 0 and replacements >= count:
+                    break
     else:
         # Fast path: no group refs, use the optimized matcher chain
         while pos <= text_len:


### PR DESCRIPTION
Closes #109

## Summary

When all capture groups in a pattern are fixed-width `\d{N}` segments (the common phone-number formatting case), `sub()` now skips the NFA engine entirely and computes group boundaries from the pattern structure via pointer arithmetic.

For `sub("(\d{3})(\d{3})(\d{4})", "\1-\2-\3", "6502530000")`:
- **Before**: NFA `match_next_with_groups` runs full backtracking engine per match to extract group spans
- **After**: `compiled.match_next()` finds the match position (DFA/lazy-DFA fast path), then `_interpolate_fixed_groups` slices text at precomputed offsets. Zero NFA execution.

## How it works

1. `_detect_fixed_width_groups(pattern)` analyzes the pattern string and returns a segment list: positive values = group widths, negative values = inter-group literal byte counts. Returns `None` for patterns with alternation, variable quantifiers, nested groups, or non-`\d` content inside groups.

2. `_interpolate_fixed_groups()` walks the `repl` string, replacing `\N` with text slices computed from `match_start + cumulative_offset`. Uses `InlineArray[Int, 10]` for O(1) group lookup.

3. `sub()` checks for fixed-width groups when `use_groups=True`. If detected, uses the optimized matcher chain for position finding + offset arithmetic for group extraction. Falls through to NFA for complex patterns.

## Patterns that qualify

- `(\d{3})(\d{3})(\d{4})` -> segments [3, 3, 4]
- `(\d{4})-(\d{2})-(\d{2})` -> segments [4, -1, 2, -1, 2]
- `(\d)(\d{3})` -> segments [1, 3]

## Patterns that fall through to NFA

- `(\w+)(\d{3})` (variable-width `\w+`)
- `(a|b)(\d{3})` (alternation)
- `(?:hello)(\d{3})` (non-capturing group)

## Test plan

- [x] All 370 tests pass (13 capture group sub tests all pass)
- [x] `test_sub_group_with_text_around` validates inter-group literal handling (`2026-04-12` -> `04/12/2026`)