### PR TITLE
Recover hot-path perf regressions under mojo 1.0.0b1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,3 +186,10 @@ most often in this repo:
 - `sys.argv()` returns `Span[StaticString, StaticConstantOrigin]`.
 - SIMD bit-pattern reinterpretation uses the free function
   `bitcast[dtype, size](value)` from `std.memory`, not a method.
+- **1.0.0b1 turns CPU bounds checks on by default** for `List`, `Span`,
+  and (when called via `[i]`) `StringSlice`. The per-access check is
+  small but adds up in tight loops; index through `unsafe_ptr()` on
+  hot paths where bounds are already guaranteed (see `verify_match`
+  in `simd_ops.mojo` and the DFA start-state probe in `dfa.mojo`).
+  Global `-D ASSERT=none` is a sledgehammer; prefer per-callsite
+  `unsafe_ptr` so non-hot code keeps the safety net.

--- a/src/regex/dfa.mojo
+++ b/src/regex/dfa.mojo
@@ -1916,13 +1916,9 @@ struct DFAEngine(Engine):
                     return Match(0, pos, pos + pattern_len, text)
                 return None
 
-        # Try SIMD matching for simple character class patterns.
-        # _try_match_simd returns None immediately when the start state
-        # is non-accepting AND the pattern isn't simd-scan-eligible
-        # (i.e., a bounded quantifier like {3} or {2,4}), so skip the
-        # function call in that common case. This is the hot path for
-        # bounded-quantifier patterns like `[0-9]{10}`, where every
-        # candidate position would otherwise pay the call overhead.
+        # _try_match_simd returns None for bounded quantifiers with a
+        # non-accepting start state; inlining the guard avoids the
+        # call per candidate position.
         if (
             self._has_simd_matcher
             and len(self.states) > 0
@@ -2122,11 +2118,8 @@ struct DFAEngine(Engine):
         if len(self.states) == 0:
             return None
 
-        # Check if start state is accepting (for patterns like [a-z]*).
-        # Use unsafe_ptr to bypass List bounds check (1.0.0b1 enables it
-        # by default on CPU); start_state is always within states bounds
-        # since we just checked len > 0 above and DFA construction
-        # guarantees the index is valid.
+        # unsafe_ptr to skip the 1.0.0b1 default List bounds check;
+        # start_state is guaranteed in-range by the len check above.
         var start_accepting = self.states.unsafe_ptr()[
             self.start_state
         ].is_accepting

--- a/src/regex/dfa.mojo
+++ b/src/regex/dfa.mojo
@@ -1916,8 +1916,21 @@ struct DFAEngine(Engine):
                     return Match(0, pos, pos + pattern_len, text)
                 return None
 
-        # Try SIMD matching for simple character class patterns
-        if self._has_simd_matcher and len(self.states) > 0:
+        # Try SIMD matching for simple character class patterns.
+        # _try_match_simd returns None immediately when the start state
+        # is non-accepting AND the pattern isn't simd-scan-eligible
+        # (i.e., a bounded quantifier like {3} or {2,4}), so skip the
+        # function call in that common case. This is the hot path for
+        # bounded-quantifier patterns like `[0-9]{10}`, where every
+        # candidate position would otherwise pay the call overhead.
+        if (
+            self._has_simd_matcher
+            and len(self.states) > 0
+            and (
+                self._simd_scan_eligible
+                or self.states.unsafe_ptr()[self.start_state].is_accepting
+            )
+        ):
             var match_result = self._try_match_simd(text, start_pos)
             if match_result:
                 return match_result
@@ -2109,8 +2122,14 @@ struct DFAEngine(Engine):
         if len(self.states) == 0:
             return None
 
-        # Check if start state is accepting (for patterns like [a-z]*)
-        var start_accepting = self.states[self.start_state].is_accepting
+        # Check if start state is accepting (for patterns like [a-z]*).
+        # Use unsafe_ptr to bypass List bounds check (1.0.0b1 enables it
+        # by default on CPU); start_state is always within states bounds
+        # since we just checked len > 0 above and DFA construction
+        # guarantees the index is valid.
+        var start_accepting = self.states.unsafe_ptr()[
+            self.start_state
+        ].is_accepting
 
         # Bounded quantifiers like {3} or {2,4} can't use SIMD scan because
         # the match length is constrained. This flag is computed at compile time.

--- a/src/regex/simd_ops.mojo
+++ b/src/regex/simd_ops.mojo
@@ -946,9 +946,9 @@ def verify_match(pattern: Span[Byte, _], text: ImmSlice, pos: Int) -> Bool:
         return False
 
     var text_ptr = text.unsafe_ptr()
+    var pattern_ptr = pattern.unsafe_ptr()
     for i in range(pattern_len):
-        var c = pattern[i]
-        if Int(text_ptr[pos + i]) != Int(c):
+        if text_ptr[pos + i] != pattern_ptr[i]:
             return False
 
     return True
@@ -983,15 +983,16 @@ def simd_search(
 
     var text_len = text.byte_length()
     var text_ptr = text.unsafe_ptr()
+    var pattern_ptr = pattern.unsafe_ptr()
 
     # Single-byte literal: pure memchr-style SIMD scan.
     if pattern_len == 1:
-        return simd_find_byte(text_ptr, start, text_len, pattern[0])
+        return simd_find_byte(text_ptr, start, text_len, pattern_ptr[0])
 
     # Two-byte anchored SIMD scan for pattern_len >= 2.
-    var first_byte = pattern[0]
+    var first_byte = pattern_ptr[0]
     var last_offset = pattern_len - 1
-    var last_byte = pattern[last_offset]
+    var last_byte = pattern_ptr[last_offset]
     var first_splat = SIMD[DType.uint8, SIMD_WIDTH](first_byte)
     var last_splat = SIMD[DType.uint8, SIMD_WIDTH](last_byte)
     var pos = start
@@ -1272,13 +1273,14 @@ def apply_quantifier_simd_generic[
     """
     var pos = start_pos
     var match_count = 0
+    var text_len = text.byte_length()
     var actual_max = max_matches
     if actual_max == -1:
-        actual_max = text.byte_length() - start_pos
+        actual_max = text_len - start_pos
 
     # Count consecutive matching characters
     var text_ptr = text.unsafe_ptr()
-    while pos < text.byte_length() and match_count < actual_max:
+    while pos < text_len and match_count < actual_max:
         if matcher.contains(Int(text_ptr[pos])):
             match_count += 1
             pos += 1
@@ -1371,11 +1373,12 @@ def twoway_search(
             return simd_search(pattern, text, start)
 
         # For 2-4 byte patterns, use rolling comparison
+        var pattern_ptr = pattern.unsafe_ptr()
         var pos = start
         while pos <= m - n:
             var matched = True
             for i in range(n):
-                if Int(text_ptr[pos + i]) != Int(pattern[i]):
+                if text_ptr[pos + i] != pattern_ptr[i]:
                     matched = False
                     break
             if matched:
@@ -1394,10 +1397,11 @@ def twoway_search(
     var period = 1
 
     # Compute actual period of the pattern
+    var pattern_ptr = pattern.unsafe_ptr()
     for i in range(1, n):
         var is_period = True
         for j in range(n - i):
-            if Int(pattern[j]) != Int(pattern[j + i]):
+            if pattern_ptr[j] != pattern_ptr[j + i]:
                 is_period = False
                 break
         if is_period:
@@ -1408,7 +1412,7 @@ def twoway_search(
         # Simple forward comparison
         var matched = True
         for i in range(n):
-            if Int(text_ptr[pos + i]) != Int(pattern[i]):
+            if text_ptr[pos + i] != pattern_ptr[i]:
                 matched = False
                 break
 


### PR DESCRIPTION
## Summary

Closes much of the perf regression flagged in #153. The remaining gap vs v0.13.0 / mojo 0.26.2 baseline on the full `bench_engine` suite drops from **~7%** (PR #152 head) to **~5%** geomean (3-median, interleaved). Several previously-worst individual benches (`pure_dfa_paren`, `optimize_extreme_quantifiers`, `literal_match_short`) come back to parity or beat baseline.

Two targeted optimizations + one doc note.

## Root cause

mojo 1.0.0b1 turned CPU bounds checks **on by default** for all stdlib collections (`Span`, `List`, and `StringSlice[byte=i]`). The release notes mention this in passing but the impact on tight hot loops is substantial: per-byte `pattern[i]` accesses in `verify_match` and similar functions now run a `check_bounds(idx, size)` call (a UInt comparison + assert) on every iteration. For a 14-byte literal `verify_match` call, that's 14 extra branches; for the per-position SIMD-candidate scan in `simd_search`, it's per-candidate.

Confirmed by attribution: `-D ASSERT=none` (which disables bounds checks globally) selectively recovers the worst regressions (`pure_dfa_paren` 110ns → 57ns, very close to baseline 63ns), with no effect on patterns that don't go through these loops. Global ASSERT=none would also disable safety nets in non-hot code, so this PR fixes the specific call sites instead.

## Changes

1. **`simd_ops.mojo`**: replace `pattern[i]` with `pattern_ptr[i]` (where `pattern_ptr = pattern.unsafe_ptr()`) in `verify_match`, `simd_search`, and the two `twoway_search` rolling/period scans. Drop the redundant `Int(byte)` round-trip on the comparison. Independent cleanup: hoist `text.byte_length()` out of the `apply_quantifier_simd_generic` loop condition.

2. **`dfa.mojo`**:
   - `_try_match_simd`: read `states[start_state].is_accepting` through `unsafe_ptr` to skip the `List[DFAState]` bounds check. The index is guaranteed valid by the `len(states) > 0` precheck plus DFA construction invariants.
   - `_try_match_at_position`: guard the `_try_match_simd` call with the same condition the callee uses to immediately return `None` (`start_state.is_accepting or _simd_scan_eligible`). For bounded-quantifier patterns (`[0-9]{10}`, `[A-Z]{3}[0-9]{4}`, ...) every candidate position used to pay the function-call cost only to receive a guaranteed `None` back; the inline check eliminates it.

3. **`CLAUDE.md`**: document the new-in-1.0.0b1 default-on bounds-check behavior in the Mojo syntax notes section. Points at the two patches as in-tree examples of the per-callsite `unsafe_ptr` fix.

## Measured impact

Methodology: 3-median runs, baseline and optimized binaries interleaved in the same session to share system conditions. Per-bench CV averages ~11%, p90 ~22%, so individual sub-µs deltas may still be noise — focus on the > 1µs benches and the geomean.

| condition                              | geomean ratio vs baseline |
|----------------------------------------|--------------------------:|
| PR #152 head (`upgrade-mojo-1.0.0b1`)  |               1.073 (slower) |
| **This PR**                            |          **1.053 (slower)** |

Recoveries on the previously-worst individual benches (`pure_dfa_paren`, `optimize_extreme_quantifiers`, `literal_match_short`):

| benchmark                    | baseline | PR #152 head | this PR  | recovered |
|------------------------------|---------:|-------------:|---------:|----------:|
| `pure_dfa_paren`             |  63 ns   |  110 ns      |  69 ns   | 87% of regression |
| `optimize_extreme_quantifiers` | 61 ns  |   86 ns      |  69 ns   | 68% of regression |
| `literal_match_short`        |  68 ns   |   84 ns      |  56 ns   | 100% recovered (now faster) |

Other wins now faster than baseline: `match_all_digits` (0.82x), `literal_prefix_long` (0.83x), `required_literal_short` (0.83x), `sparse_flex_phone_findall` (0.84x).

Remaining 5% slowdown is distributed across DFA bounded-quantifier patterns (`single_quantifier_alpha`, `dual_quantifiers`, `dfa_digits_only`, etc.) and looks compiler-side rather than something further `unsafe_ptr` work can fix. Worth leaving for upstream attention.

## Test plan

- [x] `pixi run test` — 377 tests, all passing
- [x] Full `bench_engine` 3-median interleaved on quiet system
- [x] Cross-check against PR #152 head benches in #153