### PR TITLE
Add SubFormatter for zero-regex fixed-width group substitution

### DIFF
--- a/src/regex/__init__.mojo
+++ b/src/regex/__init__.mojo
@@ -1,1 +1,1 @@
-from .matcher import match_first, findall, search, sub, Match
+from .matcher import match_first, findall, search, sub, Match, SubFormatter

--- a/src/regex/matcher.mojo
+++ b/src/regex/matcher.mojo
@@ -1254,3 +1254,212 @@ def sub(
         result += ImmSlice(ptr=text_ptr + pos, length=text_len - pos)
 
     return result
+
+
+# ===-----------------------------------------------------------------------===#
+# SubFormatter: pre-compiled format template for zero-regex substitution
+# ===-----------------------------------------------------------------------===#
+
+
+struct _TemplateSegment(Copyable, Movable, TrivialRegisterPassable):
+    """A segment of a pre-parsed replacement template.
+
+    If group_ref > 0, this segment is a group reference (\\N).
+    If group_ref == 0, this segment is a literal slice of the repl string
+    at [start, start+length).
+    """
+
+    comptime __copy_ctor_is_trivial = True
+
+    var group_ref: Int
+    var start: Int
+    var length: Int
+
+    @always_inline
+    def __init__(out self, group_ref: Int, start: Int, length: Int):
+        self.group_ref = group_ref
+        self.start = start
+        self.length = length
+
+
+struct SubFormatter(Copyable, Movable):
+    """Pre-compiled substitution template for fixed-width capture groups.
+
+    Created once per pattern+replacement pair. Formatting a number is then
+    pure slicing + concatenation with zero regex execution, zero cache
+    lookup, and zero replacement parsing.
+
+    Example:
+        var fmt = SubFormatter("(\\d{3})(\\d{3})(\\d{4})", "\\1-\\2-\\3")
+        var result = fmt.format("6502530000")  # -> "650-253-0000"
+    """
+
+    var _group_starts: InlineArray[Int, 10]
+    """Cumulative byte offset for each group (1-indexed). group_starts[i]
+    is the byte offset from match start where group i begins."""
+    var _group_widths: InlineArray[Int, 10]
+    """Width in bytes of each group (1-indexed)."""
+    var _num_groups: Int
+    """Number of capture groups."""
+    var _total_match_width: Int
+    """Total match width in bytes (sum of all segments)."""
+    var _template: List[_TemplateSegment]
+    """Pre-parsed replacement template segments."""
+    var _repl: String
+    """The original replacement string (kept alive for literal segments)."""
+    var _output_size_estimate: Int
+    """Estimated output size per substitution."""
+    var _valid: Bool
+    """Whether this formatter was successfully constructed."""
+
+    def __init__(out self, pattern: ImmSlice, repl: ImmSlice) raises:
+        """Construct a SubFormatter from a pattern and replacement string.
+
+        Args:
+            pattern: Regex pattern with fixed-width \\d{N} capture groups.
+            repl: Replacement string with \\1..\\9 backreferences.
+
+        Raises:
+            If the pattern is not a fixed-width capture group pattern.
+        """
+        self._group_starts = InlineArray[Int, 10](fill=0)
+        self._group_widths = InlineArray[Int, 10](fill=0)
+        self._num_groups = 0
+        self._total_match_width = 0
+        self._template = List[_TemplateSegment]()
+        self._repl = String(repl)
+        self._output_size_estimate = 0
+        self._valid = False
+
+        # Detect fixed-width groups
+        var segments = _detect_fixed_width_groups(pattern)
+        if not segments:
+            raise Error(
+                "SubFormatter requires a fixed-width \\d{N} capture group"
+                " pattern"
+            )
+
+        # Compute group offsets from segments
+        var segs = segments.value().copy()
+        var offset = 0
+        for si in range(len(segs)):
+            var seg = segs[si]
+            if seg > 0:
+                self._num_groups += 1
+                self._group_starts[self._num_groups] = offset
+                self._group_widths[self._num_groups] = seg
+                offset += seg
+            else:
+                offset += -seg
+        self._total_match_width = offset
+
+        # Pre-parse the replacement template
+        var repl_ptr = repl.unsafe_ptr()
+        var repl_len = len(repl)
+        var i = 0
+        var literal_start = 0
+        while i < repl_len:
+            if (
+                Int(repl_ptr[i]) == ord("\\")
+                and i + 1 < repl_len
+                and Int(repl_ptr[i + 1]) >= ord("1")
+                and Int(repl_ptr[i + 1]) <= ord("9")
+            ):
+                # Flush pending literal
+                if i > literal_start:
+                    self._template.append(
+                        _TemplateSegment(0, literal_start, i - literal_start)
+                    )
+                # Add group reference
+                var group_num = Int(repl_ptr[i + 1]) - ord("0")
+                self._template.append(_TemplateSegment(group_num, 0, 0))
+                i += 2
+                literal_start = i
+            else:
+                i += 1
+        # Flush trailing literal
+        if literal_start < repl_len:
+            self._template.append(
+                _TemplateSegment(0, literal_start, repl_len - literal_start)
+            )
+
+        # Estimate output size
+        var est = 0
+        for ti in range(len(self._template)):
+            ref seg = self._template[ti]
+            if seg.group_ref > 0 and seg.group_ref <= self._num_groups:
+                est += self._group_widths[seg.group_ref]
+            else:
+                est += seg.length
+        self._output_size_estimate = est
+        self._valid = True
+
+    @always_inline
+    def format(self, text: ImmSlice) -> String:
+        """Format a text string using the pre-compiled template.
+
+        Assumes the text is a valid match for the pattern (e.g., a phone
+        number that has already been validated). No regex execution occurs.
+
+        Args:
+            text: Input text to format. Must be at least _total_match_width
+                bytes long.
+
+        Returns:
+            Formatted string with group substitutions applied.
+        """
+        var text_ptr = text.unsafe_ptr()
+        var repl_ptr = self._repl.unsafe_ptr()
+        var result = String(capacity=self._output_size_estimate + 4)
+
+        for ti in range(len(self._template)):
+            ref seg = self._template[ti]
+            if seg.group_ref > 0 and seg.group_ref <= self._num_groups:
+                var gs = self._group_starts[seg.group_ref]
+                var gw = self._group_widths[seg.group_ref]
+                result += ImmSlice(ptr=text_ptr + gs, length=gw)
+            else:
+                result += ImmSlice(ptr=repl_ptr + seg.start, length=seg.length)
+
+        return result
+
+    @always_inline
+    def format(self, text: ImmSlice, match_start: Int) -> String:
+        """Format from a match position within a larger text.
+
+        Args:
+            text: Full input text.
+            match_start: Byte offset where the match starts.
+
+        Returns:
+            Formatted string with group substitutions applied.
+        """
+        var text_ptr = text.unsafe_ptr() + match_start
+        var repl_ptr = self._repl.unsafe_ptr()
+        var result = String(capacity=self._output_size_estimate + 4)
+
+        for ti in range(len(self._template)):
+            ref seg = self._template[ti]
+            if seg.group_ref > 0 and seg.group_ref <= self._num_groups:
+                var gs = self._group_starts[seg.group_ref]
+                var gw = self._group_widths[seg.group_ref]
+                result += ImmSlice(ptr=text_ptr + gs, length=gw)
+            else:
+                result += ImmSlice(ptr=repl_ptr + seg.start, length=seg.length)
+
+        return result
+
+    @always_inline
+    def is_valid(self) -> Bool:
+        """Whether this formatter was successfully constructed."""
+        return self._valid
+
+    @always_inline
+    def num_groups(self) -> Int:
+        """Number of capture groups in the pattern."""
+        return self._num_groups
+
+    @always_inline
+    def total_match_width(self) -> Int:
+        """Total match width in bytes."""
+        return self._total_match_width

--- a/tests/test_matcher.mojo
+++ b/tests/test_matcher.mojo
@@ -9,6 +9,7 @@ from regex.matcher import (
     match_first,
     sub,
     clear_regex_cache,
+    SubFormatter,
 )
 from regex.optimizer import PatternComplexity
 
@@ -1792,6 +1793,57 @@ def test_sub_group_with_text_around() raises:
         "Date: 2026-04-12 is today",
     )
     assert_equal(result, "Date: 04/12/2026 is today")
+
+
+# ===== SubFormatter Tests =====
+
+
+def test_sub_formatter_phone() raises:
+    """Test SubFormatter for phone number formatting."""
+    var fmt = SubFormatter("(\\d{3})(\\d{3})(\\d{4})", "\\1-\\2-\\3")
+    assert_equal(fmt.format("6502530000"), "650-253-0000")
+    assert_equal(fmt.format("4155551234"), "415-555-1234")
+
+
+def test_sub_formatter_phone_spaces() raises:
+    """Test SubFormatter with space-separated groups."""
+    var fmt = SubFormatter("(\\d{3})(\\d{3})(\\d{4})", "\\1 \\2 \\3")
+    assert_equal(fmt.format("6502530000"), "650 253 0000")
+
+
+def test_sub_formatter_date() raises:
+    """Test SubFormatter for date reformatting."""
+    var fmt = SubFormatter("(\\d{4})-(\\d{2})-(\\d{2})", "\\2/\\3/\\1")
+    assert_equal(fmt.format("2026-04-12"), "04/12/2026")
+
+
+def test_sub_formatter_two_groups() raises:
+    """Test SubFormatter with two groups."""
+    var fmt = SubFormatter("(\\d{3})(\\d{4})", "\\1-\\2")
+    assert_equal(fmt.format("5551234"), "555-1234")
+
+
+def test_sub_formatter_match_start() raises:
+    """Test SubFormatter.format with match_start offset."""
+    var fmt = SubFormatter("(\\d{3})(\\d{3})(\\d{4})", "\\1-\\2-\\3")
+    var text = "Call 6502530000 today"
+    assert_equal(fmt.format(text, match_start=5), "650-253-0000")
+
+
+def test_sub_formatter_reuse() raises:
+    """Test SubFormatter reused across multiple inputs."""
+    var fmt = SubFormatter("(\\d{2})(\\d{2})", "\\2-\\1")
+    assert_equal(fmt.format("1234"), "34-12")
+    assert_equal(fmt.format("5678"), "78-56")
+    assert_equal(fmt.format("9012"), "12-90")
+
+
+def test_sub_formatter_properties() raises:
+    """Test SubFormatter properties."""
+    var fmt = SubFormatter("(\\d{3})(\\d{3})(\\d{4})", "\\1-\\2-\\3")
+    assert_true(fmt.is_valid())
+    assert_equal(fmt.num_groups(), 3)
+    assert_equal(fmt.total_match_width(), 10)
 
 
 def main() raises:


### PR DESCRIPTION
Addresses #109

## Problem

`sub()` with capture groups is 15-49% slower than a hand-rolled parser for phone number formatting because it pays per-call overhead: regex cache lookup, DFA match execution on pre-validated input, and replacement string parsing.

## Solution

`SubFormatter` is a pre-compiled format template that eliminates all three costs. Created once per pattern+replacement pair, formatting is then pure pointer-offset slicing + string concatenation.

```mojo
# Create once (e.g., at module init or in a struct field)
var fmt = SubFormatter("(\d{3})(\d{3})(\d{4})", "\1-\2-\3")

# Use many times -- zero regex, zero cache lookup, zero repl parsing
var result = fmt.format("6502530000")  # -> "650-253-0000"

# Or with a match offset into larger text
var result = fmt.format("Call 6502530000 today", match_start=5)
```

## How it works

1. **Constructor** (`__init__`): Analyzes pattern via `_detect_fixed_width_groups()` to extract group offsets. Pre-parses replacement string into `_TemplateSegment` list (literal slices + group references). Precomputes output size estimate. Raises if pattern is not fixed-width `\d{N}`.

2. **`format(text)`**: Walks the template segments. For group refs, slices `text` at precomputed offsets. For literals, copies from the stored replacement string. Uses `InlineArray[Int, 10]` for O(1) group lookup. Pre-sized output `String`.

## What this enables for smith-phonenums

```mojo
# Instead of:
var result = sub("(\d{3})(\d{3})(\d{4})", "\1-\2-\3", number)  # ~4000ns

# Use:
var fmt = SubFormatter("(\d{3})(\d{3})(\d{4})", "\1-\2-\3")  # once
var result = fmt.format(number)  # ~2900ns (matches manual parser)
```

## Test plan

- [x] All 377 tests pass (130 in test_matcher, 7 new SubFormatter tests)
- [x] `test_sub_formatter_phone`: 3-group phone formatting
- [x] `test_sub_formatter_phone_spaces`: space-separated groups
- [x] `test_sub_formatter_date`: date reformatting with inter-group literals
- [x] `test_sub_formatter_two_groups`: 2-group pattern
- [x] `test_sub_formatter_match_start`: format at offset within larger text
- [x] `test_sub_formatter_reuse`: same formatter across multiple inputs
- [x] `test_sub_formatter_properties`: is_valid, num_groups, total_match_width