### PR TITLE
Migrate __copyinit__/__moveinit__ to __init__ keyword-only forms

### DIFF
--- a/src/regex/ast.mojo
+++ b/src/regex/ast.mojo
@@ -296,7 +296,7 @@ struct ASTNode[regex_origin: ImmutOrigin](
     #     print("Deleting ASTNode:", self, "in ", call_location)
 
     @always_inline
-    def __copyinit__(out self, copy: ASTNode[Self.regex_origin]):
+    def __init__(out self, *, copy: ASTNode[Self.regex_origin]):
         """Copy constructor for ASTNode."""
         self.type = copy.type
         self.regex_ptr = copy.regex_ptr

--- a/src/regex/dfa.mojo
+++ b/src/regex/dfa.mojo
@@ -291,7 +291,7 @@ struct DFAEngine(Engine):
         self._simd_scan_eligible = False
         self.literal_pattern = ""
 
-    def __moveinit__(out self, deinit take: Self):
+    def __init__(out self, *, deinit take: Self):
         """Move constructor."""
         self.states = take.states^
         self.start_state = take.start_state

--- a/src/regex/matcher.mojo
+++ b/src/regex/matcher.mojo
@@ -77,13 +77,13 @@ struct OptimizedLiteralInfo(Copyable, Movable):
         self.has_anchors = has_anchors
         self.is_exact_match = is_exact_match
 
-    def __copyinit__(out self, copy: Self):
+    def __init__(out self, *, copy: Self):
         """Copy constructor."""
         self.best_literal = copy.best_literal
         self.has_anchors = copy.has_anchors
         self.is_exact_match = copy.is_exact_match
 
-    def __moveinit__(out self, deinit take: Self):
+    def __init__(out self, *, deinit take: Self):
         """Move constructor."""
         self.best_literal = take.best_literal^
         self.has_anchors = take.has_anchors
@@ -226,7 +226,7 @@ struct DFAMatcher(Boolable, Copyable, Movable, RegexMatcher):
         self.engine_ptr = alloc[DFAEngine](1)
         self.engine_ptr.init_pointee_move(engine^)
 
-    def __copyinit__(out self, copy: Self):
+    def __init__(out self, *, copy: Self):
         """Copy constructor."""
         self.engine_ptr = copy.engine_ptr
 
@@ -302,7 +302,7 @@ struct NFAMatcher(Copyable, Movable, RegexMatcher):
         else:
             self._lazy_dfa_ptr = UnsafePointer[LazyDFA, MutAnyOrigin]()
 
-    def __copyinit__(out self, copy: Self):
+    def __init__(out self, *, copy: Self):
         """Copy constructor. Deep-copies owned engines."""
         self.engine = copy.engine.copy()
         self.ast = copy.ast
@@ -317,7 +317,7 @@ struct NFAMatcher(Copyable, Movable, RegexMatcher):
         else:
             self._onepass_ptr = UnsafePointer[OnePassNFA, MutAnyOrigin]()
 
-    def __moveinit__(out self, deinit take: Self):
+    def __init__(out self, *, deinit take: Self):
         """Move constructor. Transfers ownership of the heap-allocated
         engines from `take` to `self`."""
         self.engine = take.engine^
@@ -660,7 +660,7 @@ struct HybridMatcher(Copyable, Movable, RegexMatcher):
                 self.dfa_matcher.engine_ptr[]._simd_char_matcher.lookup_table,
             )
 
-    def __copyinit__(out self, copy: Self):
+    def __init__(out self, *, copy: Self):
         """Copy constructor."""
         self.dfa_matcher = copy.dfa_matcher.copy()
         self.nfa_matcher = copy.nfa_matcher.copy()
@@ -673,7 +673,7 @@ struct HybridMatcher(Copyable, Movable, RegexMatcher):
         self._use_dfa = copy._use_dfa
         self._required_byte = copy._required_byte
 
-    def __moveinit__(out self, deinit take: Self):
+    def __init__(out self, *, deinit take: Self):
         """Move constructor."""
         self.dfa_matcher = take.dfa_matcher^
         self.nfa_matcher = take.nfa_matcher^
@@ -934,7 +934,7 @@ struct CompiledRegex(ImplicitlyCopyable, Movable):
         self._fixed_sub_concat = False
         self._try_precompute_fixed_sub()
 
-    def __copyinit__(out self, copy: Self):
+    def __init__(out self, *, copy: Self):
         """Copy constructor."""
         self.matcher = copy.matcher.copy()
         self.pattern = copy.pattern
@@ -945,7 +945,7 @@ struct CompiledRegex(ImplicitlyCopyable, Movable):
         self._fixed_sub_widths = copy._fixed_sub_widths
         self._fixed_sub_concat = copy._fixed_sub_concat
 
-    def __moveinit__(out self, deinit take: Self):
+    def __init__(out self, *, deinit take: Self):
         """Move constructor."""
         self.matcher = take.matcher^
         self.pattern = take.pattern^

--- a/src/regex/matching.mojo
+++ b/src/regex/matching.mojo
@@ -69,8 +69,9 @@ struct MatchList(Copyable, Movable, Sized):
             self._realloc(capacity)
 
     @always_inline
-    def __copyinit__(
+    def __init__(
         out self,
+        *,
         copy: Self,
     ):
         """Copy constructor."""

--- a/src/regex/prefilter.mojo
+++ b/src/regex/prefilter.mojo
@@ -37,7 +37,7 @@ struct LiteralInfo(Copyable, Movable):
         self.is_exact_match = False
         self.has_anchors = False
 
-    def __copyinit__(out self, copy: Self):
+    def __init__(out self, *, copy: Self):
         """Copy constructor."""
         self.required_literals = copy.required_literals.copy()
         self.literal_prefixes = copy.literal_prefixes.copy()
@@ -45,7 +45,7 @@ struct LiteralInfo(Copyable, Movable):
         self.is_exact_match = copy.is_exact_match
         self.has_anchors = copy.has_anchors
 
-    def __moveinit__(out self, deinit take: Self):
+    def __init__(out self, *, deinit take: Self):
         """Move constructor."""
         self.required_literals = take.required_literals^
         self.literal_prefixes = take.literal_prefixes^
@@ -389,12 +389,12 @@ struct MemchrPrefilter(Copyable, Movable, PrefilterMatcher):
         self.literal = literal
         self.is_prefix = is_prefix
 
-    def __copyinit__(out self, copy: Self):
+    def __init__(out self, *, copy: Self):
         """Copy constructor."""
         self.literal = copy.literal
         self.is_prefix = copy.is_prefix
 
-    def __moveinit__(out self, deinit take: Self):
+    def __init__(out self, *, deinit take: Self):
         """Move constructor."""
         self.literal = take.literal^
         self.is_prefix = take.is_prefix


### PR DESCRIPTION
## Summary

- Mojo 0.26.2 renamed `__copyinit__` / `__moveinit__` to keyword-only `__init__` overloads. The old names are still aliased ("for now"), but the [release notes](https://github.com/modular/modular/blob/main/mojo/docs/releases/v0.26.2.md) explicitly encourage migration.
- Updated all 14 call sites across `ast.mojo`, `dfa.mojo`, `matcher.mojo`, `matching.mojo`, and `prefilter.mojo`:
  - `__copyinit__(out self, copy: Self)` → `__init__(out self, *, copy: Self)`
  - `__moveinit__(out self, deinit take: Self)` → `__init__(out self, *, deinit take: Self)`
- Argument names were already on the new convention (`copy` / `take`), so this is a pure method-name swap with `*` keeping the parameter keyword-only to avoid clashing with regular `__init__` overloads.
- Historical docstring reference to `__moveinit__` in `matcher.mojo:267` is preserved (it documents a past bug). Two commented-out declarations in `literal_optimizer.mojo` and `ast.mojo` are also left untouched.

## Test plan

- [x] `pixi run test` (full suite green, exit 0)
- [x] `pixi run format` (no changes)
- [x] Pre-commit hooks pass
- [ ] CI green