### PR TITLE
Route fixed-bounded literal quantifiers to DFA + fix O(N^2) literal findall

### DIFF
--- a/src/regex/dfa.mojo
+++ b/src/regex/dfa.mojo
@@ -2008,6 +2008,25 @@ struct DFAEngine(Engine):
         var text_ptr = text.unsafe_ptr()
         var num_states = len(self.states)
 
+        # Fast path: pure literal patterns. The general loop below would
+        # call `_try_match_at_position` per byte; for a literal pattern,
+        # each call falls into `simd_search` and rescans the rest of the
+        # text — O(N^2) on non-matching input. A single forward scan is
+        # all that's needed: jump to the next occurrence, append, advance
+        # past the match.
+        if self.is_pure_literal:
+            var pattern_bytes = self.literal_pattern.as_bytes()
+            var pattern_len = len(self.literal_pattern)
+            if pattern_len == 0:
+                return matches^
+            while pos <= text_len - pattern_len:
+                var hit = simd_search(pattern_bytes, text, pos)
+                if hit == -1:
+                    break
+                matches.append(Match(0, hit, hit + pattern_len, text))
+                pos = hit + pattern_len
+            return matches^
+
         # Fast path: use SIMD matcher to skip non-matching positions
         if self._has_simd_matcher and num_states > 0:
             if self._simd_scan_eligible:

--- a/src/regex/dfa.mojo
+++ b/src/regex/dfa.mojo
@@ -2017,8 +2017,6 @@ struct DFAEngine(Engine):
         if self.is_pure_literal:
             var pattern_bytes = self.literal_pattern.as_bytes()
             var pattern_len = len(self.literal_pattern)
-            if pattern_len == 0:
-                return matches^
             while pos <= text_len - pattern_len:
                 var hit = simd_search(pattern_bytes, text, pos)
                 if hit == -1:

--- a/src/regex/optimizer.mojo
+++ b/src/regex/optimizer.mojo
@@ -453,16 +453,20 @@ struct PatternAnalyzer:
             and quantifier_complexity.value == PatternComplexity.SIMPLE
         ):
             # For literal groups (like "hello" parsed as group of chars), be more generous
-            # Check if all children are literal elements or anchors
+            # Check if all children are literal elements or anchors. ELEMENTs
+            # with fixed bounded quantifiers (`c{N}` with N == max <= 10) also
+            # count: they expand to a flat literal sequence in DFA compilation
+            # (see `_is_literal_sequence` and `_extract_literal_chars`).
             var all_literal = True
             for i in range(ast.get_children_len()):
                 ref child = ast.get_child(i)
+                var is_literal_element = (
+                    child.type == ELEMENT
+                    and child.min == child.max
+                    and 1 <= child.min <= 10
+                )
                 if not (
-                    (
-                        child.type == ELEMENT
-                        and child.min == 1
-                        and child.max == 1
-                    )
+                    is_literal_element
                     or child.type == START
                     or child.type == END
                 ):
@@ -864,8 +868,16 @@ def _is_literal_sequence(ast: ASTNode) -> Bool:
         True if node represents literal characters only
     """
     if ast.type == ELEMENT:
-        # Must be a single character with no quantifier
-        return ast.min == 1 and ast.max == 1
+        # Single character (no quantifier) — always literal.
+        if ast.min == 1 and ast.max == 1:
+            return True
+        # Fixed-bounded quantifier `c{N}` is also literal: it expands to
+        # `cccc...` of length N. Cap N to keep the expanded literal
+        # bounded; matches `_classify_quantifier` which itself caps fixed
+        # quantifiers at <= 10 for SIMPLE.
+        if ast.min == ast.max and 1 <= ast.min <= 10:
+            return True
+        return False
     elif ast.type == START or ast.type == END:
         # Anchors are fine in literal patterns
         return True
@@ -913,7 +925,19 @@ def _extract_literal_chars(ast: ASTNode) -> String:
         String containing the literal characters
     """
     if ast.type == ELEMENT:
-        return String(ast.get_value().value()) if ast.get_value() else ""
+        var v = ast.get_value()
+        if not v:
+            return EMPTY_STRING
+        ref ch = v.value()
+        # Fixed-bounded `c{N}` expands to `cccc...` of length N. Single
+        # char (min=max=1) hits the same code path with one repeat.
+        var repeats = ast.min
+        if repeats <= 1:
+            return String(ch)
+        var out = String(capacity=repeats * len(ch))
+        for _ in range(repeats):
+            out += ch
+        return out
     elif ast.type == GROUP:
         var result = String(capacity=String.INLINE_CAPACITY)
         for i in range(ast.get_children_len()):

--- a/src/regex/optimizer.mojo
+++ b/src/regex/optimizer.mojo
@@ -30,6 +30,11 @@ from regex.literal_optimizer import (
 )
 
 
+comptime MAX_LITERAL_QUANT_REPETITIONS = 10
+"""Cap on `c{N}` repetitions still treated as a flat literal for DFA
+routing. Patterns above this cap keep the MEDIUM/NFA classification."""
+
+
 struct PatternComplexity(Copyable, TrivialRegisterPassable, Writable):
     """Classification of regex pattern complexity for optimal execution strategy.
     """
@@ -463,7 +468,7 @@ struct PatternAnalyzer:
                 var is_literal_element = (
                     child.type == ELEMENT
                     and child.min == child.max
-                    and 1 <= child.min <= 10
+                    and 1 <= child.min <= MAX_LITERAL_QUANT_REPETITIONS
                 )
                 if not (
                     is_literal_element
@@ -872,10 +877,8 @@ def _is_literal_sequence(ast: ASTNode) -> Bool:
         if ast.min == 1 and ast.max == 1:
             return True
         # Fixed-bounded quantifier `c{N}` is also literal: it expands to
-        # `cccc...` of length N. Cap N to keep the expanded literal
-        # bounded; matches `_classify_quantifier` which itself caps fixed
-        # quantifiers at <= 10 for SIMPLE.
-        if ast.min == ast.max and 1 <= ast.min <= 10:
+        # `cccc...` of length N, capped at MAX_LITERAL_QUANT_REPETITIONS.
+        if ast.min == ast.max and 1 <= ast.min <= MAX_LITERAL_QUANT_REPETITIONS:
             return True
         return False
     elif ast.type == START or ast.type == END:


### PR DESCRIPTION
## Summary

Two coordinated fixes that together close `optimize_extreme_quantifiers` (the worst remaining Mojo-vs-Rust gap, 11.7x slower) and a latent O(N²) DFA bug they exposed.

### 1. Fix O(N²) DFA `match_all` on pure-literal patterns

When `is_pure_literal` is `True`, DFA `match_all` fell through to the general loop that calls `_try_match_at_position` per byte. That call ends up in `simd_search`, which scans from `pos` to end of text. On non-matching input the outer `pos += 1` loop rescanned the whole remaining tail every iteration — O(N²).

Added a literal fast path right after the anchor check: a single forward `simd_search` loop that advances past each match by `pattern_len`. One pass, O(N).

### 2. Route fixed-bounded literal quantifier sequences to DFA

Patterns like `a{1}b{2}c{3}d{4}e{5}f{6}g{7}h{8}` were classified as MEDIUM and routed to the backtracking NFA, even though they expand to a fixed 36-byte literal string the DFA literal path already handles efficiently.

Three coordinated changes in `optimizer.mojo`:
- `_is_literal_sequence` accepts `ELEMENT`s with `min == max <= 10` (fixed bounded quantifier).
- `_extract_literal_chars` repeats the character `min` times when building the flat literal.
- `_analyze_group`'s inline literal check mirrors the same predicate so the complexity classifier returns SIMPLE.

The `<= 10` cap matches the existing `_classify_quantifier` SIMPLE cap; longer fixed quantifiers stay MEDIUM/NFA.

## Stable best-of-3 vs main

| Bench | Baseline | Branch | Ratio |
|---|---|---|---|
| `optimize_extreme_quantifiers` | 2427 ns | 382 ns | **6.35x** |
| `pure_dfa_dash` | 1231 ns | 117 ns | **10.5x** |
| `sub_literal` | 2983 ns | 2660 ns | 1.12x |
| `range_alphanumeric` | 511 ns | 480 ns | 1.06x |
| `datetime_quantifiers` | 43.5 µs | 40.4 µs | 1.08x |

Single-run full-suite scan flagged some sub-ns benchmarks as regressions; best-of-3 medians showed they were within noise. The two real residuals (`alternation_simple` 0.92x, `is_match_digits` 0.79x) are sub-2 ns benchmarks where ±30% is normal variance.

Closes the 11.7x Mojo-vs-Rust gap on `optimize_extreme_quantifiers` (now ~2.1x slower than Rust, was 11.7x).

## Test plan

- [x] `pixi run test` — all 377 tests pass
- [x] `pixi run format`
- [x] Stable best-of-3 verification of every flagged regression