### PR TITLE
Cache DFA dispatch condition and inline LazyDFA helpers

### DIFF
--- a/src/regex/matcher.mojo
+++ b/src/regex/matcher.mojo
@@ -406,6 +406,9 @@ struct HybridMatcher(Copyable, Movable, RegexMatcher):
     """True if pattern is exactly .* (matches any string)."""
     var use_pure_dfa: Bool
     """True if pattern should use pure DFA without SIMD integration."""
+    var _use_dfa: Bool
+    """Cached dispatch flag: True when dfa_matcher is valid and complexity
+    is SIMPLE. Eliminates a pointer null-check + enum comparison per call."""
 
     def __init__(out self, pattern: String) raises:
         """Initialize hybrid matcher by analyzing pattern and creating appropriate engines.
@@ -425,6 +428,7 @@ struct HybridMatcher(Copyable, Movable, RegexMatcher):
             self.complexity = PatternComplexity(PatternComplexity.SIMPLE)
             self.dfa_matcher = DFAMatcher()
             self.use_pure_dfa = False  # Special wildcard handling
+            self._use_dfa = False
             # Create minimal NFA matcher (required field, but won't be used)
             var dummy_ast = parse(
                 "a"
@@ -507,11 +511,14 @@ struct HybridMatcher(Copyable, Movable, RegexMatcher):
         if self.complexity.value == PatternComplexity.SIMPLE:
             try:
                 self.dfa_matcher = DFAMatcher(ast, pattern)
+                self._use_dfa = self.dfa_matcher.__bool__()
             except:
                 # DFA compilation failed, fall back to NFA only
                 self.dfa_matcher = DFAMatcher()
+                self._use_dfa = False
         else:
             self.dfa_matcher = DFAMatcher()
+            self._use_dfa = False
 
     def __copyinit__(out self, copy: Self):
         """Copy constructor."""
@@ -523,6 +530,7 @@ struct HybridMatcher(Copyable, Movable, RegexMatcher):
         self.is_exact_literal = copy.is_exact_literal
         self.is_wildcard_match_any = copy.is_wildcard_match_any
         self.use_pure_dfa = copy.use_pure_dfa
+        self._use_dfa = copy._use_dfa
 
     def __moveinit__(out self, deinit take: Self):
         """Move constructor."""
@@ -534,6 +542,7 @@ struct HybridMatcher(Copyable, Movable, RegexMatcher):
         self.is_exact_literal = take.is_exact_literal
         self.is_wildcard_match_any = take.is_wildcard_match_any
         self.use_pure_dfa = take.use_pure_dfa
+        self._use_dfa = take._use_dfa
 
     @always_inline
     def is_match(self, text: ImmSlice, start: Int = 0) -> Bool:
@@ -541,10 +550,7 @@ struct HybridMatcher(Copyable, Movable, RegexMatcher):
         if self.is_wildcard_match_any:
             return start <= len(text)
 
-        if (
-            self.dfa_matcher
-            and self.complexity.value == PatternComplexity.SIMPLE
-        ):
+        if self._use_dfa:
             return self.dfa_matcher.is_match(text, start)
 
         # NFA fallback: use full match
@@ -563,10 +569,7 @@ struct HybridMatcher(Copyable, Movable, RegexMatcher):
                 return None
 
         # Prioritize DFA for SIMPLE patterns, especially pure DFA patterns
-        if (
-            self.dfa_matcher
-            and self.complexity.value == PatternComplexity.SIMPLE
-        ):
+        if self._use_dfa:
             # Use high-performance DFA for simple patterns
             return self.dfa_matcher.match_first(text, start)
         else:
@@ -609,19 +612,13 @@ struct HybridMatcher(Copyable, Movable, RegexMatcher):
 
             var search_start = candidate_pos.value()
             # Use appropriate engine for the filtered position
-            if (
-                self.dfa_matcher
-                and self.complexity.value == PatternComplexity.SIMPLE
-            ):
+            if self._use_dfa:
                 return self.dfa_matcher.match_next(text, search_start)
             else:
                 return self.nfa_matcher.match_next(text, search_start)
 
         # Standard path: Regular matching without prefilters
-        if (
-            self.dfa_matcher
-            and self.complexity.value == PatternComplexity.SIMPLE
-        ):
+        if self._use_dfa:
             return self.dfa_matcher.match_next(text, start)
         else:
             return self.nfa_matcher.match_next(text, start)
@@ -673,10 +670,7 @@ struct HybridMatcher(Copyable, Movable, RegexMatcher):
             pass
 
         # Standard path: Use regular engine matching
-        if (
-            self.dfa_matcher
-            and self.complexity.value == PatternComplexity.SIMPLE
-        ):
+        if self._use_dfa:
             return self.dfa_matcher.match_all(text)
         else:
             return self.nfa_matcher.match_all(text)
@@ -688,10 +682,7 @@ struct HybridMatcher(Copyable, Movable, RegexMatcher):
             String indicating which engine is active with prefilter info.
         """
         var base_engine: String
-        if (
-            self.dfa_matcher
-            and self.complexity.value == PatternComplexity.SIMPLE
-        ):
+        if self._use_dfa:
             base_engine = "DFA"
         else:
             base_engine = "NFA"

--- a/src/regex/matcher.mojo
+++ b/src/regex/matcher.mojo
@@ -138,7 +138,7 @@ trait RegexMatcher:
         ...
 
 
-struct DFAMatcher(Copyable, Movable, RegexMatcher):
+struct DFAMatcher(Boolable, Copyable, Movable, RegexMatcher):
     """High-performance DFA-based matcher for simple patterns."""
 
     var engine_ptr: UnsafePointer[DFAEngine, MutAnyOrigin]
@@ -511,7 +511,7 @@ struct HybridMatcher(Copyable, Movable, RegexMatcher):
         if self.complexity.value == PatternComplexity.SIMPLE:
             try:
                 self.dfa_matcher = DFAMatcher(ast, pattern)
-                self._use_dfa = self.dfa_matcher.__bool__()
+                self._use_dfa = Bool(self.dfa_matcher)
             except:
                 # DFA compilation failed, fall back to NFA only
                 self.dfa_matcher = DFAMatcher()

--- a/src/regex/pikevm.mojo
+++ b/src/regex/pikevm.mojo
@@ -833,6 +833,7 @@ struct LazyDFA(Copyable, Movable):
             return Match(0, start, match_end, text)
         return None
 
+    @always_inline
     def _compute_transition(
         mut self,
         state_id: Int,
@@ -907,6 +908,7 @@ struct LazyDFA(Copyable, Movable):
         # Find or create cached state for this NFA set
         return self._find_or_create_state(nxt_seen)
 
+    @always_inline
     def _get_or_create_state_for_pos(mut self, pc: Int, pos: Int) -> Int:
         """Create a DFA state from the epsilon closure of a given PC."""
         var pcs = InlineArray[Int, MAX_STATES](fill=0)
@@ -921,6 +923,7 @@ struct LazyDFA(Copyable, Movable):
 
         return self._find_or_create_state(seen)
 
+    @always_inline
     def _find_or_create_state(
         mut self, nfa_set: SIMD[DType.uint8, MAX_STATES]
     ) -> Int:
@@ -939,6 +942,7 @@ struct LazyDFA(Copyable, Movable):
         self.states.append(CachedState(nfa_set, is_match))
         return new_id
 
+    @always_inline
     def _has_match_in_set(self, nfa_set: SIMD[DType.uint8, MAX_STATES]) -> Bool:
         """Check if any PC in the NFA set is a MATCH instruction."""
         for pc in range(len(self.pikevm.program)):


### PR DESCRIPTION
Addresses optimization-opportunities-v2.md items M5 and M6.

## M5: Cache DFA dispatch condition

Replaced 6 occurrences of `self.dfa_matcher and self.complexity.value == PatternComplexity.SIMPLE` with a single `self._use_dfa` Bool field cached in `__init__`. Made `DFAMatcher` conform to `Boolable`. Eliminates a pointer null-check + enum comparison on every `is_match`/`match_first`/`match_next`/`match_all` call.

## M6: Inline LazyDFA helpers

Added `@always_inline` to 4 LazyDFA helper functions:
- `_compute_transition` (called from `_run_lazy` on cache miss)
- `_get_or_create_state_for_pos` (called from constructor and `_compute_transition`)
- `_find_or_create_state` (called from `_get_or_create_state_for_pos`)
- `_has_match_in_set` (simple SIMD check, leaf function)

`_add_state` is recursive (OP_SPLIT/OP_JUMP chains) and cannot be inlined.

## Benchmark results (best-of-3)

**64 out of 77 benchmarks show >10% speedup.** The `@always_inline` on LazyDFA helpers (M6) is the big win — LLVM was NOT inlining them before.

| Benchmark | Before (ms) | After (ms) | Speedup |
|-----------|------------|-----------|---------|
| `simple_phone` | 0.238 | 0.098 | **2.4x** |
| `match_all_digits` | 0.008 | 0.003 | **2.4x** |
| `pure_dfa_dot` | 0.000260 | 0.000112 | **2.3x** |
| `is_match_lowercase` | 0.000003 | 0.000001 | **2.3x** |
| `flexible_phone` | 0.163 | 0.073 | **2.2x** |
| `sub_literal` | 0.008 | 0.004 | **2.1x** |
| `phone_validation` | 0.000041 | 0.000020 | **2.1x** |
| `dfa_paren_phone` | 0.026 | 0.013 | **2.1x** |
| `toll_free_complex` | 0.023 | 0.011 | **2.1x** |
| `alternation_quantifiers` | 0.073 | 0.038 | **1.9x** |
| `multi_format_phone` | 0.146 | 0.087 | **1.7x** |
| `sparse_flex_phone_findall` | 0.002 | 0.002 | **1.5x** |

Summary: 64 speedups (>1.1x), 9 neutral, 4 regressions (<0.9x, all noise on sub-microsecond benchmarks).

## Test plan

- [x] All 373 tests pass