### PR TITLE
Thread text origin through Match: compiler-tracked match lifetimes (#57 task 2)

### DIFF
--- a/src/regex/dfa.mojo
+++ b/src/regex/dfa.mojo
@@ -5,7 +5,7 @@ This module provides O(n) time complexity regex matching for simple patterns tha
 compiled to DFA, as opposed to the exponential worst-case of NFA backtracking.
 """
 
-from regex.aliases import ALL_EXCEPT_NEWLINE, ImmSlice, WORD_CHARS
+from regex.aliases import ALL_EXCEPT_NEWLINE, WORD_CHARS
 from regex.ast import (
     ASTNode,
     DIGIT,
@@ -1786,7 +1786,9 @@ struct DFAEngine(Engine):
         return self.literal_pattern
 
     @always_inline
-    def is_match(self, text: ImmSlice, start: Int = 0) -> Bool:
+    def is_match[
+        O: ImmutOrigin
+    ](self, text: StringSlice[O], start: Int = 0) -> Bool:
         """Check if pattern matches at the given position without computing
         match boundaries. Much faster than match_first for simple checks.
 
@@ -1821,7 +1823,9 @@ struct DFAEngine(Engine):
         )
 
     @always_inline
-    def match_first(self, text: ImmSlice, start: Int = 0) -> Optional[Match]:
+    def match_first[
+        O: ImmutOrigin
+    ](self, text: StringSlice[O], start: Int = 0) -> Optional[Match[O]]:
         """Execute DFA matching against input text. To be Python compatible,
         it will not match if the start position is not at the beginning of a line.
 
@@ -1842,7 +1846,9 @@ struct DFAEngine(Engine):
         )
 
     @always_inline
-    def match_next(self, text: ImmSlice, start: Int = 0) -> Optional[Match]:
+    def match_next[
+        O: ImmutOrigin
+    ](self, text: StringSlice[O], start: Int = 0) -> Optional[Match[O]]:
         """Execute DFA matching against input text. It will match from the given start
         position.
 
@@ -1871,12 +1877,14 @@ struct DFAEngine(Engine):
         return None
 
     @always_inline
-    def _try_match_at_position(
+    def _try_match_at_position[
+        O: ImmutOrigin
+    ](
         self,
-        text: ImmSlice,
+        text: StringSlice[O],
         start_pos: Int,
         require_exact_position: Bool = False,
-    ) -> Optional[Match]:
+    ) -> Optional[Match[O]]:
         """Try to match pattern starting at a specific position.
 
         Args:
@@ -1989,7 +1997,7 @@ struct DFAEngine(Engine):
 
         return None
 
-    def match_all(self, text: ImmSlice) -> MatchList:
+    def match_all[O: ImmutOrigin](self, text: StringSlice[O]) -> MatchList[O]:
         """Find all non-overlapping matches using DFA.
 
         Args:
@@ -2002,7 +2010,7 @@ struct DFAEngine(Engine):
         # Skip the hint on short texts where over-allocating wastes more
         # than the grows cost.
         var text_len = text.byte_length()
-        var matches = MatchList(
+        var matches = MatchList[O](
             capacity=text_len >> 7 if text_len >= 1024 else 0
         )
 
@@ -2094,9 +2102,9 @@ struct DFAEngine(Engine):
         return matches^
 
     @always_inline
-    def _try_match_simd(
-        self, text: ImmSlice, start_pos: Int
-    ) -> Optional[Match]:
+    def _try_match_simd[
+        O: ImmutOrigin
+    ](self, text: StringSlice[O], start_pos: Int) -> Optional[Match[O]]:
         """SIMD-optimized matching for character class patterns with quantifier support.
 
         This hybrid approach uses SIMD for fast character matching while respecting
@@ -2161,9 +2169,9 @@ struct DFAEngine(Engine):
         return None
 
     @always_inline
-    def _optimized_simd_search(
-        self, text: ImmSlice, start: Int
-    ) -> Optional[Match]:
+    def _optimized_simd_search[
+        O: ImmutOrigin
+    ](self, text: StringSlice[O], start: Int) -> Optional[Match[O]]:
         """Optimized SIMD-based search for character class patterns.
 
         Args:
@@ -2216,8 +2224,10 @@ struct DFAEngine(Engine):
 
         return None
 
-    def _find_next_matching_char(
-        self, text: ImmSlice, start: Int, simd_matcher: CharacterClassSIMD
+    def _find_next_matching_char[
+        O: ImmutOrigin
+    ](
+        self, text: StringSlice[O], start: Int, simd_matcher: CharacterClassSIMD
     ) -> Int:
         """Use SIMD to find the next character that matches the character class.
 

--- a/src/regex/engine.mojo
+++ b/src/regex/engine.mojo
@@ -1,4 +1,3 @@
-from regex.aliases import ImmSlice
 from regex.matching import Match, MatchList
 
 
@@ -11,7 +10,9 @@ trait Engine(Copyable, Movable):
         """
         ...
 
-    def match_first(self, text: ImmSlice, start: Int = 0) -> Optional[Match]:
+    def match_first[
+        O: ImmutOrigin
+    ](self, text: StringSlice[O], start: Int = 0) -> Optional[Match[O]]:
         """Execute DFA matching against input text. To be Python compatible,
         it will not match if the start position is not at the beginning of a line.
 
@@ -24,7 +25,7 @@ trait Engine(Copyable, Movable):
         """
         ...
 
-    def match_all(self, text: ImmSlice) -> MatchList:
+    def match_all[O: ImmutOrigin](self, text: StringSlice[O]) -> MatchList[O]:
         """Find all non-overlapping matches using Engine.
 
         Args:

--- a/src/regex/matcher.mojo
+++ b/src/regex/matcher.mojo
@@ -180,7 +180,9 @@ def check_ast_for_anchors(ast: ASTNode[MutAnyOrigin]) -> Bool:
 trait RegexMatcher:
     """Interface for different regex matching engines."""
 
-    def match_first(self, text: ImmSlice, start: Int = 0) -> Optional[Match]:
+    def match_first[
+        O: ImmutOrigin
+    ](self, text: StringSlice[O], start: Int = 0) -> Optional[Match[O]]:
         """Find the first match in text starting from the given position.
 
         Args:
@@ -192,7 +194,9 @@ trait RegexMatcher:
         """
         ...
 
-    def match_all(self, text: ImmSlice) raises -> MatchList:
+    def match_all[
+        O: ImmutOrigin
+    ](self, text: StringSlice[O]) raises -> MatchList[O]:
         """Find all non-overlapping matches in text.
 
         Args:
@@ -245,16 +249,22 @@ struct DFAMatcher(Boolable, Copyable, Movable, RegexMatcher):
         return self.engine_ptr.value()[].is_match(text, start)
 
     @always_inline
-    def match_first(self, text: ImmSlice, start: Int = 0) -> Optional[Match]:
+    def match_first[
+        O: ImmutOrigin
+    ](self, text: StringSlice[O], start: Int = 0) -> Optional[Match[O]]:
         """Find first match using DFA execution."""
         return self.engine_ptr.value()[].match_first(text, start)
 
     @always_inline
-    def match_next(self, text: ImmSlice, start: Int = 0) -> Optional[Match]:
+    def match_next[
+        O: ImmutOrigin
+    ](self, text: StringSlice[O], start: Int = 0) -> Optional[Match[O]]:
         """Find first match using DFA execution."""
         return self.engine_ptr.value()[].match_next(text, start)
 
-    def match_all(self, text: ImmSlice) raises -> MatchList:
+    def match_all[
+        O: ImmutOrigin
+    ](self, text: StringSlice[O]) raises -> MatchList[O]:
         """Find all matches using DFA execution."""
         return self.engine_ptr.value()[].match_all(text)
 
@@ -347,7 +357,9 @@ struct NFAMatcher(Copyable, Movable, RegexMatcher):
             ptr.free()
 
     @always_inline
-    def match_first(self, text: ImmSlice, start: Int = 0) -> Optional[Match]:
+    def match_first[
+        O: ImmutOrigin
+    ](self, text: StringSlice[O], start: Int = 0) -> Optional[Match[O]]:
         """Find first match. Routing order:
         - LazyDFA when available and the pattern has no `$` anchor
           (cached is_match is position-dependent otherwise).
@@ -396,7 +408,9 @@ struct NFAMatcher(Copyable, Movable, RegexMatcher):
         return Bool(self._lazy_dfa_ptr) and self._nfa_fast_paths_absent()
 
     @always_inline
-    def match_next(self, text: ImmSlice, start: Int = 0) -> Optional[Match]:
+    def match_next[
+        O: ImmutOrigin
+    ](self, text: StringSlice[O], start: Int = 0) -> Optional[Match[O]]:
         """Search for match."""
         if self._use_lazy_dfa_for_search():
             return self._lazy_dfa_ptr.value()[].match_next(text, start)
@@ -405,7 +419,9 @@ struct NFAMatcher(Copyable, Movable, RegexMatcher):
         return self.engine.match_next(text, start)
 
     @always_inline
-    def match_all(self, text: ImmSlice) raises -> MatchList:
+    def match_all[
+        O: ImmutOrigin
+    ](self, text: StringSlice[O]) raises -> MatchList[O]:
         """Find all matches."""
         if self._use_lazy_dfa_for_search():
             return self._lazy_dfa_ptr.value()[].match_all(text)
@@ -714,7 +730,9 @@ struct HybridMatcher(Copyable, Movable, RegexMatcher):
         return Bool(self.nfa_matcher.match_first(text, start))
 
     @always_inline
-    def match_first(self, text: ImmSlice, start: Int = 0) -> Optional[Match]:
+    def match_first[
+        O: ImmutOrigin
+    ](self, text: StringSlice[O], start: Int = 0) -> Optional[Match[O]]:
         """Find first match using optimal engine. This equivalent to re.match in Python.
         """
 
@@ -734,7 +752,9 @@ struct HybridMatcher(Copyable, Movable, RegexMatcher):
             return self.nfa_matcher.match_first(text, start)
 
     @always_inline
-    def match_next(self, text: ImmSlice, start: Int = 0) -> Optional[Match]:
+    def match_next[
+        O: ImmutOrigin
+    ](self, text: StringSlice[O], start: Int = 0) -> Optional[Match[O]]:
         """Find first match using optimal engine. This is equivalent to re.search in Python.
         """
         # Fast path: Wildcard match any (.* pattern) always matches from start to end
@@ -780,18 +800,20 @@ struct HybridMatcher(Copyable, Movable, RegexMatcher):
         else:
             return self.nfa_matcher.match_next(text, start)
 
-    def match_all(self, text: ImmSlice) raises -> MatchList:
+    def match_all[
+        O: ImmutOrigin
+    ](self, text: StringSlice[O]) raises -> MatchList[O]:
         """Find all matches using optimal engine."""
         # Fast path: Wildcard match any (.* pattern) matches entire text once
         if self.is_wildcard_match_any:
-            var matches = MatchList(capacity=1)
+            var matches = MatchList[O](capacity=1)
             if text.byte_length() >= 0:  # .* matches even empty strings
                 matches.append(Match(0, 0, text.byte_length(), text))
             return matches^
         # Fast path: Exact literal patterns without anchors
         if self.is_exact_literal and not self.literal_info.has_anchors:
             var text_len = text.byte_length()
-            var matches = MatchList(
+            var matches = MatchList[O](
                 capacity=text_len >> 7 if text_len >= 1024 else 0
             )
             var best_literal = self.literal_info.get_best_required_literal()
@@ -838,10 +860,12 @@ struct HybridMatcher(Copyable, Movable, RegexMatcher):
         else:
             return self.nfa_matcher.match_all(text)
 
-    def _match_all_required_byte(self, text: ImmSlice) raises -> MatchList:
+    def _match_all_required_byte[
+        O: ImmutOrigin
+    ](self, text: StringSlice[O]) raises -> MatchList[O]:
         """findall fast path for patterns with a rare required byte."""
         var text_len = text.byte_length()
-        var matches = MatchList(
+        var matches = MatchList[O](
             capacity=text_len >> 7 if text_len >= 1024 else 0
         )
         var text_ptr = text.unsafe_ptr()
@@ -1019,7 +1043,9 @@ struct CompiledRegex(ImplicitlyCopyable, Movable):
     #     )
 
     @always_inline
-    def match_first(self, text: ImmSlice, start: Int = 0) -> Optional[Match]:
+    def match_first[
+        O: ImmutOrigin
+    ](self, text: StringSlice[O], start: Int = 0) -> Optional[Match[O]]:
         """Find first match in text. This is equivalent to re.match in Python.
 
         Args:
@@ -1032,7 +1058,9 @@ struct CompiledRegex(ImplicitlyCopyable, Movable):
         return self.matcher.match_first(text, start)
 
     @always_inline
-    def match_next(self, text: ImmSlice, start: Int = 0) -> Optional[Match]:
+    def match_next[
+        O: ImmutOrigin
+    ](self, text: StringSlice[O], start: Int = 0) -> Optional[Match[O]]:
         """Find first match in text. This is equivalent to re.search in Python.
 
         Args:
@@ -1044,7 +1072,9 @@ struct CompiledRegex(ImplicitlyCopyable, Movable):
         """
         return self.matcher.match_next(text, start)
 
-    def match_all(self, text: ImmSlice) raises -> MatchList:
+    def match_all[
+        O: ImmutOrigin
+    ](self, text: StringSlice[O]) raises -> MatchList[O]:
         """Find all matches in text.
 
         Args:
@@ -1289,7 +1319,9 @@ def clear_regex_cache():
 
 
 # High-level convenience functions that match Python's re module interface
-def search(pattern: ImmSlice, text: ImmSlice) raises -> Optional[Match]:
+def search[
+    O: ImmutOrigin
+](pattern: ImmSlice, text: StringSlice[O]) raises -> Optional[Match[O]]:
     """Search for pattern in text (equivalent to re.search in Python).
 
     Args:
@@ -1303,7 +1335,9 @@ def search(pattern: ImmSlice, text: ImmSlice) raises -> Optional[Match]:
     return compiled_ptr[].match_next(text)
 
 
-def findall(pattern: ImmSlice, text: ImmSlice) raises -> MatchList:
+def findall[
+    O: ImmutOrigin
+](pattern: ImmSlice, text: StringSlice[O]) raises -> MatchList[O]:
     """Find all matches of pattern in text (equivalent to re.findall in Python).
 
     Args:
@@ -1317,7 +1351,9 @@ def findall(pattern: ImmSlice, text: ImmSlice) raises -> MatchList:
     return compiled_ptr[].match_all(text)
 
 
-def match_first(pattern: ImmSlice, text: ImmSlice) raises -> Optional[Match]:
+def match_first[
+    O: ImmutOrigin
+](pattern: ImmSlice, text: StringSlice[O]) raises -> Optional[Match[O]]:
     """Match pattern at beginning of text (equivalent to re.match in Python).
 
     Args:
@@ -1532,10 +1568,12 @@ def _apply_template_fixed(
 
 
 @always_inline
-def _apply_template_groups(
+def _apply_template_groups[
+    O: ImmutOrigin
+](
     template: List[_ReplSegment],
     repl_ptr: UnsafePointer[Byte, ImmutAnyOrigin],
-    groups: List[Match],
+    groups: List[Match[O]],
     group_idx: InlineArray[Int, 10],
 ) -> String:
     """Apply pre-parsed template using NFA-extracted group matches."""

--- a/src/regex/matching.mojo
+++ b/src/regex/matching.mojo
@@ -1,10 +1,12 @@
 from std.memory import UnsafePointer, memcpy, alloc
 
-from regex.aliases import ImmSlice, imm_slice_from_ptr
 
+struct Match[origin: ImmutOrigin](Copyable, Movable, TrivialRegisterPassable):
+    """Contains the information of a match in a regular expression.
 
-struct Match(Copyable, Movable, TrivialRegisterPassable):
-    """Contains the information of a match in a regular expression."""
+    Parameterized on the origin of the backing text, so the borrow into
+    that text is compiler-tracked: a `Match` cannot outlive the string it
+    points into. No AnyOrigin escape hatch."""
 
     # Trivially copyable in lists
     comptime __copy_ctor_is_trivial = True
@@ -15,44 +17,49 @@ struct Match(Copyable, Movable, TrivialRegisterPassable):
     """Starting position of the match in the text."""
     var end_idx: Int
     """Ending position of the match in the text (exclusive)."""
-    var text_ptr: UnsafePointer[Byte, ImmutAnyOrigin]
-    """Pointer to the start of the backing text bytes. Does not own memory;
-    the caller must keep the backing storage alive for the lifetime of the
-    match. We only store the base pointer (not a full slice) to keep Match
-    at the same 32-byte footprint as before the StringSlice refactor."""
+    var text_ptr: UnsafePointer[Byte, Self.origin]
+    """Origin-tracked pointer to the start of the backing text bytes. Does
+    not own memory; the `origin` parameter ties its lifetime to the source
+    text. We store the base pointer (not a full slice) to keep Match at a
+    32-byte footprint."""
 
     def __init__(
         out self,
         group_id: Int,
         start_idx: Int,
         end_idx: Int,
-        text: ImmSlice,
+        text: StringSlice[Self.origin],
     ):
         self.group_id = group_id
         self.start_idx = start_idx
         self.end_idx = end_idx
         self.text_ptr = text.unsafe_ptr()
 
-    def get_match_text(self) -> ImmSlice:
+    def get_match_text(self) -> StringSlice[Self.origin]:
         """Returns the text that was matched."""
-        return imm_slice_from_ptr(
-            self.text_ptr + self.start_idx,
-            self.end_idx - self.start_idx,
+        return StringSlice[Self.origin](
+            unsafe_from_utf8=Span[Byte, Self.origin](
+                ptr=self.text_ptr + self.start_idx,
+                length=self.end_idx - self.start_idx,
+            )
         )
 
 
-struct MatchList(Copyable, Movable, Sized):
+struct MatchList[origin: ImmutOrigin](Copyable, Movable, Sized):
     """Smart container for regex matches with lazy allocation and optimal reservation.
 
     This struct provides zero allocation until the first match is added, then
     reserves a small amount of capacity to avoid malloc churn for common cases.
     Provides List-compatible interface for easy integration with existing code.
+
+    Parameterized on the backing-text origin it shares with the `Match`
+    elements it stores.
     """
 
     comptime DEFAULT_RESERVE_SIZE = 8
     """Default number of matches to reserve on first allocation."""
 
-    var _data: UnsafePointer[Match, MutAnyOrigin]
+    var _data: UnsafePointer[Match[Self.origin], MutAnyOrigin]
     """Internal list storing the matches. Dangling (and never read
     from) until the first allocation runs through `_realloc`; tracked
     via `_capacity > 0` since 1.0.0b1 forbids null UnsafePointer
@@ -65,7 +72,9 @@ struct MatchList(Copyable, Movable, Sized):
         capacity: Int = 0,
     ):
         """Initialize empty Matches container."""
-        self._data = UnsafePointer[Match, MutAnyOrigin].unsafe_dangling()
+        self._data = UnsafePointer[
+            Match[Self.origin], MutAnyOrigin
+        ].unsafe_dangling()
         self._capacity = 0
         self._len = 0
         if capacity > 0:
@@ -78,7 +87,9 @@ struct MatchList(Copyable, Movable, Sized):
         copy: Self,
     ):
         """Copy constructor."""
-        self._data = UnsafePointer[Match, MutAnyOrigin].unsafe_dangling()
+        self._data = UnsafePointer[
+            Match[Self.origin], MutAnyOrigin
+        ].unsafe_dangling()
         self._len = 0
         self._capacity = 0
         if copy._len > 0:
@@ -99,7 +110,9 @@ struct MatchList(Copyable, Movable, Sized):
         """Return the number of matches."""
         return self._len
 
-    def __getitem__[I: Indexer](ref self, idx: I) -> ref[self] Match:
+    def __getitem__[
+        I: Indexer
+    ](ref self, idx: I) -> ref[self] Match[Self.origin]:
         """Gets the list element at the given index.
 
         Args:
@@ -115,7 +128,7 @@ struct MatchList(Copyable, Movable, Sized):
 
     @no_inline
     def _realloc(mut self, new_capacity: Int):
-        var new_data = alloc[Match](new_capacity)
+        var new_data = alloc[Match[Self.origin]](new_capacity)
 
         if self._capacity > 0:
             memcpy(dest=new_data, src=self._data, count=len(self))
@@ -125,7 +138,7 @@ struct MatchList(Copyable, Movable, Sized):
 
     def append(
         mut self,
-        m: Match,
+        m: Match[Self.origin],
     ):
         """Add a match to the container, reserving capacity on first use."""
         if self._len >= self._capacity:

--- a/src/regex/nfa.mojo
+++ b/src/regex/nfa.mojo
@@ -27,7 +27,6 @@ from regex.aliases import (
     CHAR_Z,
     CHAR_Z_UPPER,
     CHAR_ZERO,
-    ImmSlice,
     SIMD_MATCHER_DIGITS,
     SIMD_MATCHER_WHITESPACE,
     byte_in_string,
@@ -167,10 +166,9 @@ struct NFAEngine(Copyable, Engine):
             )
         return rebind[Span[Byte, ImmutAnyOrigin]](self.pattern.as_bytes())
 
-    def match_all(
-        self,
-        text: ImmSlice,
-    ) -> MatchList:
+    def match_all[
+        O: ImmutOrigin
+    ](self, text: StringSlice[O],) -> MatchList[O]:
         """Searches a regex in a test string.
 
         Searches the passed regular expression in the passed test string and
@@ -196,7 +194,7 @@ struct NFAEngine(Copyable, Engine):
         # Pre-allocate for long-text findall. Skip the hint on short texts
         # where over-allocating wastes more than the grows cost.
         var text_len = text.byte_length()
-        var matches = MatchList(
+        var matches = MatchList[O](
             capacity=text_len >> 7 if text_len >= 1024 else 0
         )
         if not self.prev_ast and not self.regex:
@@ -207,7 +205,7 @@ struct NFAEngine(Copyable, Engine):
         var current_pos = 0
 
         # Smaller temp capacity since we clear frequently
-        var temp_matches = List[Match](capacity=3)
+        var temp_matches = List[Match[O]](capacity=3)
 
         # Fast path for .* prefix patterns in findall.
         # Only safe when no newlines in text (since .* doesn't match \n).
@@ -341,7 +339,9 @@ struct NFAEngine(Copyable, Engine):
 
         return matches^
 
-    def match_first(self, text: ImmSlice, start: Int = 0) -> Optional[Match]:
+    def match_first[
+        O: ImmutOrigin
+    ](self, text: StringSlice[O], start: Int = 0) -> Optional[Match[O]]:
         """Same as match_all, but always returns after the first match.
         Equivalent to re.match in Python.
 
@@ -355,7 +355,7 @@ struct NFAEngine(Copyable, Engine):
             position contains the whole match, and the subsequent positions
             contain all the group and subgroups matched.
         """
-        var matches = List[Match]()
+        var matches = List[Match[O]]()
         var str_i = start
         if not self.regex:
             try:
@@ -388,7 +388,9 @@ struct NFAEngine(Copyable, Engine):
         return None
 
     @always_inline
-    def match_next(self, text: ImmSlice, start: Int = 0) -> Optional[Match]:
+    def match_next[
+        O: ImmutOrigin
+    ](self, text: StringSlice[O], start: Int = 0) -> Optional[Match[O]]:
         """Same as match_all, but always returns after the first match.
         It's equivalent to re.search in Python.
 
@@ -402,7 +404,7 @@ struct NFAEngine(Copyable, Engine):
             position contains the whole match, and the subsequent positions
             contain all the group and subgroups matched.
         """
-        var matches = List[Match]()
+        var matches = List[Match[O]]()
         if not self.regex:
             return None
 
@@ -495,9 +497,11 @@ struct NFAEngine(Copyable, Engine):
 
         return None
 
-    def match_next_with_groups(
-        self, text: ImmSlice, start: Int = 0
-    ) -> Tuple[Optional[Match], List[Match]]:
+    def match_next_with_groups[
+        O: ImmutOrigin
+    ](self, text: StringSlice[O], start: Int = 0) -> Tuple[
+        Optional[Match[O]], List[Match[O]]
+    ]:
         """Like match_next but also returns capture group matches.
 
         Uses literal prefiltering when available to skip non-matching
@@ -507,13 +511,13 @@ struct NFAEngine(Copyable, Engine):
             Tuple of (overall_match, group_matches). group_matches contains
             Match objects with group_id set to the 1-based capture group index.
         """
-        var empty_groups = List[Match]()
+        var empty_groups = List[Match[O]]()
         if not self.prev_ast and not self.regex:
             return (None, empty_groups^)
         ref ast = self.prev_ast.value() if self.prev_ast else self.regex.value()
 
         var search_pos = start
-        var matches = List[Match](capacity=8)
+        var matches = List[Match[O]](capacity=8)
 
         # Use literal prefiltering to skip positions when available
         if self.has_literal_optimization:
@@ -570,7 +574,9 @@ struct NFAEngine(Copyable, Engine):
         return (None, empty_groups^)
 
     @always_inline
-    def _find_last_literal(self, text: ImmSlice, start: Int) -> Int:
+    def _find_last_literal[
+        O: ImmutOrigin
+    ](self, text: StringSlice[O], start: Int) -> Int:
         """Find the last occurrence of the literal prefix in text from start."""
         # Use rfind for O(n) reverse search instead of repeated forward search
         var pos = text.rfind(self.literal_prefix)
@@ -631,9 +637,9 @@ struct NFAEngine(Copyable, Engine):
             return get_character_class_matcher(range_pattern)
 
     @always_inline
-    def _match_contains_literal(
-        self, text: ImmSlice, start: Int, end: Int
-    ) -> Bool:
+    def _match_contains_literal[
+        O: ImmutOrigin
+    ](self, text: StringSlice[O], start: Int, end: Int) -> Bool:
         """Verify that a match contains the required literal."""
         if (
             not self.has_literal_optimization
@@ -646,12 +652,14 @@ struct NFAEngine(Copyable, Engine):
         return pos != -1 and pos + self.literal_prefix.byte_length() <= end
 
     @always_inline
-    def _match_node(
+    def _match_node[
+        O: ImmutOrigin
+    ](
         self,
         ast: ASTNode,
-        str: ImmSlice,
+        str: StringSlice[O],
         str_i: Int,
-        mut matches: List[Match],
+        mut matches: List[Match[O]],
         match_first_mode: Bool = False,
         required_start_pos: Int = -1,
     ) capturing -> Tuple[Bool, Int]:
@@ -744,10 +752,12 @@ struct NFAEngine(Copyable, Engine):
             return (False, str_i)
 
     @always_inline
-    def _match_element(
+    def _match_element[
+        O: ImmutOrigin
+    ](
         self,
         ast: ASTNode,
-        str: ImmSlice,
+        str: StringSlice[O],
         str_i: Int,
         match_first_mode: Bool,
         required_start_pos: Int,
@@ -769,10 +779,12 @@ struct NFAEngine(Copyable, Engine):
             return (False, str_i)
 
     @always_inline
-    def _match_wildcard(
+    def _match_wildcard[
+        O: ImmutOrigin
+    ](
         self,
         ast: ASTNode,
-        str: ImmSlice,
+        str: StringSlice[O],
         str_i: Int,
         match_first_mode: Bool,
         required_start_pos: Int,
@@ -791,10 +803,12 @@ struct NFAEngine(Copyable, Engine):
             return (False, str_i)
 
     @always_inline
-    def _match_space(
+    def _match_space[
+        O: ImmutOrigin
+    ](
         self,
         ast: ASTNode,
-        str: ImmSlice,
+        str: StringSlice[O],
         str_i: Int,
         match_first_mode: Bool,
         required_start_pos: Int,
@@ -821,10 +835,12 @@ struct NFAEngine(Copyable, Engine):
             return (False, str_i)
 
     @always_inline
-    def _match_digit(
+    def _match_digit[
+        O: ImmutOrigin
+    ](
         self,
         ast: ASTNode,
-        str: ImmSlice,
+        str: StringSlice[O],
         str_i: Int,
         match_first_mode: Bool,
         required_start_pos: Int,
@@ -861,10 +877,12 @@ struct NFAEngine(Copyable, Engine):
                 return (False, str_i)
 
     @always_inline
-    def _match_word(
+    def _match_word[
+        O: ImmutOrigin
+    ](
         self,
         ast: ASTNode,
-        str: ImmSlice,
+        str: StringSlice[O],
         str_i: Int,
         match_first_mode: Bool,
         required_start_pos: Int,
@@ -906,10 +924,12 @@ struct NFAEngine(Copyable, Engine):
                 return (False, str_i)
 
     @always_inline
-    def _match_range(
+    def _match_range[
+        O: ImmutOrigin
+    ](
         self,
         ast: ASTNode,
-        str: ImmSlice,
+        str: StringSlice[O],
         str_i: Int,
         match_first_mode: Bool,
         required_start_pos: Int,
@@ -980,21 +1000,25 @@ struct NFAEngine(Copyable, Engine):
             return (False, str_i)
 
     @always_inline
-    def _match_end(
-        self, ast: ASTNode, str: ImmSlice, str_i: Int
-    ) capturing -> Tuple[Bool, Int]:
+    def _match_end[
+        O: ImmutOrigin
+    ](self, ast: ASTNode, str: StringSlice[O], str_i: Int) capturing -> Tuple[
+        Bool, Int
+    ]:
         """Match end anchor ($)."""
         if str_i == str.byte_length():
             return (True, str_i)
         else:
             return (False, str_i)
 
-    def _match_or(
+    def _match_or[
+        O: ImmutOrigin
+    ](
         self,
         ast: ASTNode,
-        str: ImmSlice,
+        str: StringSlice[O],
         str_i: Int,
-        mut matches: List[Match],
+        mut matches: List[Match[O]],
         match_first_mode: Bool,
         required_start_pos: Int,
     ) capturing -> Tuple[Bool, Int]:
@@ -1025,12 +1049,14 @@ struct NFAEngine(Copyable, Engine):
         )
         return right_result
 
-    def _match_group(
+    def _match_group[
+        O: ImmutOrigin
+    ](
         self,
         ast: ASTNode,
-        str: ImmSlice,
+        str: StringSlice[O],
         str_i: Int,
-        mut matches: List[Match],
+        mut matches: List[Match[O]],
         match_first_mode: Bool,
         required_start_pos: Int,
     ) capturing -> Tuple[Bool, Int]:
@@ -1071,12 +1097,14 @@ struct NFAEngine(Copyable, Engine):
 
         return result
 
-    def _match_group_with_quantifier(
+    def _match_group_with_quantifier[
+        O: ImmutOrigin
+    ](
         self,
         ast: ASTNode,
-        str: ImmSlice,
+        str: StringSlice[O],
         str_i: Int,
-        mut matches: List[Match],
+        mut matches: List[Match[O]],
         match_first_mode: Bool,
         required_start_pos: Int,
     ) capturing -> Tuple[Bool, Int]:
@@ -1122,13 +1150,15 @@ struct NFAEngine(Copyable, Engine):
         else:
             return (False, str_i)
 
-    def _match_sequence(
+    def _match_sequence[
+        O: ImmutOrigin
+    ](
         self,
         ast_parent: ASTNode,
         child_index: Int,
-        str: ImmSlice,
+        str: StringSlice[O],
         str_i: Int,
-        mut matches: List[Match],
+        mut matches: List[Match[O]],
         match_first_mode: Bool,
         required_start_pos: Int,
     ) capturing -> Tuple[Bool, Int]:
@@ -1193,14 +1223,16 @@ struct NFAEngine(Copyable, Engine):
         return ast.min != 1 or ast.max != 1
 
     @always_inline
-    def _match_with_backtracking(
+    def _match_with_backtracking[
+        O: ImmutOrigin
+    ](
         self,
         quantified_node: ASTNode,
         ast_parent: ASTNode,
         remaining_index: Int,
-        str: ImmSlice,
+        str: StringSlice[O],
         str_i: Int,
-        mut matches: List[Match],
+        mut matches: List[Match[O]],
         match_first_mode: Bool,
         required_start_pos: Int,
     ) capturing -> Tuple[Bool, Int]:
@@ -1273,10 +1305,12 @@ struct NFAEngine(Copyable, Engine):
         return (False, str_i)
 
     @always_inline
-    def _try_match_count(
+    def _try_match_count[
+        O: ImmutOrigin
+    ](
         self,
         ast: ASTNode,
-        str: ImmSlice,
+        str: StringSlice[O],
         str_i: Int,
         count: Int,
         match_first_mode: Bool,
@@ -1309,12 +1343,14 @@ struct NFAEngine(Copyable, Engine):
         else:
             return -1
 
-    def _match_re(
+    def _match_re[
+        O: ImmutOrigin
+    ](
         self,
         ast: ASTNode,
-        str: ImmSlice,
+        str: StringSlice[O],
         str_i: Int,
-        mut matches: List[Match],
+        mut matches: List[Match[O]],
         match_first_mode: Bool,
         required_start_pos: Int,
     ) capturing -> Tuple[Bool, Int]:
@@ -1331,10 +1367,12 @@ struct NFAEngine(Copyable, Engine):
             required_start_pos,
         )
 
-    def _apply_quantifier(
+    def _apply_quantifier[
+        O: ImmutOrigin
+    ](
         self,
         ast: ASTNode,
-        str: ImmSlice,
+        str: StringSlice[O],
         str_i: Int,
         char_consumed: Int,
         match_first_mode: Bool,
@@ -1400,10 +1438,12 @@ struct NFAEngine(Copyable, Engine):
             return (False, str_i)
 
     @always_inline
-    def _apply_quantifier_simd(
+    def _apply_quantifier_simd[
+        O: ImmutOrigin
+    ](
         self,
         ast: ASTNode,
-        str: ImmSlice,
+        str: StringSlice[O],
         str_i: Int,
         min_matches: Int,
         max_matches: Int,
@@ -1620,11 +1660,13 @@ struct NFAEngine(Copyable, Engine):
             return byte_in_string(ch_code, range_pattern)
 
     @always_inline
-    def _quantifier_negated_loop(
+    def _quantifier_negated_loop[
+        O: ImmutOrigin
+    ](
         self,
         matcher: RangeBasedMatcher,
-        str_ptr: UnsafePointer[Byte, ImmutAnyOrigin],
-        str: ImmSlice,
+        str_ptr: UnsafePointer[Byte, O],
+        str: StringSlice[O],
         str_i: Int,
         min_matches: Int,
         max_matches: Int,
@@ -1647,13 +1689,15 @@ struct NFAEngine(Copyable, Engine):
         return (False, str_i)
 
     @always_inline
-    def _quantifier_range_loop(
+    def _quantifier_range_loop[
+        O: ImmutOrigin
+    ](
         self,
         range_start: Int,
         range_end: Int,
         positive_logic: Bool,
-        str_ptr: UnsafePointer[Byte, ImmutAnyOrigin],
-        str: ImmSlice,
+        str_ptr: UnsafePointer[Byte, O],
+        str: StringSlice[O],
         str_i: Int,
         min_matches: Int,
         max_matches: Int,
@@ -1677,7 +1721,9 @@ struct NFAEngine(Copyable, Engine):
         return (False, str_i)
 
 
-def findall(pattern: String, text: ImmSlice) raises -> MatchList:
+def findall[
+    O: ImmutOrigin
+](pattern: String, text: StringSlice[O]) raises -> MatchList[O]:
     """Find all matches of pattern in text (equivalent to re.findall in Python).
 
     Args:
@@ -1691,7 +1737,9 @@ def findall(pattern: String, text: ImmSlice) raises -> MatchList:
     return engine.match_all(text)
 
 
-def match_first(pattern: String, text: ImmSlice) raises -> Optional[Match]:
+def match_first[
+    O: ImmutOrigin
+](pattern: String, text: StringSlice[O]) raises -> Optional[Match[O]]:
     """Match pattern at beginning of text (equivalent to re.match in Python).
 
     Args:

--- a/src/regex/onepass.mojo
+++ b/src/regex/onepass.mojo
@@ -27,7 +27,6 @@ one distinct follow-up closure, the pattern is rejected.
 from std.memory import alloc, UnsafePointer
 
 from regex.matching import Match, MatchList
-from regex.aliases import ImmSlice
 from regex.pikevm import (
     Program,
     Instruction,
@@ -467,7 +466,9 @@ struct OnePassNFA(Copyable, Movable):
         self.has_end_anchor = has_end_anchor
 
     @always_inline
-    def match_first(self, text: ImmSlice, start: Int = 0) -> Optional[Match]:
+    def match_first[
+        O: ImmutOrigin
+    ](self, text: StringSlice[O], start: Int = 0) -> Optional[Match[O]]:
         """Match the pattern starting exactly at `start`. Returns None
         if the pattern cannot match here (e.g. `^` anchor with start > 0,
         or no accepting state reached).
@@ -506,7 +507,9 @@ struct OnePassNFA(Copyable, Movable):
         return None
 
     @always_inline
-    def match_next(self, text: ImmSlice, start: Int = 0) -> Optional[Match]:
+    def match_next[
+        O: ImmutOrigin
+    ](self, text: StringSlice[O], start: Int = 0) -> Optional[Match[O]]:
         """Search for the first match at or after `start` (like
         `re.search`). Honours `^` by only trying position 0."""
         if self.has_start_anchor:
@@ -521,9 +524,9 @@ struct OnePassNFA(Copyable, Movable):
         return None
 
     @always_inline
-    def match_all(self, text: ImmSlice) -> MatchList:
+    def match_all[O: ImmutOrigin](self, text: StringSlice[O]) -> MatchList[O]:
         var text_len = text.byte_length()
-        var matches = MatchList(
+        var matches = MatchList[O](
             capacity=text_len >> 7 if text_len >= 1024 else 0
         )
         if self.has_start_anchor:

--- a/src/regex/pikevm.mojo
+++ b/src/regex/pikevm.mojo
@@ -26,7 +26,7 @@ from regex.ast import (
     END,
 )
 from regex.matching import Match, MatchList
-from regex.aliases import ImmSlice, WORD_CHARS
+from regex.aliases import WORD_CHARS
 from regex.dfa import _expand_character_range
 from regex.simd_ops import build_nibble_tables, find_first_in_nibble_tables
 
@@ -413,12 +413,16 @@ struct PikeVMEngine(Copyable, Movable):
         # Filter is useful if it excludes at least half the byte values
         self.has_filter = matching_bytes < 128
 
-    def match_first(self, text: ImmSlice, start: Int = 0) -> Optional[Match]:
+    def match_first[
+        O: ImmutOrigin
+    ](self, text: StringSlice[O], start: Int = 0) -> Optional[Match[O]]:
         """Match pattern at the given position (like re.match)."""
         return self._run(text, start)
 
     @always_inline
-    def match_next(self, text: ImmSlice, start: Int = 0) -> Optional[Match]:
+    def match_next[
+        O: ImmutOrigin
+    ](self, text: StringSlice[O], start: Int = 0) -> Optional[Match[O]]:
         """Search for pattern anywhere in text (like re.search)."""
         var text_len = len(text)
         if self.has_filter:
@@ -442,10 +446,10 @@ struct PikeVMEngine(Copyable, Movable):
                 return result
         return None
 
-    def match_all(self, text: ImmSlice) -> MatchList:
+    def match_all[O: ImmutOrigin](self, text: StringSlice[O]) -> MatchList[O]:
         """Find all non-overlapping matches (like re.findall)."""
         var text_len = len(text)
-        var matches = MatchList(
+        var matches = MatchList[O](
             capacity=text_len >> 7 if text_len >= 1024 else 0
         )
         var pos = 0
@@ -482,7 +486,9 @@ struct PikeVMEngine(Copyable, Movable):
 
         return matches^
 
-    def _run(self, text: ImmSlice, start: Int) -> Optional[Match]:
+    def _run[
+        O: ImmutOrigin
+    ](self, text: StringSlice[O], start: Int) -> Optional[Match[O]]:
         """Run PikeVM with fixed-size SIMD state tracking.
         Zero heap allocations per step."""
         var text_ptr = text.unsafe_ptr()
@@ -711,7 +717,7 @@ struct LazyDFA(Copyable, Movable):
     @always_inline
     def _find_first_candidate(
         self,
-        text_ptr: UnsafePointer[Byte, ImmutAnyOrigin],
+        text_ptr: UnsafePointer[Byte, _],
         start: Int,
         text_len: Int,
     ) -> Int:
@@ -731,14 +737,16 @@ struct LazyDFA(Copyable, Movable):
         return self.pikevm.is_supported()
 
     @always_inline
-    def match_first(
-        mut self, text: ImmSlice, start: Int = 0
-    ) -> Optional[Match]:
+    def match_first[
+        O: ImmutOrigin
+    ](mut self, text: StringSlice[O], start: Int = 0) -> Optional[Match[O]]:
         """Match at position using cached DFA transitions."""
         return self._run_lazy(text, start)
 
     @always_inline
-    def match_next(mut self, text: ImmSlice, start: Int = 0) -> Optional[Match]:
+    def match_next[
+        O: ImmutOrigin
+    ](mut self, text: StringSlice[O], start: Int = 0) -> Optional[Match[O]]:
         """Search using cached DFA with SIMD first-byte prefilter."""
         var text_len = text.byte_length()
         if self.pikevm.has_filter:
@@ -764,10 +772,12 @@ struct LazyDFA(Copyable, Movable):
         return None
 
     @always_inline
-    def match_all(mut self, text: ImmSlice) -> MatchList:
+    def match_all[
+        O: ImmutOrigin
+    ](mut self, text: StringSlice[O]) -> MatchList[O]:
         """Find all matches using cached DFA."""
         var text_len = text.byte_length()
-        var matches = MatchList(
+        var matches = MatchList[O](
             capacity=text_len >> 7 if text_len >= 1024 else 0
         )
         var pos = 0
@@ -801,7 +811,9 @@ struct LazyDFA(Copyable, Movable):
         return matches^
 
     @always_inline
-    def _run_lazy(mut self, text: ImmSlice, start: Int) -> Optional[Match]:
+    def _run_lazy[
+        O: ImmutOrigin
+    ](mut self, text: StringSlice[O], start: Int) -> Optional[Match[O]]:
         """Run the lazy DFA from a start position."""
         var text_ptr = text.unsafe_ptr()
         var text_len = text.byte_length()

--- a/src/regex/simd_ops.mojo
+++ b/src/regex/simd_ops.mojo
@@ -21,7 +21,6 @@ from std.sys.info import simd_width_of
 from std.ffi import _Global
 
 from regex.aliases import (
-    ImmSlice,
     SIMD_MATCHER_NONE,
     SIMD_MATCHER_WHITESPACE,
     SIMD_MATCHER_DIGITS,
@@ -929,7 +928,9 @@ def _create_word_chars() -> CharacterClassSIMD:
     return CharacterClassSIMD(WORD_CHARS)
 
 
-def verify_match(pattern: Span[Byte, _], text: ImmSlice, pos: Int) -> Bool:
+def verify_match[
+    O: ImmutOrigin
+](pattern: Span[Byte, _], text: StringSlice[O], pos: Int) -> Bool:
     """Verify that pattern matches at given position.
 
     Args:
@@ -953,11 +954,9 @@ def verify_match(pattern: Span[Byte, _], text: ImmSlice, pos: Int) -> Bool:
     return True
 
 
-def simd_search(
-    pattern: Span[Byte, _],
-    text: ImmSlice,
-    start: Int = 0,
-) -> Int:
+def simd_search[
+    O: ImmutOrigin
+](pattern: Span[Byte, _], text: StringSlice[O], start: Int = 0,) -> Int:
     """Search for pattern in text using SIMD acceleration.
 
     Two-byte memchr-style scan: compares text[pos] to pattern[0] AND
@@ -1245,10 +1244,10 @@ def process_text_with_matcher[
 
 
 def apply_quantifier_simd_generic[
-    T: SIMDMatcher
+    T: SIMDMatcher, O: ImmutOrigin
 ](
     matcher: T,
-    text: ImmSlice,
+    text: StringSlice[O],
     start_pos: Int,
     min_matches: Int,
     max_matches: Int,
@@ -1337,11 +1336,9 @@ def find_in_text_simd[
     return -1
 
 
-def twoway_search(
-    pattern: Span[Byte, _],
-    text: ImmSlice,
-    start: Int = 0,
-) -> Int:
+def twoway_search[
+    O: ImmutOrigin
+](pattern: Span[Byte, _], text: StringSlice[O], start: Int = 0,) -> Int:
     """Search for pattern in text using Two-Way algorithm with SIMD.
 
     This is a standalone version of TwoWaySearcher.search() that doesn't require


### PR DESCRIPTION
Task 2 of the issue #57 unsafe-pointer cleanup. The full origin thread requested after the analysis.

## What & why

`Match` stored `UnsafePointer[Byte, ImmutAnyOrigin]` into the backing text, with a docstring warning that *"the caller must keep the backing storage alive for the lifetime of the match"* — an invariant the compiler **could not enforce**, because `AnyOrigin` erases the borrow's lifetime and disables exclusivity checking.

Now `Match[origin]` and `MatchList[origin]` are parameterized on the backing-text origin, threaded from the public API (`findall`/`search`/`match_first`) all the way down through every engine. **A `Match` can no longer outlive the string it points into — the compiler enforces it.** No `AnyOrigin` escape hatch on the match path.

## Why the full thread (not a Match-only change)

The text origin is erased to `ImmutAnyOrigin` at the public API boundary (the `ImmSlice` alias on every `match_*` signature and the `Engine`/`RegexMatcher` traits). Parameterizing `Match` alone would yield `Match[ImmutAnyOrigin]` — no safety gain. The only version with real safety value threads the caller's origin from the boundary down, which is what this does. A boundary-rebuild alternative was rejected because it would copy every match on the `findall` hot path; full threading is **zero runtime cost** since origins are compile-time only.

## Scope (8 files, +288/-166)

- **matching.mojo**: `Match[origin]` stores `UnsafePointer[Byte, origin]` — kept the deliberate **32-byte layout** (origin is compile-time only, so the base pointer stays one word); `get_match_text()` returns `StringSlice[origin]`. `MatchList[origin]` holds `Match[origin]` (its own heap-buffer pointer is unrelated owning storage, left for the #57 owning-pointer task).
- **engine.mojo / matcher.mojo**: `Engine` and `RegexMatcher` trait methods + all matcher structs parametric on `O: ImmutOrigin`.
- **dfa / nfa / pikevm / onepass**: every `match_*` method and the text-threading helpers parametric on `O`, building `Match[O]`. Hot-loop `unsafe_ptr()` locals are untouched (intentional bounds-check elision).
- **simd_ops**: `verify_match`/`simd_search`/`twoway_search`/`apply_quantifier_simd_generic` accept `StringSlice[O]` so engines pass origin-typed text without erasing it.

`sub`/`is_match`/`test` keep `ImmSlice` (they return `String`/`Bool` — no match borrow escapes) and infer `O = ImmutAnyOrigin` when calling the parametric engines, so the replacement path is unchanged.

## Verification

- **Zero runtime cost**: origins erase at compile time, `Match` stays 32 bytes, the benchmark binary is marginally **smaller** (no monomorphization bloat for single-origin callers).
- **No regression**: 3-median interleaved full-suite bench at low load (1.9–2.5) → **-0.33% geomean** (task2 marginally faster). A 7-round focused median on the `sub`/`findall` family (the highest-Match-volume paths) at load 1.56 → **-0.64% geomean**. Apparent per-bench swings are sub-µs noise (they shrink as samples increase and are symmetric).
- All **377 tests pass**; `src/`, `tests/`, and all three benchmark binaries build **warning-free** and error-free.