### PR TITLE
Add @always_inline to match_next dispatch chain and _apply_quantifier_simd

### DIFF
--- a/src/regex/matcher.mojo
+++ b/src/regex/matcher.mojo
@@ -568,6 +568,7 @@ struct HybridMatcher(Copyable, Movable, RegexMatcher):
             # Fall back to NFA for complex patterns
             return self.nfa_matcher.match_first(text, start)
 
+    @always_inline
     def match_next(self, text: ImmSlice, start: Int = 0) -> Optional[Match]:
         """Find first match using optimal engine. This is equivalent to re.search in Python.
         """
@@ -771,6 +772,7 @@ struct CompiledRegex(ImplicitlyCopyable, Movable):
         """
         return self.matcher.match_first(text, start)
 
+    @always_inline
     def match_next(self, text: ImmSlice, start: Int = 0) -> Optional[Match]:
         """Find first match in text. This is equivalent to re.search in Python.
 

--- a/src/regex/nfa.mojo
+++ b/src/regex/nfa.mojo
@@ -1425,6 +1425,7 @@ struct NFAEngine(Copyable, Engine):
         else:
             return (False, str_i)
 
+    @always_inline
     def _apply_quantifier_simd(
         self,
         ast: ASTNode,


### PR DESCRIPTION
Addresses optimization-opportunities-v2.md items M1 (partial) and M2.

## Changes

**M2: match_next dispatch chain** - Added `@always_inline` to `HybridMatcher.match_next` and `CompiledRegex.match_next`. These are the most-used dispatch path (`search`, `sub`, `test` all call them). `match_first` and `is_match` already had it.

**M1 (partial): _apply_quantifier_simd** - Added `@always_inline`. This function uses SIMD matchers directly and does not recurse back to `_match_node`, so it's safe to inline.

The other 6 NFA dispatch functions (`_match_or`, `_match_group`, `_match_group_with_quantifier`, `_match_sequence`, `_match_re`, `_apply_quantifier`) participate in mutual recursion with `_match_node` and **cannot** be marked `@always_inline` (Mojo rejects recursive inline).

## Test plan

- [x] All 370 tests pass