### PR TITLE
Fix 3+ way alternation with character classes failing to match

### DIFF
--- a/src/regex/matcher.mojo
+++ b/src/regex/matcher.mojo
@@ -487,8 +487,13 @@ struct HybridMatcher(Copyable, Movable, RegexMatcher):
             )
             self.is_exact_literal = is_exact
 
-            # Create prefilter if beneficial
-            self.prefilter = create_optimized_prefilter(self.literal_info)
+            # Create prefilter if beneficial. Skip for alternation patterns
+            # where the extracted literal comes from one branch only and
+            # is not required across all match possibilities (issue #114).
+            if "|" not in pattern:
+                self.prefilter = create_optimized_prefilter(self.literal_info)
+            else:
+                self.prefilter = None
         else:
             # Initialize with empty info for simple patterns
             self.literal_info = OptimizedLiteralInfo(None, False, False)

--- a/tests/test_matcher.mojo
+++ b/tests/test_matcher.mojo
@@ -1794,5 +1794,45 @@ def test_sub_group_with_text_around() raises:
     assert_equal(result, "Date: 04/12/2026 is today")
 
 
+# ===== Regression Tests =====
+
+
+def test_3way_alternation_with_char_class() raises:
+    """Regression test for issue #114: 3+ way alternation with character
+    classes fails to match. The prefilter extracted a literal from one
+    alternation branch and rejected matches from other branches."""
+    # 2-way works
+    var m1 = search("3[02]|40", "301234")
+    assert_true(Bool(m1))
+
+    # 3-way was failing
+    var m2 = search("3[02]|40|[68]9", "301234")
+    assert_true(Bool(m2))
+    assert_equal(m2.value().start_idx, 0)
+    assert_equal(m2.value().end_idx, 2)
+
+    # 4-way
+    var m3 = search("24|[346]|7[2-57-9]|9[2-9]", "301234")
+    assert_true(Bool(m3))
+
+    # Match the third alternative
+    var m4 = search("3[02]|40|[68]9", "891234")
+    assert_true(Bool(m4))
+    assert_equal(m4.value().start_idx, 0)
+    assert_equal(m4.value().end_idx, 2)
+
+    # Match the second alternative
+    var m5 = search("3[02]|40|[68]9", "401234")
+    assert_true(Bool(m5))
+    assert_equal(m5.value().start_idx, 0)
+    assert_equal(m5.value().end_idx, 2)
+
+
+def test_3way_alternation_sub() raises:
+    """Regression test for issue #114: sub with 3+ way alternation."""
+    var result = sub("3[02]|40|[68]9", "XX", "30 and 40 and 89")
+    assert_equal(result, "XX and XX and XX")
+
+
 def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
Closes #114

## Problem

Patterns with 3+ way alternation and character classes failed to match:
```
search("3[02]|40|[68]9", "301234")  # returned None, should match "30"
```

Each alternative matched individually. 2-way alternation worked. Adding a 3rd alternative caused all to fail.

## Root cause

The HybridMatcher prefilter extracted a literal from one branch of the alternation (e.g., `"40"` from `3[02]|40|[68]9`) and used it to skip text positions. When searching for text matching a *different* branch (`"30"` matching `3[02]`), the prefilter looked for `"40"`, didn't find it at the right position, and rejected the match.

## Fix

Skip prefilter creation when the pattern contains alternation (`|`). The prefilter's literal comes from one branch only and is not required across all match possibilities. Non-alternation patterns still benefit from prefiltering.

## Test plan

- [x] All 372 tests pass (125 in test_matcher, +2 new)
- [x] `test_3way_alternation_with_char_class`: verifies all 3 branches match individually and in combination
- [x] `test_3way_alternation_sub`: verifies `sub()` replaces all branches