### PR TITLE
Make LiteralInfo.node_ptr a safe origin-tracked borrow (#57 task 1)

### DIFF
--- a/src/regex/literal_optimizer.mojo
+++ b/src/regex/literal_optimizer.mojo
@@ -21,19 +21,19 @@ from regex.ast import (
 )
 
 
-struct LiteralInfo[node_origin: ImmutOrigin](
-    ImplicitlyCopyable, Movable, TrivialRegisterPassable
-):
-    """Information about a literal substring found in a regex pattern."""
+struct LiteralInfo[node_origin: ImmutOrigin](ImplicitlyCopyable, Movable):
+    """Information about a literal substring found in a regex pattern.
 
-    var node_ptr: UnsafePointer[ASTNode[ImmutAnyOrigin], ImmutAnyOrigin]
-    """Pointer to the AST node containing the literal (for single nodes).
-    Only meaningful when `has_node` is True; otherwise dangling."""
-    var has_node: Bool
-    """True when `node_ptr` references a real AST node. Tracked
-    separately because 1.0.0b1 forbids null UnsafePointer, and
-    LiteralInfo must stay TrivialRegisterPassable (which rules out
-    `Optional[UnsafePointer[...]]` here)."""
+    Built only during regex compilation (pattern analysis), never on the
+    per-match hot path, so it does not need to stay `TrivialRegisterPassable`;
+    that lets `node_ptr` be a safe `Optional[Pointer[...]]` borrow instead of
+    a raw `UnsafePointer`."""
+
+    var node_ptr: Optional[Pointer[ASTNode[ImmutAnyOrigin], Self.node_origin]]
+    """Origin-tracked borrow of the AST node containing the literal (for
+    single nodes). `None` when this LiteralInfo refers to a string-index
+    literal instead. The borrow rides `node_origin`, so the compiler keeps
+    the referenced node alive for us; no AnyOrigin escape hatch."""
     var literal_string_idx: Int
     """Index into LiteralSet.literal_strings for the literal string (for concatenated literals or computed values). -1 if not used."""
     var start_offset: Int
@@ -54,8 +54,7 @@ struct LiteralInfo[node_origin: ImmutOrigin](
         is_required: Bool = True,
     ):
         """Initialize a LiteralInfo with a string literal."""
-        self.node_ptr = UnsafePointer(to=node).as_unsafe_any_origin()
-        self.has_node = True
+        self.node_ptr = Pointer(to=node)
         self.literal_string_idx = -1
         self.start_offset = start_offset
         self.is_prefix = is_prefix
@@ -71,10 +70,7 @@ struct LiteralInfo[node_origin: ImmutOrigin](
         is_required: Bool = True,
     ):
         """Initialize a LiteralInfo with a string literal index."""
-        self.node_ptr = UnsafePointer[
-            ASTNode[ImmutAnyOrigin], ImmutAnyOrigin
-        ].unsafe_dangling()
-        self.has_node = False
+        self.node_ptr = None
         self.literal_string_idx = literal_string_idx
         self.start_offset = start_offset
         self.is_prefix = is_prefix
@@ -96,9 +92,9 @@ struct LiteralInfo[node_origin: ImmutOrigin](
 
     def get_literal(self, literal_set: LiteralSet[Self.node_origin]) -> String:
         """Get the literal string."""
-        if self.has_node and self.node_ptr[].get_value():
+        if self.node_ptr and self.node_ptr.value()[].get_value():
             # If we have an AST node, use its value
-            return String(self.node_ptr[].get_value().value())
+            return String(self.node_ptr.value()[].get_value().value())
         elif self.literal_string_idx >= 0:
             # If we have a literal string index, get it from the set
             return literal_set.literal_strings[self.literal_string_idx]
@@ -108,8 +104,8 @@ struct LiteralInfo[node_origin: ImmutOrigin](
 
     def get_literal_len(self, literal_set: LiteralSet[Self.node_origin]) -> Int:
         """Get the length of the literal string."""
-        if self.has_node and self.node_ptr[].get_value():
-            return self.node_ptr[].get_value().value().byte_length()
+        if self.node_ptr and self.node_ptr.value()[].get_value():
+            return self.node_ptr.value()[].get_value().value().byte_length()
         elif self.literal_string_idx >= 0:
             return literal_set.literal_strings[
                 self.literal_string_idx


### PR DESCRIPTION
First task of the issue #57 unsafe-pointer cleanup, applying the origin-tracking pattern from [modular/modular@67bdc228](https://github.com/modular/modular/commit/67bdc228a2cfc4a958484dae1be0fc9aa85914e4) and [@fd460d0b](https://github.com/modular/modular/commit/fd460d0b97c54f293935fdb75535e49c9900b6bb).

## What

`LiteralInfo` already carries a `node_origin` parameter and its constructor already takes `ref[node_origin] node` — but it immediately erased that origin, storing the borrow as `UnsafePointer[..., ImmutAnyOrigin]` via `as_unsafe_any_origin()`. `AnyOrigin` is the genuinely unsafe part: it silently extends lifetimes and disables exclusivity checking.

This replaces the field with a safe, origin-tracked borrow:

```mojo
# before
var node_ptr: UnsafePointer[ASTNode[ImmutAnyOrigin], ImmutAnyOrigin]
var has_node: Bool
# after
var node_ptr: Optional[Pointer[ASTNode[ImmutAnyOrigin], node_origin]]
```

The borrow now rides the concrete `node_origin`, so the compiler tracks the referenced node's lifetime. The "no node" case (string-index literals) becomes the `Optional` `None` niche, which also retires the separate `has_node` bool that only existed because a raw `UnsafePointer` cannot be null. `Pointer` is the same one-word representation as `UnsafePointer`, so this is zero-cost.

## Trait change is safe

`Optional[Pointer[...]]` is not `TrivialRegisterPassable`, so that trait is dropped from `LiteralInfo`. This is safe: `LiteralInfo`/`LiteralSet` are built **only during regex compilation** (pattern analysis in `CompiledRegex.__init__`, `NFAEngine.__init__`, `analyze_optimizations`), never on the per-match hot path, and compiled regexes are cached. No runtime matching path is affected.

## Verification

- All 377 tests pass (`pixi run test`).
- `src/`, `tests/`, and all three benchmark binaries build warning-free and error-free.