### PR TITLE
Extract shared nibble table builder and SIMD scan into simd_ops.mojo

### DIFF
--- a/src/regex/pikevm.mojo
+++ b/src/regex/pikevm.mojo
@@ -25,13 +25,10 @@ from regex.ast import (
     START,
     END,
 )
-from std.sys.info import simd_width_of
-
 from regex.matching import Match, MatchList
 from regex.aliases import ImmSlice, WORD_CHARS
 from regex.dfa import _expand_character_range
-
-comptime SIMD_WIDTH = simd_width_of[DType.uint8]()
+from regex.simd_ops import build_nibble_tables, find_first_in_nibble_tables
 
 
 # ===-----------------------------------------------------------------------===#
@@ -693,21 +690,10 @@ struct LazyDFA(Copyable, Movable):
             self._build_filter_nibble_tables()
 
     def _build_filter_nibble_tables(mut self):
-        """Build 16-byte nibble tables from first_byte_filter for SIMD scan.
-        Same bucket encoding as CharacterClassSIMD._build_nibble_tables."""
-        var lo_tbl = SIMD[DType.uint8, 16](0)
-        var hi_tbl = SIMD[DType.uint8, 16](0)
-        var bucket = 0
-        for c in range(256):
-            if self.pikevm.first_byte_filter[c] != 0:
-                var lo = c & 0xF
-                var hi = (c >> 4) & 0xF
-                var bit = UInt8(1 << (bucket & 7))
-                lo_tbl[lo] = lo_tbl[lo] | bit
-                hi_tbl[hi] = hi_tbl[hi] | bit
-                bucket += 1
-        self._filter_lo_nibble = lo_tbl
-        self._filter_hi_nibble = hi_tbl
+        """Build nibble lookup tables from first_byte_filter for SIMD scan."""
+        var tables = build_nibble_tables(self.pikevm.first_byte_filter)
+        self._filter_lo_nibble = tables[0]
+        self._filter_hi_nibble = tables[1]
 
     @always_inline
     def _find_first_candidate(
@@ -718,31 +704,14 @@ struct LazyDFA(Copyable, Movable):
     ) -> Int:
         """Find first text position where the first-byte filter matches,
         using SIMD nibble scan. Returns -1 if not found."""
-        var pos = start
-        var mask_0f = SIMD[DType.uint8, SIMD_WIDTH](0x0F)
-
-        while pos + SIMD_WIDTH <= text_len:
-            var chunk = text_ptr.load[width=SIMD_WIDTH](pos)
-            var lo_res = self._filter_lo_nibble._dynamic_shuffle(
-                chunk & mask_0f
-            )
-            var hi_res = self._filter_hi_nibble._dynamic_shuffle(
-                (chunk >> 4) & mask_0f
-            )
-            var matches = (lo_res & hi_res).ne(0)
-            if matches.reduce_or():
-                for i in range(SIMD_WIDTH):
-                    if matches[i]:
-                        return pos + i
-            pos += SIMD_WIDTH
-
-        # Scalar tail
-        while pos < text_len:
-            if self.pikevm.first_byte_filter[Int(text_ptr[pos])] != 0:
-                return pos
-            pos += 1
-
-        return -1
+        return find_first_in_nibble_tables(
+            self._filter_lo_nibble,
+            self._filter_hi_nibble,
+            self.pikevm.first_byte_filter,
+            text_ptr,
+            start,
+            text_len,
+        )
 
     def is_supported(self) -> Bool:
         """Check if the underlying PikeVM program fits."""

--- a/src/regex/simd_ops.mojo
+++ b/src/regex/simd_ops.mojo
@@ -59,6 +59,82 @@ from regex.simd_matchers import (
 comptime SIMD_WIDTH = simd_width_of[DType.uint8]()
 comptime USE_SHUFFLE = SIMD_WIDTH == 16 or SIMD_WIDTH == 32
 
+
+@always_inline
+def build_nibble_tables(
+    filter: SIMD[DType.uint8, 256],
+) -> Tuple[SIMD[DType.uint8, 16], SIMD[DType.uint8, 16]]:
+    """Build 16-byte nibble lookup tables from a 256-byte filter.
+
+    Each matching byte is assigned to a bucket (0-7). Both lo and hi
+    tables use the same bucket bit so AND produces correct results.
+    Used by CharacterClassSIMD and LazyDFA first-byte prefilter.
+
+    Returns:
+        Tuple of (lo_nibble_table, hi_nibble_table).
+    """
+    var lo_tbl = SIMD[DType.uint8, 16](0)
+    var hi_tbl = SIMD[DType.uint8, 16](0)
+    var bucket = 0
+    for c in range(256):
+        if filter[c] != 0:
+            var lo = c & 0xF
+            var hi = (c >> 4) & 0xF
+            var bit = UInt8(1 << (bucket & 7))
+            lo_tbl[lo] = lo_tbl[lo] | bit
+            hi_tbl[hi] = hi_tbl[hi] | bit
+            bucket += 1
+    return (lo_tbl, hi_tbl)
+
+
+@always_inline
+def find_first_in_nibble_tables(
+    lo_nibble: SIMD[DType.uint8, 16],
+    hi_nibble: SIMD[DType.uint8, 16],
+    filter: SIMD[DType.uint8, 256],
+    text_ptr: UnsafePointer[Byte, _],
+    start: Int,
+    text_len: Int,
+) -> Int:
+    """Find first matching byte using nibble-based SIMD scan.
+
+    Scans SIMD_WIDTH bytes per iteration using _dynamic_shuffle on
+    the nibble tables. Falls back to scalar filter lookup for tail bytes.
+
+    Args:
+        lo_nibble: Low-nibble lookup table.
+        hi_nibble: High-nibble lookup table.
+        filter: 256-byte filter for scalar tail.
+        text_ptr: Pointer to text bytes.
+        start: Starting position.
+        text_len: Total length of text.
+
+    Returns:
+        Position of first matching byte, or -1 if not found.
+    """
+    var pos = start
+    var mask_0f = SIMD[DType.uint8, SIMD_WIDTH](0x0F)
+
+    while pos + SIMD_WIDTH <= text_len:
+        var chunk = text_ptr.load[width=SIMD_WIDTH](pos)
+        var lo_res = lo_nibble._dynamic_shuffle(chunk & mask_0f)
+        var hi_res = hi_nibble._dynamic_shuffle((chunk >> 4) & mask_0f)
+        var matches = (lo_res & hi_res).ne(0)
+        if matches.reduce_or():
+            for i in range(SIMD_WIDTH):
+                if matches[i]:
+                    return pos + i
+        pos += SIMD_WIDTH
+
+    # Scalar tail
+    while pos < text_len:
+        if filter[Int(text_ptr[pos])] != 0:
+            return pos
+        pos += 1
+
+    return -1
+
+
 # Shuffle optimization thresholds
 # Below this size, simple lookup is faster than shuffle
 comptime SHUFFLE_MIN_SIZE = 4
@@ -145,26 +221,10 @@ struct CharacterClassSIMD(
         self._build_nibble_tables()
 
     def _build_nibble_tables(mut self):
-        """Build 16-byte nibble lookup tables from the 256-byte lookup table.
-        These enable fast SIMD character matching using two _dynamic_shuffle
-        calls on 16-byte tables (native pshufb) instead of one on 256-byte
-        table (emulated with multiple shuffles).
-        """
-        var lo_tbl = SIMD[DType.uint8, 16](0)
-        var hi_tbl = SIMD[DType.uint8, 16](0)
-        # Assign each character to a bucket (0-7). Both lo and hi tables
-        # use the same bucket bit so AND produces correct results.
-        var bucket = 0
-        for c in range(256):
-            if self.lookup_table[c] != 0:
-                var lo = c & 0xF
-                var hi = (c >> 4) & 0xF
-                var bit = UInt8(1 << (bucket & 7))
-                lo_tbl[lo] = lo_tbl[lo] | bit
-                hi_tbl[hi] = hi_tbl[hi] | bit
-                bucket += 1
-        self.lo_nibble_table = lo_tbl
-        self.hi_nibble_table = hi_tbl
+        """Build nibble lookup tables from the 256-byte lookup table."""
+        var tables = build_nibble_tables(self.lookup_table)
+        self.lo_nibble_table = tables[0]
+        self.hi_nibble_table = tables[1]
 
     def contains(self, char_code: Int) -> Bool:
         """Check if character is in this character class.
@@ -340,29 +400,14 @@ struct CharacterClassSIMD(
         Returns:
             Position of first matching character, or -1 if not found.
         """
-        var pos = start
-        var mask_0f = SIMD[DType.uint8, SIMD_WIDTH](0x0F)
-
-        while pos + SIMD_WIDTH <= text_len:
-            var chunk = text_ptr.load[width=SIMD_WIDTH](pos)
-            var lo_res = self.lo_nibble_table._dynamic_shuffle(chunk & mask_0f)
-            var hi_res = self.hi_nibble_table._dynamic_shuffle(
-                (chunk >> 4) & mask_0f
-            )
-            var chunk_matches = (lo_res & hi_res).ne(0)
-            if chunk_matches.reduce_or():
-                for i in range(SIMD_WIDTH):
-                    if chunk_matches[i]:
-                        return pos + i
-            pos += SIMD_WIDTH
-
-        # Scalar tail
-        while pos < text_len:
-            if self.contains(Int(text_ptr[pos])):
-                return pos
-            pos += 1
-
-        return -1
+        return find_first_in_nibble_tables(
+            self.lo_nibble_table,
+            self.hi_nibble_table,
+            self.lookup_table,
+            text_ptr,
+            start,
+            text_len,
+        )
 
     @always_inline
     def count_consecutive_matches(


### PR DESCRIPTION
Follow-up cleanup from PR #115 review.

## Problem

`CharacterClassSIMD._build_nibble_tables` and `LazyDFA._build_filter_nibble_tables` had identical bucket-encoding logic. `CharacterClassSIMD.find_first_nibble_match` and `LazyDFA._find_first_candidate` had identical SIMD scan loops. `SIMD_WIDTH` was defined in both `simd_ops.mojo` and `pikevm.mojo`.

## Fix

Extracted two free functions into `simd_ops.mojo`:
- `build_nibble_tables(filter: SIMD[uint8, 256]) -> Tuple[SIMD[uint8, 16], SIMD[uint8, 16]]`
- `find_first_in_nibble_tables(lo, hi, filter, text_ptr, start, len) -> Int`

Both `CharacterClassSIMD` and `LazyDFA` now delegate to these. Removed `SIMD_WIDTH` from `pikevm.mojo`. Net: ~50 lines of duplicated logic removed.

## Test plan

- [x] All 370 tests pass