### PR TITLE
Add --dev and --filter flags to bench_engine for fast iteration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,12 +84,11 @@ already encountered:
   "Assisted by Claude"). Project-level global rule — see
   `~/.claude/CLAUDE.md` for the user-wide version.
 - Don't use the `—` character in messages; use `.` instead.
-- **Always run `pixi run format` before committing any `.mojo` file**.
-  CI runs `pre-commit run --all-files` and fails on unformatted code;
-  catching it locally saves a round-trip. The repo ships a hook config
-  in `.pre-commit-config.yaml` that you can install with `pre-commit
-  install` (may require `git config --unset core.hooksPath` first,
-  which requires explicit user permission — don't do it unprompted).
+- The pre-commit hook (`.pre-commit-config.yaml`) is installed locally
+  and runs `pixi run format` on every commit touching `.mojo` files.
+  If the hook reformats files, the commit fails; re-add and commit
+  again. To save the round-trip, run `pixi run format` before
+  `git commit` on any `.mojo` change. CI runs the same hook.
 
 ## Mojo syntax notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,12 @@ already encountered:
   "Assisted by Claude"). Project-level global rule — see
   `~/.claude/CLAUDE.md` for the user-wide version.
 - Don't use the `—` character in messages; use `.` instead.
+- **Always run `pixi run format` before committing any `.mojo` file**.
+  CI runs `pre-commit run --all-files` and fails on unformatted code;
+  catching it locally saves a round-trip. The repo ships a hook config
+  in `.pre-commit-config.yaml` that you can install with `pre-commit
+  install` (may require `git config --unset core.hooksPath` first,
+  which requires explicit user permission — don't do it unprompted).
 
 ## Mojo syntax notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,101 @@
+# Claude guidance for mojo-regex
+
+This file briefs future Claude sessions on how to work in this repo.
+Keep it terse — load-bearing facts only. Everything here overrides
+generic priors.
+
+## Project shape
+
+A pure-Mojo regex library with four dispatch paths:
+
+- **DFA** (`src/regex/dfa.mojo`) — fastest, used for simple patterns
+  that compile to a deterministic automaton.
+- **NFA** (`src/regex/nfa.mojo`) — backtracking engine with literal
+  prefiltering. Used for complex patterns when lazy DFA isn't
+  applicable (e.g. `$` anchors).
+- **PikeVM + LazyDFA** (`src/regex/pikevm.mojo`) — Thompson NFA
+  simulation. `LazyDFA` caches state-set transitions for near-full-DFA
+  speed after warmup. `MAX_STATES = 512`.
+- **HybridMatcher** (`src/regex/matcher.mojo`) — `CompiledRegex` entry
+  point. Dispatches to the right engine based on pattern complexity.
+
+Routing happens in `src/regex/optimizer.mojo`. Literal extraction for
+prefilters is in `src/regex/literal_optimizer.mojo`. SIMD primitives
+(nibble scans, character class matchers) live in `src/regex/simd_ops.mojo`.
+
+## Commands
+
+| Task | Command |
+|---|---|
+| Run tests | `pixi run test` |
+| Format code | `pixi run format` |
+| Full bench (stable, ~4 min) | `mojo run -I src benchmarks/bench_engine.mojo` |
+| Fast dev bench (~8 s, noisier) | `mojo run -I src benchmarks/bench_engine.mojo -- --dev` |
+| Filtered bench | `mojo run -I src benchmarks/bench_engine.mojo -- --filter=<substr>` |
+
+Benchmarks compose the flags: `-- --dev --filter=sub_` runs the `sub_*`
+subset in dev mode for rapid iteration. See
+`benchmarks/BENCHMARKING_GUIDE.md` for the full workflow.
+
+**Never publish numbers from `--dev`**; it's 10x faster but noisier
+(1 ms samples instead of 10 ms). Always do a full stable run before
+committing benchmark deltas or updating `benchmarks/results/`.
+
+## Performance change workflow
+
+1. Identify the hot path (see `docs/optimization-opportunities-v2.md` /
+   `v3.md` for open items; `docs/optimization-opportunities.md` for the
+   history of what's already been tried).
+2. Edit, run `pixi run test` — must be green before benchmarking.
+3. Get a directional signal: `-- --dev --filter=<relevant>`.
+4. If the signal is positive, run the full stable bench and compare
+   to a freshly-measured baseline on the pre-change commit. The
+   committed `benchmarks/results/mojo_results.json` is a long-lived
+   reference that may be stale after infrastructure tweaks
+   (e.g. `MIN_SAMPLE_NS` changes), so always re-measure the baseline
+   in the same run; don't compare against the stored JSON alone.
+5. Watch out for single-run noise on sub-µs benchmarks: ±30 % is
+   normal. If a regression is isolated to one benchmark and the
+   affected code path wasn't touched, it's probably noise. Re-run or
+   run a 3× median pass before acting on it.
+
+## Optimization audits
+
+The authoritative list of open performance work is in
+`docs/optimization-opportunities-v3.md`. When asked to find new
+opportunities, read v1/v2/v3 first to avoid duplicating analysis, then
+scrutinize the code directly — several v1/v2 items have been fixed or
+were re-evaluated as not worth pursuing. See the "Items re-evaluated"
+sections at the bottom of each doc for what was tried and dropped.
+
+Be skeptical of agent-reported findings: verify each claim by reading
+the cited lines before writing anything down. Common false positives
+already encountered:
+- SIMD broadcasts "inside loops" that are actually hoisted.
+- `@always_inline` candidates that are recursive (Mojo rejects).
+- Trait virtual dispatch "overhead" on `Optional[ConcreteType]` —
+  Mojo devirtualizes.
+
+## Git conventions
+
+- One commit per topic. Don't mix refactor + logic + tests.
+- Don't amend; stack new commits.
+- No Claude attribution on commits or PRs (no `Co-Authored-By`, no
+  "Assisted by Claude"). Project-level global rule — see
+  `~/.claude/CLAUDE.md` for the user-wide version.
+- Don't use the `—` character in messages; use `.` instead.
+
+## Mojo syntax notes
+
+See the `mojo-syntax` skill for the full set, but the ones that bite
+most often in this repo:
+
+- `comptime` replaces `alias` and `@parameter`.
+- `def` does **not** imply `raises`; add it explicitly.
+- `@always_inline` errors on recursive functions — the compiler
+  rejects them outright, not silently.
+- Mojo `Dict` `__getitem__` raises even after a `in` check; wrap the
+  subscript in `try/except` or propagate `raises` up.
+- `sys.argv()` returns `Span[StaticString, StaticConstantOrigin]`.
+- SIMD bit-pattern reinterpretation uses the free function
+  `bitcast[dtype, size](value)` from `std.memory`, not a method.

--- a/benchmarks/BENCHMARKING_GUIDE.md
+++ b/benchmarks/BENCHMARKING_GUIDE.md
@@ -31,6 +31,34 @@ Run the complete benchmark comparison for the main benchmark suite:
 ./benchmarks/run_comparison.sh bench_engine
 ```
 
+## Fast iteration flags
+
+A full `bench_engine.mojo` run takes ~4 min, which is slow when iterating
+on an optimization. Two flags cut the loop to seconds; combine them.
+
+| Flag | Effect |
+|---|---|
+| `--dev` | 1 ms sample / 50 ms per-bench budget (vs 10 ms / 500 ms). Noisier, for directional signal only. Full 80-bench run: ~8 s. |
+| `--filter=<substr>` | Only run benchmarks whose name contains `<substr>`. Substring match, single value. |
+
+Pass flags after a literal `--` so Mojo forwards them to the program:
+
+```bash
+# Fast dev iteration on a specific code path
+mojo run -I src benchmarks/bench_engine.mojo -- --dev --filter=sub_
+
+# Just one benchmark, stable measurement
+mojo run -I src benchmarks/bench_engine.mojo -- --filter=phone_validation
+
+# Full stable run (pre-commit, publishable numbers)
+mojo run -I src benchmarks/bench_engine.mojo
+```
+
+**Workflow**: use `--dev --filter=...` to get a quick signal while
+editing, then drop the flags for a stable final run before you commit
+or update `benchmarks/results/`. Do **not** publish numbers from
+`--dev`; it's noisier by design.
+
 Run SIMD-focused benchmarks:
 
 ```bash

--- a/benchmarks/bench_engine.mojo
+++ b/benchmarks/bench_engine.mojo
@@ -1,3 +1,4 @@
+from std.sys import argv
 from std.time import perf_counter_ns
 from regex.matcher import compile_regex, sub
 
@@ -78,12 +79,65 @@ def make_complex_pattern_test_data(num_entries: Int) -> String:
 # Benchmark Infrastructure
 # ===-----------------------------------------------------------------------===#
 
-# Target runtime per benchmark: 500ms for more stable measurements
-comptime TARGET_RUNTIME_NS = 500_000_000
+# Target runtime per benchmark: 500ms prod, 50ms dev
+comptime TARGET_RUNTIME_NS_PROD = 500_000_000
+comptime TARGET_RUNTIME_NS_DEV = 50_000_000
 comptime MAX_ITERATIONS = 200_000
 comptime WARMUP_ITERATIONS = 10
-# Minimum time per sample (10ms) to reduce noise for sub-microsecond benchmarks
-comptime MIN_SAMPLE_NS = 10_000_000
+# Minimum time per sample: 10ms prod (stable), 1ms dev (fast, noisier)
+comptime MIN_SAMPLE_NS_PROD = 10_000_000
+comptime MIN_SAMPLE_NS_DEV = 1_000_000
+
+
+# ===-----------------------------------------------------------------------===#
+# CLI flags
+# ===-----------------------------------------------------------------------===#
+#
+# Supported:
+#   --dev              Fast mode: 1ms samples, 50ms per-bench budget (10x)
+#   --filter=<substr>  Only run benchmarks whose name contains <substr>
+#
+# Example: mojo run -I src benchmarks/bench_engine.mojo -- --dev --filter=sub_
+
+
+def _arg_has(flag: StaticString) -> Bool:
+    """True if `flag` appears as a bare argv entry."""
+    var args = argv()
+    for i in range(1, len(args)):
+        if args[i] == flag:
+            return True
+    return False
+
+
+def _arg_value(prefix: StaticString) -> String:
+    """Return the suffix of an argv entry starting with `prefix`, or empty."""
+    var args = argv()
+    var plen = len(prefix)
+    for i in range(1, len(args)):
+        var a = args[i]
+        if len(a) >= plen and a[byte=0:plen] == prefix:
+            return String(a[byte=plen:])
+    return ""
+
+
+def _dev_mode() -> Bool:
+    return _arg_has("--dev")
+
+
+def _min_sample_ns() -> UInt:
+    return UInt(MIN_SAMPLE_NS_DEV) if _dev_mode() else UInt(MIN_SAMPLE_NS_PROD)
+
+
+def _target_runtime_ns() -> UInt:
+    return UInt(TARGET_RUNTIME_NS_DEV) if _dev_mode() else UInt(
+        TARGET_RUNTIME_NS_PROD
+    )
+
+
+def _bench_skip(name: String) -> Bool:
+    """True if --filter=<substr> is set and `name` does not contain it."""
+    var f = _arg_value("--filter=")
+    return len(f) > 0 and f not in name
 
 
 def _find_median(mut times: List[Float64]) -> Float64:
@@ -124,6 +178,10 @@ def benchmark_match_first(
     name: String, pattern: String, text: String, internal_iterations: Int
 ) raises:
     """Benchmark match_first with pre-compiled regex and median timing."""
+    if _bench_skip(name):
+        return
+    var min_sample_ns = _min_sample_ns()
+    var target_runtime_ns = _target_runtime_ns()
 
     # Pre-compile regex outside timing loop
     var compiled = compile_regex(pattern)
@@ -134,14 +192,14 @@ def benchmark_match_first(
     for _ in range(WARMUP_ITERATIONS):
         _ = compiled.match_first(text)
 
-    # Auto-calibrate: ensure each sample takes >= MIN_SAMPLE_NS
+    # Auto-calibrate: ensure each sample takes >= min_sample_ns
     var iters = internal_iterations
     var cal_start = perf_counter_ns()
     for _ in range(iters):
         _ = compiled.match_first(text)
     var cal_elapsed = perf_counter_ns() - cal_start
-    if cal_elapsed < MIN_SAMPLE_NS:
-        var multiplier = Int(MIN_SAMPLE_NS // cal_elapsed) + 1
+    if cal_elapsed < min_sample_ns:
+        var multiplier = Int(min_sample_ns // cal_elapsed) + 1
         iters = iters * multiplier
 
     # Collect per-iteration times
@@ -150,7 +208,7 @@ def benchmark_match_first(
     var actual_iterations = 0
 
     while (
-        total_time < UInt(TARGET_RUNTIME_NS)
+        total_time < UInt(target_runtime_ns)
         and actual_iterations < MAX_ITERATIONS
     ):
         var start_time = perf_counter_ns()
@@ -176,6 +234,10 @@ def benchmark_search(
 ) raises:
     """Benchmark search (match_next) with pre-compiled regex and median timing.
     """
+    if _bench_skip(name):
+        return
+    var min_sample_ns = _min_sample_ns()
+    var target_runtime_ns = _target_runtime_ns()
 
     var compiled = compile_regex(pattern)
     var stats = compiled.get_stats()
@@ -185,14 +247,14 @@ def benchmark_search(
     for _ in range(WARMUP_ITERATIONS):
         _ = compiled.match_next(text)
 
-    # Auto-calibrate: ensure each sample takes >= MIN_SAMPLE_NS
+    # Auto-calibrate: ensure each sample takes >= min_sample_ns
     var iters = internal_iterations
     var cal_start = perf_counter_ns()
     for _ in range(iters):
         _ = compiled.match_next(text)
     var cal_elapsed = perf_counter_ns() - cal_start
-    if cal_elapsed < MIN_SAMPLE_NS:
-        var multiplier = Int(MIN_SAMPLE_NS // cal_elapsed) + 1
+    if cal_elapsed < min_sample_ns:
+        var multiplier = Int(min_sample_ns // cal_elapsed) + 1
         iters = iters * multiplier
 
     var times = List[Float64]()
@@ -200,7 +262,7 @@ def benchmark_search(
     var actual_iterations = 0
 
     while (
-        total_time < UInt(TARGET_RUNTIME_NS)
+        total_time < UInt(target_runtime_ns)
         and actual_iterations < MAX_ITERATIONS
     ):
         var start_time = perf_counter_ns()
@@ -227,6 +289,10 @@ def benchmark_findall(
     name: String, pattern: String, text: String, internal_iterations: Int
 ) raises:
     """Benchmark findall with pre-compiled regex and median timing."""
+    if _bench_skip(name):
+        return
+    var min_sample_ns = _min_sample_ns()
+    var target_runtime_ns = _target_runtime_ns()
 
     var compiled = compile_regex(pattern)
     var stats = compiled.get_stats()
@@ -236,14 +302,14 @@ def benchmark_findall(
     for _ in range(WARMUP_ITERATIONS):
         _ = compiled.match_all(text)
 
-    # Auto-calibrate: ensure each sample takes >= MIN_SAMPLE_NS
+    # Auto-calibrate: ensure each sample takes >= min_sample_ns
     var iters = internal_iterations
     var cal_start = perf_counter_ns()
     for _ in range(iters):
         _ = compiled.match_all(text)
     var cal_elapsed = perf_counter_ns() - cal_start
-    if cal_elapsed < MIN_SAMPLE_NS:
-        var multiplier = Int(MIN_SAMPLE_NS // cal_elapsed) + 1
+    if cal_elapsed < min_sample_ns:
+        var multiplier = Int(min_sample_ns // cal_elapsed) + 1
         iters = iters * multiplier
 
     var times = List[Float64]()
@@ -251,7 +317,7 @@ def benchmark_findall(
     var actual_iterations = 0
 
     while (
-        total_time < UInt(TARGET_RUNTIME_NS)
+        total_time < UInt(target_runtime_ns)
         and actual_iterations < MAX_ITERATIONS
     ):
         var start_time = perf_counter_ns()
@@ -276,6 +342,10 @@ def benchmark_is_match(
 ) raises:
     """Benchmark is_match (bool-only) with pre-compiled regex and median timing.
     """
+    if _bench_skip(name):
+        return
+    var min_sample_ns = _min_sample_ns()
+    var target_runtime_ns = _target_runtime_ns()
 
     var compiled = compile_regex(pattern)
     var stats = compiled.get_stats()
@@ -285,14 +355,14 @@ def benchmark_is_match(
     for _ in range(WARMUP_ITERATIONS):
         _ = compiled.is_match(text)
 
-    # Auto-calibrate: ensure each sample takes >= MIN_SAMPLE_NS
+    # Auto-calibrate: ensure each sample takes >= min_sample_ns
     var iters = internal_iterations
     var cal_start = perf_counter_ns()
     for _ in range(iters):
         _ = compiled.is_match(text)
     var cal_elapsed = perf_counter_ns() - cal_start
-    if cal_elapsed < MIN_SAMPLE_NS:
-        var multiplier = Int(MIN_SAMPLE_NS // cal_elapsed) + 1
+    if cal_elapsed < min_sample_ns:
+        var multiplier = Int(min_sample_ns // cal_elapsed) + 1
         iters = iters * multiplier
 
     # Collect per-iteration times
@@ -301,7 +371,7 @@ def benchmark_is_match(
     var actual_iterations = 0
 
     while (
-        total_time < UInt(TARGET_RUNTIME_NS)
+        total_time < UInt(target_runtime_ns)
         and actual_iterations < MAX_ITERATIONS
     ):
         var start_time = perf_counter_ns()
@@ -330,6 +400,10 @@ def benchmark_sub(
     internal_iterations: Int,
 ) raises:
     """Benchmark sub() with pre-compiled regex and median timing."""
+    if _bench_skip(name):
+        return
+    var min_sample_ns = _min_sample_ns()
+    var target_runtime_ns = _target_runtime_ns()
 
     # Warmup
     for _ in range(WARMUP_ITERATIONS):
@@ -341,8 +415,8 @@ def benchmark_sub(
     for _ in range(iters):
         _ = sub(pattern, repl, text)
     var cal_elapsed = perf_counter_ns() - cal_start
-    if cal_elapsed < MIN_SAMPLE_NS:
-        var multiplier = Int(MIN_SAMPLE_NS // cal_elapsed) + 1
+    if cal_elapsed < min_sample_ns:
+        var multiplier = Int(min_sample_ns // cal_elapsed) + 1
         iters = iters * multiplier
 
     var times = List[Float64]()
@@ -350,7 +424,7 @@ def benchmark_sub(
     var actual_iterations = 0
 
     while (
-        total_time < UInt(TARGET_RUNTIME_NS)
+        total_time < UInt(target_runtime_ns)
         and actual_iterations < MAX_ITERATIONS
     ):
         var start_time = perf_counter_ns()
@@ -379,9 +453,17 @@ def benchmark_sub(
 def main() raises:
     """Run all regex benchmarks with manual timing."""
     print("=== REGEX ENGINE BENCHMARKS (Pre-compiled, Median Timing) ===")
-    print(
-        "Target runtime: 500ms per benchmark, reporting median iteration time"
-    )
+    if _dev_mode():
+        print(
+            "Dev mode: 1ms samples, 50ms per-bench budget (use for fast iteration)"
+        )
+    else:
+        print(
+            "Target runtime: 500ms per benchmark, reporting median iteration time"
+        )
+    var filter = _arg_value("--filter=")
+    if len(filter) > 0:
+        print("Filter: only running benchmarks matching '" + filter + "'")
     print()
 
     # Prepare test data - same as original benchmarks

--- a/benchmarks/bench_engine.mojo
+++ b/benchmarks/bench_engine.mojo
@@ -455,11 +455,13 @@ def main() raises:
     print("=== REGEX ENGINE BENCHMARKS (Pre-compiled, Median Timing) ===")
     if _dev_mode():
         print(
-            "Dev mode: 1ms samples, 50ms per-bench budget (use for fast iteration)"
+            "Dev mode: 1ms samples, 50ms per-bench budget (use for fast"
+            " iteration)"
         )
     else:
         print(
-            "Target runtime: 500ms per benchmark, reporting median iteration time"
+            "Target runtime: 500ms per benchmark, reporting median iteration"
+            " time"
         )
     var filter = _arg_value("--filter=")
     if len(filter) > 0:


### PR DESCRIPTION
## Summary

A full bench_engine run takes ~4 min, making it slow to iterate on
optimization changes. Two new flags make targeted dev iterations
10-30x faster while keeping the existing stable-measurement run
available as the default.

### Flags

**--dev**: Switch sample-time budget from 10ms to 1ms and per-bench
target runtime from 500ms to 50ms. Noisier (use only for directional
signal), but a full 80-bench run takes **~8 s** instead of **~4 min**
once Mojo's compile cache is warm.

**--filter=<substr>**: Substring match against benchmark name. Running
just the subset touched by a change (e.g. \`--filter=sub_\` for the
sub() benchmarks) takes seconds.

The flags compose. Typical workflow:

\`\`\`bash
# Fast dev iteration on one code path
mojo run -I src benchmarks/bench_engine.mojo -- --dev --filter=sub_

# Full stable run before committing
mojo run -I src benchmarks/bench_engine.mojo
\`\`\`

### Measured wall time

| Invocation | Wall time |
|---|---|
| No flags (pre-PR behavior) | ~4 min |
| \`--dev\` (80 benches, 1ms samples) | **~8 s** |
| \`--dev --filter=sub_\` (10 benches) | **~18 s** (first run) |
| \`--filter=sub_literal\` prod (1 bench) | ~1 s + compile |

## Implementation

The comptime MIN_SAMPLE_NS / TARGET_RUNTIME_NS constants split into
_PROD / _DEV pairs. Each of the 5 benchmark functions reads the
appropriate value at entry via helpers that parse \`argv()\`. The
helpers also implement the filter check that short-circuits before
regex compilation for skipped benches.

## Test plan

- [x] \`--dev --filter=sub_literal\` runs 1 bench in ~1 s of work
- [x] \`--dev\` (no filter) runs all 80 in ~8 s
- [x] \`--filter=sub_\` prod mode runs only the sub_* subset
- [x] No flags behaves identically to pre-PR (default 10ms / 500ms)
- [x] No new compiler warnings