### PR TITLE
Bump mojo to 1.0.0b3 nightly + migrate deprecated any-origin casts

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -32,10 +32,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.4.0.dev2026053106-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b2.dev2026053106-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b2.dev2026053106-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b2.dev2026053106-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026061506-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026061506-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026061506-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026061506-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
@@ -76,10 +76,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.22-h1a92334_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.1-h1b79a29_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.4.0.dev2026053106-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b2.dev2026053106-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b2.dev2026053106-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b2.dev2026053106-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026061506-release.conda
+      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026061506-release.conda
+      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026061506-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026061506-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
@@ -133,10 +133,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.4.0.dev2026053106-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b2.dev2026053106-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b2.dev2026053106-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b2.dev2026053106-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026061506-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026061506-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026061506-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026061506-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
@@ -179,10 +179,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.22-h1a92334_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.1-h1b79a29_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.4.0.dev2026053106-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b2.dev2026053106-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b2.dev2026053106-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b2.dev2026053106-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026061506-release.conda
+      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026061506-release.conda
+      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026061506-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026061506-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
@@ -585,10 +585,10 @@ packages:
   license_family: Other
   size: 47759
   timestamp: 1774072956767
-- conda: https://conda.modular.com/max-nightly/noarch/mblack-26.4.0.dev2026053106-release.conda
+- conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026061506-release.conda
   noarch: python
-  sha256: 6264ce562d44c0ed48dba7a7145bcfef1318ba2e95d32ae619e939d7da484281
-  md5: 11e3e158a250f827f43ea96c06890de5
+  sha256: 97f40520a2d161eecdb6e1877b5ca286fae8137273c8155d6cd09f988d1e70d2
+  md5: 525b4e8cad846beb1c48fd40a58806f6
   depends:
   - python >=3.10
   - click >=8.0.0
@@ -598,55 +598,55 @@ packages:
   - platformdirs >=2
   - tomli >=1.1.0
   license: LicenseRef-Modular-Proprietary
-  size: 135157
-  timestamp: 1780209436677
-- conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b2.dev2026053106-release.conda
-  sha256: 03e3f9e7ca2d428bc3ee1125612dd0f48725fafa722b0c5113971678ff450748
-  md5: d366f1982c807b472e13dd2e45b5bc5e
+  size: 134707
+  timestamp: 1781506747587
+- conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026061506-release.conda
+  sha256: f739c3aa37531fb2bedcaa7dcfe39fe981c650e5fe99e41ddc69f763a0e27e9f
+  md5: f452816977c6235241dd5c363535c16a
   depends:
   - python >=3.10
-  - mojo-compiler ==1.0.0b2.dev2026053106
-  - mblack ==26.4.0.dev2026053106
+  - mojo-compiler ==1.0.0b3.dev2026061506
+  - mblack ==26.5.0.dev2026061506
   - jupyter_client >=8.6.2,<8.7
   license: LicenseRef-Modular-Proprietary
-  size: 96208415
-  timestamp: 1780209668202
-- conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b2.dev2026053106-release.conda
-  sha256: 35be273c19e370a24f8b9a5ca8088c087c16d41e43b57725ac09aef02bd7ac88
-  md5: ef3d9af1b06c889927e406714f43ee86
+  size: 96767705
+  timestamp: 1781506995928
+- conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026061506-release.conda
+  sha256: 588f8b9bb79ff9b5ce35b3d3da541d45a5d17c89ef44cee2786a77f94d33ea4d
+  md5: 23e83fdfb1a3ae506fb6a8fbab6a2e42
   depends:
   - python >=3.10
-  - mojo-compiler ==1.0.0b2.dev2026053106
-  - mblack ==26.4.0.dev2026053106
+  - mojo-compiler ==1.0.0b3.dev2026061506
+  - mblack ==26.5.0.dev2026061506
   - jupyter_client >=8.6.2,<8.7
   license: LicenseRef-Modular-Proprietary
-  size: 84386407
-  timestamp: 1780210047605
-- conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b2.dev2026053106-release.conda
-  sha256: 481734b08f035b6683932d569cfb10ab5ea5b151027d2c0f5c6c3b5feca443fc
-  md5: f3a54ec5e9beeb216a008607ce526231
+  size: 84790670
+  timestamp: 1781539690028
+- conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026061506-release.conda
+  sha256: 6a14d8e94def85307059150c003e160ac33993e466222a932fa9527c8c9253a9
+  md5: dfe0c8b98e9ad307e7c9adbe24336711
   depends:
-  - mojo-python ==1.0.0b2.dev2026053106
+  - mojo-python ==1.0.0b3.dev2026061506
   license: LicenseRef-Modular-Proprietary
-  size: 91603524
-  timestamp: 1780209706830
-- conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b2.dev2026053106-release.conda
-  sha256: 0b6f255099efa8ead68cb81747fa2046327f26d0564cee0919bb1b423087639a
-  md5: 4ba554abd7ad31555208b854634f5be6
+  size: 81260906
+  timestamp: 1781506996215
+- conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026061506-release.conda
+  sha256: 03fe14b050deb2e5fd7ebed44bd0fe53a86b283bc619d7741980fbf548db2599
+  md5: 5dbcb30cce6a67f0062c37e63c8d9035
   depends:
-  - mojo-python ==1.0.0b2.dev2026053106
+  - mojo-python ==1.0.0b3.dev2026061506
   license: LicenseRef-Modular-Proprietary
-  size: 68901109
-  timestamp: 1780210039298
-- conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b2.dev2026053106-release.conda
+  size: 62842704
+  timestamp: 1781539690402
+- conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026061506-release.conda
   noarch: python
-  sha256: 908fa85a0e4837290082f274203898367ca063db514a4d814b905f706cbf6498
-  md5: 5f3d6e9499da15516047c872f9db10f7
+  sha256: ee6b75f3da235b3dff78e9473b122e801190a0f2e46af6b5d2e34f54d56c547e
+  md5: 868f897377f9eb1c3828b818d4aac155
   depends:
   - python >=3.10
   license: LicenseRef-Modular-Proprietary
-  size: 23182
-  timestamp: 1780209436808
+  size: 24127
+  timestamp: 1781506743774
 - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
   sha256: 6ed158e4e5dd8f6a10ad9e525631e35cee8557718f83de7a4e3966b1f772c4b1
   md5: e9c622e0d00fa24a6292279af3ab6d06

--- a/pixi.toml
+++ b/pixi.toml
@@ -19,7 +19,7 @@ version = "0.20.0"
 backend = { name = "pixi-build-rattler-build", version = "*" }
 
 [dependencies]
-mojo = "==1.0.0b2.dev2026053106"
+mojo = "==1.0.0b3.dev2026061506"
 
 [tasks]
 test = "bash -c 'status=0; for f in tests/test_*.mojo; do echo \"Running $f...\"; out=$(mktemp -d); mojo build -I ./src -debug-level=line-tables \"$f\" -o \"$out/exe\" && \"$out/exe\" || status=1; rm -rf \"$out\"; done; exit $status'"

--- a/src/regex/ast.mojo
+++ b/src/regex/ast.mojo
@@ -93,7 +93,7 @@ struct Regex[origin: Origin](Copyable, Equatable, Movable, Writable):
         self.children_len = 0
         self.children_ptr = alloc[ASTNode[ImmutAnyOrigin]](
             pattern.byte_length() * 2
-        )  # Allocate enough space for children
+        ).as_unsafe_any_origin()  # Allocate enough space for children
 
     @always_inline
     def __eq__[o: Origin](self, other: Regex[origin=o]) -> Bool:
@@ -559,7 +559,7 @@ def Element[
     end_idx: Int,
 ) -> ASTNode[ImmutAnyOrigin]:
     """Create an Element node with a value string."""
-    var regex_ptr = UnsafePointer(to=regex).as_any_origin()
+    var regex_ptr = UnsafePointer(to=regex).as_unsafe_any_origin()
     return ASTNode[ImmutAnyOrigin](
         type=ELEMENT,
         regex_ptr=regex_ptr,
@@ -579,7 +579,7 @@ def WildcardElement[
     end_idx: Int,
 ) -> ASTNode[regex_origin]:
     """Create a WildcardElement node."""
-    var regex_ptr = UnsafePointer(to=regex).as_any_origin()
+    var regex_ptr = UnsafePointer(to=regex).as_unsafe_any_origin()
     return ASTNode[regex_origin](
         type=WILDCARD,
         regex_ptr=regex_ptr,
@@ -599,7 +599,7 @@ def SpaceElement[
     end_idx: Int,
 ) -> ASTNode[regex_origin]:
     """Create a SpaceElement node."""
-    var regex_ptr = UnsafePointer(to=regex).as_any_origin()
+    var regex_ptr = UnsafePointer(to=regex).as_unsafe_any_origin()
     return ASTNode[regex_origin](
         type=SPACE,
         regex_ptr=regex_ptr,
@@ -619,7 +619,7 @@ def DigitElement[
     end_idx: Int,
 ) -> ASTNode[regex_origin]:
     """Create a DigitElement node."""
-    var regex_ptr = UnsafePointer(to=regex).as_any_origin()
+    var regex_ptr = UnsafePointer(to=regex).as_unsafe_any_origin()
     return ASTNode[regex_origin](
         type=DIGIT,
         regex_ptr=regex_ptr,
@@ -639,7 +639,7 @@ def WordElement[
     end_idx: Int,
 ) -> ASTNode[regex_origin]:
     """Create a WordElement node."""
-    var regex_ptr = UnsafePointer(to=regex).as_any_origin()
+    var regex_ptr = UnsafePointer(to=regex).as_unsafe_any_origin()
     return ASTNode[regex_origin](
         type=WORD,
         regex_ptr=regex_ptr,
@@ -690,7 +690,7 @@ def RangeElement[
     is_positive_logic: Bool = True,
 ) -> ASTNode[regex_origin]:
     """Create a RangeElement node."""
-    var regex_ptr = UnsafePointer(to=regex).as_any_origin()
+    var regex_ptr = UnsafePointer(to=regex).as_unsafe_any_origin()
     # Classify the range pattern once at build time.
     var kind = RANGE_KIND_OTHER
     if start_idx < end_idx:
@@ -722,7 +722,7 @@ def StartElement[
     end_idx: Int,
 ) -> ASTNode[regex_origin]:
     """Create a StartElement node."""
-    var regex_ptr = UnsafePointer(to=regex).as_any_origin()
+    var regex_ptr = UnsafePointer(to=regex).as_unsafe_any_origin()
     return ASTNode[regex_origin](
         type=START,
         regex_ptr=regex_ptr,
@@ -742,7 +742,7 @@ def EndElement[
     end_idx: Int,
 ) -> ASTNode[regex_origin]:
     """Create an EndElement node."""
-    var regex_ptr = UnsafePointer(to=regex).as_any_origin()
+    var regex_ptr = UnsafePointer(to=regex).as_unsafe_any_origin()
     return ASTNode[regex_origin](
         type=END,
         regex_ptr=regex_ptr,
@@ -764,7 +764,7 @@ def OrNode[
     end_idx: Int,
 ) -> ASTNode[regex_origin]:
     """Create an OrNode with left and right children."""
-    var regex_ptr = UnsafePointer(to=regex).as_any_origin()
+    var regex_ptr = UnsafePointer(to=regex).as_unsafe_any_origin()
     return ASTNode[regex_origin](
         type=OR,
         regex_ptr=regex_ptr,
@@ -788,7 +788,7 @@ def NotNode[
     end_idx: Int,
 ) -> ASTNode[regex_origin]:
     """Create a NotNode with a child."""
-    var regex_ptr = UnsafePointer(to=regex).as_any_origin()
+    var regex_ptr = UnsafePointer(to=regex).as_unsafe_any_origin()
     return ASTNode[regex_origin](
         type=NOT,
         regex_ptr=regex_ptr,
@@ -810,7 +810,7 @@ def GroupNode[
     group_id: Int = -1,
 ) -> ASTNode[regex_origin]:
     """Create a GroupNode with children."""
-    var regex_ptr = UnsafePointer(to=regex).as_any_origin()
+    var regex_ptr = UnsafePointer(to=regex).as_unsafe_any_origin()
     var node = ASTNode[regex_origin](
         type=GROUP,
         regex_ptr=regex_ptr,

--- a/src/regex/literal_optimizer.mojo
+++ b/src/regex/literal_optimizer.mojo
@@ -54,7 +54,7 @@ struct LiteralInfo[node_origin: ImmutOrigin](
         is_required: Bool = True,
     ):
         """Initialize a LiteralInfo with a string literal."""
-        self.node_ptr = UnsafePointer(to=node).as_any_origin()
+        self.node_ptr = UnsafePointer(to=node).as_unsafe_any_origin()
         self.has_node = True
         self.literal_string_idx = -1
         self.start_offset = start_offset

--- a/src/regex/matcher.mojo
+++ b/src/regex/matcher.mojo
@@ -1151,7 +1151,7 @@ def _init_regex_cache() -> RegexCache:
 def _get_regex_cache() -> UnsafePointer[RegexCache, MutAnyOrigin]:
     """Returns an pointer to the global regex cache."""
     try:
-        return _CACHE_GLOBAL.get_or_create_ptr()
+        return _CACHE_GLOBAL.get_or_create_ptr().as_unsafe_any_origin()
     except e:
         abort[prefix="ERROR:"](String(e))
 
@@ -1204,7 +1204,7 @@ def _init_last_sub_cache() -> _LastSubCache:
 
 def _get_last_sub_cache() -> UnsafePointer[_LastSubCache, MutAnyOrigin]:
     try:
-        return _LAST_SUB_CACHE_GLOBAL.get_or_create_ptr()
+        return _LAST_SUB_CACHE_GLOBAL.get_or_create_ptr().as_unsafe_any_origin()
     except e:
         abort[prefix="ERROR:"](String(e))
 

--- a/src/regex/matching.mojo
+++ b/src/regex/matching.mojo
@@ -120,7 +120,7 @@ struct MatchList(Copyable, Movable, Sized):
         if self._capacity > 0:
             memcpy(dest=new_data, src=self._data, count=len(self))
             self._data.free()
-        self._data = new_data
+        self._data = new_data.as_unsafe_any_origin()
         self._capacity = new_capacity
 
     def append(

--- a/src/regex/parser.mojo
+++ b/src/regex/parser.mojo
@@ -502,7 +502,7 @@ def parse(pattern: String) raises -> ASTNode[ImmutAnyOrigin]:
     # Use the heap-allocated regex pointer directly
     var re_root = ASTNode[ImmutAnyOrigin](
         type=RE,
-        regex_ptr=regex_ptr,
+        regex_ptr=regex_ptr.as_unsafe_any_origin(),
         start_idx=0,
         end_idx=pattern.byte_length(),
         children_indexes=_make_children_indexes(root_child_index),

--- a/src/regex/simd_matchers.mojo
+++ b/src/regex/simd_matchers.mojo
@@ -390,7 +390,7 @@ def _init_range_matchers() -> RangeMatchers:
 def _get_range_matchers() -> UnsafePointer[RangeMatchers, MutAnyOrigin]:
     """Returns a pointer to the global range matchers dictionary."""
     try:
-        return _RANGE_MATCHERS_GLOBAL.get_or_create_ptr()
+        return _RANGE_MATCHERS_GLOBAL.get_or_create_ptr().as_unsafe_any_origin()
     except e:
         abort[prefix="ERROR:"](String(e))
 
@@ -411,7 +411,9 @@ def _init_nibble_matchers() -> NibbleMatchers:
 def _get_nibble_matchers() -> UnsafePointer[NibbleMatchers, MutAnyOrigin]:
     """Returns a pointer to the global nibble matchers dictionary."""
     try:
-        return _NIBBLE_MATCHERS_GLOBAL.get_or_create_ptr()
+        return (
+            _NIBBLE_MATCHERS_GLOBAL.get_or_create_ptr().as_unsafe_any_origin()
+        )
     except e:
         abort[prefix="ERROR:"](String(e))
 

--- a/src/regex/simd_ops.mojo
+++ b/src/regex/simd_ops.mojo
@@ -1115,7 +1115,7 @@ def _init_simd_matchers() -> SIMDMatchers:
 def _get_simd_matchers() -> UnsafePointer[SIMDMatchers, MutAnyOrigin]:
     """Returns a pointer to the global SIMD matchers dictionary."""
     try:
-        return _SIMD_MATCHERS_GLOBAL.get_or_create_ptr()
+        return _SIMD_MATCHERS_GLOBAL.get_or_create_ptr().as_unsafe_any_origin()
     except e:
         abort[prefix="ERROR:"](String(e))
 

--- a/tests/test_ast.mojo
+++ b/tests/test_ast.mojo
@@ -30,7 +30,7 @@ from regex.ast import (
 def test_ASTNode() raises:
     var pattern = String("")
     var regex = Regex[ImmutAnyOrigin](pattern)
-    var regex_ptr = UnsafePointer(to=regex)
+    var regex_ptr = UnsafePointer(to=regex).as_unsafe_any_origin()
     var ast_node = ASTNode[ImmutAnyOrigin](
         type=ELEMENT, regex_ptr=regex_ptr, start_idx=0, end_idx=0
     )


### PR DESCRIPTION
## What

Pins the toolchain to mojo `1.0.0b3.dev2026061506` (max-nightly channel) and resolves the deprecation warnings introduced by [modular/modular@896e4bb](https://github.com/modular/modular/commit/896e4bb3821516e0611094c8f4bf38a7172c070c), which deprecates implicit `UnsafePointer` conversion to `UnsafeAnyOrigin` and renames `as_any_origin()` to `as_unsafe_any_origin()`.

## Changes

Two warning classes, all 20 resolved:

**1. `as_any_origin()` -> `as_unsafe_any_origin()` rename (12 sites)**
- The 11 AST node builders in `ast.mojo` (`Element`, `WildcardElement`, `SpaceElement`, `DigitElement`, `WordElement`, `RangeElement`, `StartElement`, `EndElement`, `OrNode`, `NotNode`, `GroupNode`).
- `LiteralInfo.__init__` in `literal_optimizer.mojo`.

**2. Implicit concrete-origin -> any-origin conversions made explicit (8 sites)**
- The five `_Global.get_or_create_ptr()` cache accessors: `_get_regex_cache`, `_get_last_sub_cache` (`matcher.mojo`), `_get_range_matchers`, `_get_nibble_matchers` (`simd_matchers.mojo`), `_get_simd_matchers` (`simd_ops.mojo`).
- The two heap allocations stored into any-origin fields: `Regex.children_ptr` (`ast.mojo`), `MatchList._data` (`matching.mojo`).
- The `regex_ptr` argument in `parser.parse` (`parser.mojo`).
- The test helper in `test_ast.mojo`.

These pointers intentionally erase their origin (self-referential AST nodes, process-global caches), so the explicit `.as_unsafe_any_origin()` cast is the correct fix rather than threading concrete origins through the engine.

## Verification

- All 377 tests pass (`pixi run test`).
- `src/`, `tests/`, and all three benchmark binaries build **warning-free** and error-free.