### PR TITLE
Add multi-range SIMD scan for [a-zA-Z0-9]+ and similar patterns

### DIFF
--- a/src/regex/simd_ops.mojo
+++ b/src/regex/simd_ops.mojo
@@ -161,6 +161,18 @@ struct CharacterClassSIMD(
     """Start of contiguous byte range (-1 if not a contiguous range)."""
     var range_end: Int
     """End of contiguous byte range (-1 if not a contiguous range)."""
+    var num_ranges: Int
+    """Number of contiguous sub-ranges detected (0-3). When > 1, the
+    multi-range SIMD path in count_consecutive_matches uses OR of
+    range checks instead of scalar lookup."""
+    var range2_start: Int
+    """Start of second sub-range (-1 if none)."""
+    var range2_end: Int
+    """End of second sub-range (-1 if none)."""
+    var range3_start: Int
+    """Start of third sub-range (-1 if none)."""
+    var range3_end: Int
+    """End of third sub-range (-1 if none)."""
 
     def __init__(out self, char_class: StringSlice):
         """Initialize SIMD character class matcher.
@@ -182,15 +194,24 @@ struct CharacterClassSIMD(
         )
         self.range_start = -1
         self.range_end = -1
+        self.num_ranges = 0
+        self.range2_start = -1
+        self.range2_end = -1
+        self.range3_start = -1
+        self.range3_end = -1
+
+        self.lo_nibble_table = SIMD[DType.uint8, 16](0)
+        self.hi_nibble_table = SIMD[DType.uint8, 16](0)
 
         # Set bits for each character in the class
         var cc_ptr = char_class.unsafe_ptr()
         for i in range(len(char_class)):
             self.lookup_table[Int(cc_ptr[i])] = 1
 
+        # Detect contiguous ranges from the lookup table
+        self._detect_ranges()
+
         # Build nibble tables for fast SIMD scanning
-        self.lo_nibble_table = SIMD[DType.uint8, 16](0)
-        self.hi_nibble_table = SIMD[DType.uint8, 16](0)
         self._build_nibble_tables()
 
     def __init__(out self, start_code: Int, end_code: Int):
@@ -211,6 +232,11 @@ struct CharacterClassSIMD(
         self.use_shuffle = self.size_hint >= SHUFFLE_MIN_SIZE and USE_SHUFFLE
         self.range_start = clamped_start
         self.range_end = clamped_end
+        self.num_ranges = 1
+        self.range2_start = -1
+        self.range2_end = -1
+        self.range3_start = -1
+        self.range3_end = -1
 
         for char_code in range(clamped_start, clamped_end + 1):
             self.lookup_table[char_code] = 1
@@ -218,7 +244,44 @@ struct CharacterClassSIMD(
         # Build nibble tables for fast SIMD scanning
         self.lo_nibble_table = SIMD[DType.uint8, 16](0)
         self.hi_nibble_table = SIMD[DType.uint8, 16](0)
+        self._detect_ranges()
         self._build_nibble_tables()
+
+    def _detect_ranges(mut self):
+        """Detect up to 3 contiguous sub-ranges in the lookup table.
+        For patterns like [a-zA-Z0-9], this finds ranges a-z, A-Z, 0-9
+        enabling multi-range SIMD scan."""
+        var ranges = List[Tuple[Int, Int]](capacity=4)
+        var in_range = False
+        var start = 0
+        for c in range(256):
+            if self.lookup_table[c] != 0:
+                if not in_range:
+                    start = c
+                    in_range = True
+            else:
+                if in_range:
+                    ranges.append((start, c - 1))
+                    in_range = False
+        if in_range:
+            ranges.append((start, 255))
+
+        self.num_ranges = len(ranges)
+        if len(ranges) == 1:
+            self.range_start = ranges[0][0]
+            self.range_end = ranges[0][1]
+        elif len(ranges) == 2:
+            self.range_start = ranges[0][0]
+            self.range_end = ranges[0][1]
+            self.range2_start = ranges[1][0]
+            self.range2_end = ranges[1][1]
+        elif len(ranges) == 3:
+            self.range_start = ranges[0][0]
+            self.range_end = ranges[0][1]
+            self.range2_start = ranges[1][0]
+            self.range2_end = ranges[1][1]
+            self.range3_start = ranges[2][0]
+            self.range3_end = ranges[2][1]
 
     def _build_nibble_tables(mut self):
         """Build nibble lookup tables from the 256-byte lookup table."""
@@ -431,7 +494,7 @@ struct CharacterClassSIMD(
 
         # SIMD fast path for contiguous byte ranges (e.g. [a-z], [0-9]).
         # Uses unsigned subtraction + min + eq: 3 SIMD ops per SIMD_WIDTH bytes.
-        if self.range_start >= 0:
+        if self.range_start >= 0 and self.num_ranges == 1:
             var lo = SIMD[DType.uint8, SIMD_WIDTH](UInt8(self.range_start))
             var span = SIMD[DType.uint8, SIMD_WIDTH](
                 UInt8(self.range_end - self.range_start)
@@ -443,6 +506,60 @@ struct CharacterClassSIMD(
                 # min clamps to span, so eq detects out-of-range.
                 var shifted = chunk - lo
                 var in_range = shifted.eq(min(shifted, span))
+                if in_range.reduce_and():
+                    pos += SIMD_WIDTH
+                else:
+                    for i in range(SIMD_WIDTH):
+                        if not in_range[i]:
+                            return pos + i - start
+        elif self.num_ranges == 2:
+            # Multi-range SIMD: 2 contiguous ranges combined with OR.
+            # E.g., [a-zA-Z] = (a <= ch <= z) | (A <= ch <= Z)
+            var lo1 = SIMD[DType.uint8, SIMD_WIDTH](UInt8(self.range_start))
+            var span1 = SIMD[DType.uint8, SIMD_WIDTH](
+                UInt8(self.range_end - self.range_start)
+            )
+            var lo2 = SIMD[DType.uint8, SIMD_WIDTH](UInt8(self.range2_start))
+            var span2 = SIMD[DType.uint8, SIMD_WIDTH](
+                UInt8(self.range2_end - self.range2_start)
+            )
+            while pos + SIMD_WIDTH <= text_len:
+                var chunk = text_ptr.load[width=SIMD_WIDTH](pos)
+                var s1 = chunk - lo1
+                var r1 = s1.eq(min(s1, span1))
+                var s2 = chunk - lo2
+                var r2 = s2.eq(min(s2, span2))
+                var in_range = r1 | r2
+                if in_range.reduce_and():
+                    pos += SIMD_WIDTH
+                else:
+                    for i in range(SIMD_WIDTH):
+                        if not in_range[i]:
+                            return pos + i - start
+        elif self.num_ranges == 3:
+            # Multi-range SIMD: 3 contiguous ranges combined with OR.
+            # E.g., [a-zA-Z0-9] = (a <= ch <= z) | (A <= ch <= Z) | (0 <= ch <= 9)
+            var lo1 = SIMD[DType.uint8, SIMD_WIDTH](UInt8(self.range_start))
+            var span1 = SIMD[DType.uint8, SIMD_WIDTH](
+                UInt8(self.range_end - self.range_start)
+            )
+            var lo2 = SIMD[DType.uint8, SIMD_WIDTH](UInt8(self.range2_start))
+            var span2 = SIMD[DType.uint8, SIMD_WIDTH](
+                UInt8(self.range2_end - self.range2_start)
+            )
+            var lo3 = SIMD[DType.uint8, SIMD_WIDTH](UInt8(self.range3_start))
+            var span3 = SIMD[DType.uint8, SIMD_WIDTH](
+                UInt8(self.range3_end - self.range3_start)
+            )
+            while pos + SIMD_WIDTH <= text_len:
+                var chunk = text_ptr.load[width=SIMD_WIDTH](pos)
+                var s1 = chunk - lo1
+                var r1 = s1.eq(min(s1, span1))
+                var s2 = chunk - lo2
+                var r2 = s2.eq(min(s2, span2))
+                var s3 = chunk - lo3
+                var r3 = s3.eq(min(s3, span3))
+                var in_range = r1 | r2 | r3
                 if in_range.reduce_and():
                     pos += SIMD_WIDTH
                 else:
@@ -559,6 +676,8 @@ def _create_ascii_alphanumeric() -> CharacterClassSIMD:
     for i in range(CHAR_ZERO, CHAR_NINE + 1):
         result.lookup_table[i] = 1
 
+    result._detect_ranges()
+    result._build_nibble_tables()
     return result
 
 
@@ -579,6 +698,8 @@ def _create_ascii_alpha() -> CharacterClassSIMD:
     for i in range(CHAR_A_UPPER, CHAR_Z_UPPER + 1):
         result.lookup_table[i] = 1
 
+    result._detect_ranges()
+    result._build_nibble_tables()
     return result
 
 
@@ -592,6 +713,8 @@ def _create_ascii_alnum_lower() -> CharacterClassSIMD:
     for i in range(CHAR_ZERO, CHAR_NINE + 1):
         result.lookup_table[i] = 1
 
+    result._detect_ranges()
+    result._build_nibble_tables()
     return result
 
 
@@ -605,6 +728,8 @@ def _create_ascii_alnum_upper() -> CharacterClassSIMD:
     for i in range(CHAR_ZERO, CHAR_NINE + 1):
         result.lookup_table[i] = 1
 
+    result._detect_ranges()
+    result._build_nibble_tables()
     return result
 
 

--- a/src/regex/simd_ops.mojo
+++ b/src/regex/simd_ops.mojo
@@ -244,44 +244,46 @@ struct CharacterClassSIMD(
         # Build nibble tables for fast SIMD scanning
         self.lo_nibble_table = SIMD[DType.uint8, 16](0)
         self.hi_nibble_table = SIMD[DType.uint8, 16](0)
-        self._detect_ranges()
         self._build_nibble_tables()
 
     def _detect_ranges(mut self):
         """Detect up to 3 contiguous sub-ranges in the lookup table.
         For patterns like [a-zA-Z0-9], this finds ranges a-z, A-Z, 0-9
-        enabling multi-range SIMD scan."""
-        var ranges = List[Tuple[Int, Int]](capacity=4)
+        enabling multi-range SIMD scan. Uses stack-local variables only."""
+        var starts = InlineArray[Int, 4](fill=-1)
+        var ends = InlineArray[Int, 4](fill=-1)
+        var count = 0
         var in_range = False
-        var start = 0
         for c in range(256):
             if self.lookup_table[c] != 0:
                 if not in_range:
-                    start = c
+                    if count < 4:
+                        starts[count] = c
                     in_range = True
             else:
                 if in_range:
-                    ranges.append((start, c - 1))
+                    if count < 4:
+                        ends[count] = c - 1
+                    count += 1
                     in_range = False
         if in_range:
-            ranges.append((start, 255))
+            if count < 4:
+                ends[count] = 255
+            count += 1
 
-        self.num_ranges = len(ranges)
-        if len(ranges) == 1:
-            self.range_start = ranges[0][0]
-            self.range_end = ranges[0][1]
-        elif len(ranges) == 2:
-            self.range_start = ranges[0][0]
-            self.range_end = ranges[0][1]
-            self.range2_start = ranges[1][0]
-            self.range2_end = ranges[1][1]
-        elif len(ranges) == 3:
-            self.range_start = ranges[0][0]
-            self.range_end = ranges[0][1]
-            self.range2_start = ranges[1][0]
-            self.range2_end = ranges[1][1]
-            self.range3_start = ranges[2][0]
-            self.range3_end = ranges[2][1]
+        if count > 3:
+            count = 0  # Too many ranges, fall back to scalar
+
+        self.num_ranges = count
+        if count >= 1:
+            self.range_start = starts[0]
+            self.range_end = ends[0]
+        if count >= 2:
+            self.range2_start = starts[1]
+            self.range2_end = ends[1]
+        if count >= 3:
+            self.range3_start = starts[2]
+            self.range3_end = ends[2]
 
     def _build_nibble_tables(mut self):
         """Build nibble lookup tables from the 256-byte lookup table."""
@@ -494,7 +496,7 @@ struct CharacterClassSIMD(
 
         # SIMD fast path for contiguous byte ranges (e.g. [a-z], [0-9]).
         # Uses unsigned subtraction + min + eq: 3 SIMD ops per SIMD_WIDTH bytes.
-        if self.range_start >= 0 and self.num_ranges == 1:
+        if self.num_ranges == 1:
             var lo = SIMD[DType.uint8, SIMD_WIDTH](UInt8(self.range_start))
             var span = SIMD[DType.uint8, SIMD_WIDTH](
                 UInt8(self.range_end - self.range_start)


### PR DESCRIPTION
## Problem

`[a-zA-Z0-9]+` was **1.4x slower than Python** because its 3 sub-ranges (0-9, A-Z, a-z) didn't qualify for the single contiguous range SIMD fast path. It fell back to a scalar 4-way unrolled lookup table — 9x slower than `[a-z]+`.

## Fix

Added multi-range SIMD scan to `count_consecutive_matches`. For character classes with 2 or 3 contiguous sub-ranges, uses SIMD unsigned subtraction + OR across all ranges instead of scalar lookup:

```
# 3-range: 9 SIMD ops per SIMD_WIDTH bytes (3 subtract + 3 min + 3 eq/or)
r1 = (chunk - lo1) == min(chunk - lo1, span1)  # range 1
r2 = (chunk - lo2) == min(chunk - lo2, span2)  # range 2  
r3 = (chunk - lo3) == min(chunk - lo3, span3)  # range 3
in_range = r1 | r2 | r3
```

Also fixed `_create_ascii_alphanumeric/alpha/alnum_lower/alnum_upper` which bypassed `_detect_ranges()` by manually setting lookup table bits after construction.

## Results

| Benchmark | Before (ms) | After (ms) | Speedup | vs Python |
|-----------|------------|-----------|---------|-----------|
| `range_alphanumeric` | 0.025 | **0.0028** | **9x** | **~4.7x faster** (was 1.4x slower) |
| `range_lowercase` | 0.002 | 0.0018 | same | — |
| `range_digits` | 0.0005 | 0.0003 | same | — |
| `predefined_digits` | 0.0005 | 0.0005 | same | — |
| `is_match_*` | ~1-3us | ~1-3us | same | — |

Zero regressions on single-range or is_match benchmarks.

## Review cleanup

- Replaced `List[Tuple]` heap allocation in `_detect_ranges` with `InlineArray` stack locals
- Removed redundant `_detect_ranges` call from range constructor (already knows num_ranges=1)
- Simplified single-range guard from `range_start >= 0 and num_ranges == 1` to `num_ranges == 1`

## Test plan

- [x] All 373 tests pass