### PR TITLE
Bump mojo to 1.0.0b3.dev2026062806 + migrate AnyOrigin to UntrackedOrigin

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -32,10 +32,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026061806-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026061806-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026061806-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026061806-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026062806-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026062806-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026062806-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026062806-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
@@ -76,10 +76,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.22-h1a92334_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.1-h1b79a29_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026061806-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026061806-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026061806-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026061806-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026062806-release.conda
+      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026062806-release.conda
+      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026062806-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026062806-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
@@ -133,10 +133,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026061806-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026061806-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026061806-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026061806-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026062806-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026062806-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026062806-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026062806-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
@@ -179,10 +179,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.22-h1a92334_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.1-h1b79a29_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026061806-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026061806-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026061806-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026061806-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026062806-release.conda
+      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026062806-release.conda
+      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026062806-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026062806-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
@@ -585,10 +585,10 @@ packages:
   license_family: Other
   size: 47759
   timestamp: 1774072956767
-- conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026061806-release.conda
+- conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026062806-release.conda
   noarch: python
-  sha256: fa5b9748a0858a415a5e0ea1345847818437bca536ecfd85c94ad169aae140fe
-  md5: 874474ff67e5d9c66499e47746fa4e5e
+  sha256: dfaae72b44ad19644ad90b44e034231baadf7f02791335caaaec97ff2b6c7b10
+  md5: 37d44a6f9eed4d2d2b53c041f5361397
   depends:
   - python >=3.10
   - click >=8.0.0
@@ -598,55 +598,55 @@ packages:
   - platformdirs >=2
   - tomli >=1.1.0
   license: LicenseRef-Modular-Proprietary
-  size: 134697
-  timestamp: 1781765075588
-- conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026061806-release.conda
-  sha256: 7c0535c6e6ff1e6a24c07fc93f9ed4fa2f66b4fb2fc2ff354281931e12ec5c23
-  md5: b01644620b540c3c1cf2f5ae9b350341
+  size: 134645
+  timestamp: 1782628802579
+- conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026062806-release.conda
+  sha256: ea8438bc30ce2bbfdc15f6dfd293d1f6a2347abbb078aa5068f99fadaf9ba2f7
+  md5: 88464b6cc2bb1324351eea2731f245a8
   depends:
   - python >=3.10
-  - mojo-compiler ==1.0.0b3.dev2026061806
-  - mblack ==26.5.0.dev2026061806
+  - mojo-compiler ==1.0.0b3.dev2026062806
+  - mblack ==26.5.0.dev2026062806
   - jupyter_client >=8.6.2,<8.7
   license: LicenseRef-Modular-Proprietary
-  size: 96769531
-  timestamp: 1781765234282
-- conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026061806-release.conda
-  sha256: 46b26c4f389933151f40c52df3b0173eeee6e3a1a90776766c87929dbf92ba81
-  md5: 3a01433bc4ea7f8ff1a488e787efce69
+  size: 114370329
+  timestamp: 1782628970657
+- conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026062806-release.conda
+  sha256: 473fd9954822d04458064fb349d3cd4702fd6a426ad384535f7e492fd198c6a3
+  md5: 71cefdf2277ab5c468a7e2b9875b32db
   depends:
   - python >=3.10
-  - mojo-compiler ==1.0.0b3.dev2026061806
-  - mblack ==26.5.0.dev2026061806
+  - mojo-compiler ==1.0.0b3.dev2026062806
+  - mblack ==26.5.0.dev2026062806
   - jupyter_client >=8.6.2,<8.7
   license: LicenseRef-Modular-Proprietary
-  size: 84790163
-  timestamp: 1781765421492
-- conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026061806-release.conda
-  sha256: 1e1a1fdf8743a4f1047fefe5bb8933c1f08ba5d609a3dabf8898f016ef0bf274
-  md5: 89c4355c82ce492ec9b4650d73414f09
+  size: 99942071
+  timestamp: 1782629175524
+- conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026062806-release.conda
+  sha256: 02a9510b861673629b49b3a39d7f20690dd9bd75201aca519e2a965a2f4e3284
+  md5: 9e07563cb01fe15a30f8f84744c961de
   depends:
-  - mojo-python ==1.0.0b3.dev2026061806
+  - mojo-python ==1.0.0b3.dev2026062806
   license: LicenseRef-Modular-Proprietary
-  size: 81272662
-  timestamp: 1781765270343
-- conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026061806-release.conda
-  sha256: fb9806ee6fab4b9c959b1a494490908270ff625257f5a9fa4425dbd619e02f99
-  md5: 7149269e0608b925a56d3e930d4c1d06
+  size: 81488718
+  timestamp: 1782628993842
+- conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026062806-release.conda
+  sha256: 03c4a79e38a45a8d9857b81bde334c535b4cd92846c3104ff06ccfc1a67d03b1
+  md5: 796f909a7ed7c32c98661769d6c49949
   depends:
-  - mojo-python ==1.0.0b3.dev2026061806
+  - mojo-python ==1.0.0b3.dev2026062806
   license: LicenseRef-Modular-Proprietary
-  size: 62850650
-  timestamp: 1781765406138
-- conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026061806-release.conda
+  size: 62989159
+  timestamp: 1782629181997
+- conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026062806-release.conda
   noarch: python
-  sha256: 098d936f36cba387d05188a8f6c3cb7fb269a1622492ca99b9bde2b33868ca99
-  md5: b8e9cf14a93e5a3b742d1d1d09dbc918
+  sha256: 4b4b39680bebf929e105cccc6266da06f9b3feca020154aa6a049fc176ea2a63
+  md5: 1f384f8afdd161f7b8746e8a935ffc77
   depends:
   - python >=3.10
   license: LicenseRef-Modular-Proprietary
-  size: 24115
-  timestamp: 1781765076881
+  size: 24111
+  timestamp: 1782628802253
 - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
   sha256: 6ed158e4e5dd8f6a10ad9e525631e35cee8557718f83de7a4e3966b1f772c4b1
   md5: e9c622e0d00fa24a6292279af3ab6d06

--- a/pixi.toml
+++ b/pixi.toml
@@ -19,7 +19,7 @@ version = "0.20.0"
 backend = { name = "pixi-build-rattler-build", version = "*" }
 
 [dependencies]
-mojo = "==1.0.0b3.dev2026061806"
+mojo = "==1.0.0b3.dev2026062806"
 
 [tasks]
 test = "bash -c 'status=0; for f in tests/test_*.mojo; do echo \"Running $f...\"; out=$(mktemp -d); mojo build -I ./src -debug-level=line-tables \"$f\" -o \"$out/exe\" && \"$out/exe\" || status=1; rm -rf \"$out\"; done; exit $status'"

--- a/src/regex/ast.mojo
+++ b/src/regex/ast.mojo
@@ -83,17 +83,19 @@ struct Regex[origin: Origin](Copyable, Equatable, Movable, Writable):
     comptime ImmOrigin = ImmutOrigin(Self.origin)
     comptime Immutable = Regex[origin=Self.ImmOrigin]
     var pattern: String
-    var children_ptr: UnsafePointer[ASTNode[ImmutAnyOrigin], MutAnyOrigin]
+    var children_ptr: UnsafePointer[
+        ASTNode[ImmutUntrackedOrigin], MutUntrackedOrigin
+    ]
     var children_len: Int
     """Regex struct for representing a regular expression pattern."""
 
-    def __init__(out self, ref[Self.origin] pattern: String):
+    def __init__(out self, pattern: String):
         """Initialize a Regex with a pattern."""
         self.pattern = pattern
         self.children_len = 0
-        self.children_ptr = alloc[ASTNode[ImmutAnyOrigin]](
+        self.children_ptr = alloc[ASTNode[ImmutUntrackedOrigin]](
             pattern.byte_length() * 2
-        ).as_unsafe_any_origin()  # Allocate enough space for children
+        )  # Allocate enough space for children
 
     @always_inline
     def __eq__[o: Origin](self, other: Regex[origin=o]) -> Bool:
@@ -142,7 +144,7 @@ struct Regex[origin: Origin](Copyable, Equatable, Movable, Writable):
         return rebind[Self.Immutable](self).copy()
 
     @always_inline
-    def get_child(self, i: Int) -> ASTNode[ImmutAnyOrigin]:
+    def get_child(self, i: Int) -> ASTNode[ImmutUntrackedOrigin]:
         """Get the child ASTNode at index `i`."""
         return self.children_ptr[i]
 
@@ -152,7 +154,7 @@ struct Regex[origin: Origin](Copyable, Equatable, Movable, Writable):
         return self.children_len
 
     @always_inline
-    def append_child(mut self, var child: ASTNode[ImmutAnyOrigin]):
+    def append_child(mut self, var child: ASTNode[ImmutUntrackedOrigin]):
         """Append a child ASTNode to the Regex."""
         # print(
         #     "Appending child to Regex at ",
@@ -179,7 +181,9 @@ struct ASTNode[regex_origin: ImmutOrigin](
 
     var type: Int
     """The type of AST node (e.g., ELEMENT, GROUP, RANGE, etc.)."""
-    var regex_ptr: UnsafePointer[Regex[ImmutAnyOrigin], ImmutAnyOrigin]
+    var regex_ptr: UnsafePointer[
+        Regex[ImmutUntrackedOrigin], ImmutUntrackedOrigin
+    ]
     """Pointer to the parent regex object containing the pattern string."""
     var start_idx: Int
     """Starting position of this node in the original pattern string."""
@@ -207,7 +211,9 @@ struct ASTNode[regex_origin: ImmutOrigin](
     def __init__(
         out self,
         type: Int,
-        regex_ptr: UnsafePointer[Regex[ImmutAnyOrigin], ImmutAnyOrigin],
+        regex_ptr: UnsafePointer[
+            Regex[ImmutUntrackedOrigin], ImmutUntrackedOrigin
+        ],
         start_idx: Int,
         end_idx: Int,
         capturing_group: Bool = False,
@@ -234,7 +240,9 @@ struct ASTNode[regex_origin: ImmutOrigin](
 
     def __init__(
         out self,
-        regex_ptr: UnsafePointer[Regex[ImmutAnyOrigin], ImmutAnyOrigin],
+        regex_ptr: UnsafePointer[
+            Regex[ImmutUntrackedOrigin], ImmutUntrackedOrigin
+        ],
         type: Int,
         child_index: UInt16,
         start_idx: Int,
@@ -262,7 +270,9 @@ struct ASTNode[regex_origin: ImmutOrigin](
 
     def __init__(
         out self,
-        regex_ptr: UnsafePointer[Regex[ImmutAnyOrigin], ImmutAnyOrigin],
+        regex_ptr: UnsafePointer[
+            Regex[ImmutUntrackedOrigin], ImmutUntrackedOrigin
+        ],
         type: Int,
         children_indexes: ChildrenIndexes,
         start_idx: Int,
@@ -532,7 +542,7 @@ struct ASTNode[regex_origin: ImmutOrigin](
         return self.get_children_len() > 0
 
     @always_inline
-    def get_child(self, i: Int) -> ASTNode[ImmutAnyOrigin]:
+    def get_child(self, i: Int) -> ASTNode[ImmutUntrackedOrigin]:
         """Get the children of the AST node."""
         return self.regex_ptr[].get_child(Int(self.children_indexes[i] - 1))
 
@@ -552,15 +562,19 @@ struct ASTNode[regex_origin: ImmutOrigin](
 
 @always_inline
 def Element[
-    regex_origin: MutOrigin,
+    regex_origin: Origin,
 ](
-    ref[regex_origin] regex: Regex[ImmutAnyOrigin],
+    ref[regex_origin] regex: Regex[ImmutUntrackedOrigin],
     start_idx: Int,
     end_idx: Int,
-) -> ASTNode[ImmutAnyOrigin]:
+) -> ASTNode[ImmutUntrackedOrigin]:
     """Create an Element node with a value string."""
-    var regex_ptr = UnsafePointer(to=regex).as_unsafe_any_origin()
-    return ASTNode[ImmutAnyOrigin](
+    var regex_ptr = (
+        UnsafePointer(to=regex)
+        .as_immutable()
+        .unsafe_origin_cast[ImmutUntrackedOrigin]()
+    )
+    return ASTNode[ImmutUntrackedOrigin](
         type=ELEMENT,
         regex_ptr=regex_ptr,
         start_idx=start_idx,
@@ -572,15 +586,19 @@ def Element[
 
 @always_inline
 def WildcardElement[
-    regex_origin: ImmutOrigin,
+    regex_origin: Origin,
 ](
-    ref[regex_origin] regex: Regex[ImmutAnyOrigin],
+    ref[regex_origin] regex: Regex[ImmutUntrackedOrigin],
     start_idx: Int,
     end_idx: Int,
-) -> ASTNode[regex_origin]:
+) -> ASTNode[ImmutUntrackedOrigin]:
     """Create a WildcardElement node."""
-    var regex_ptr = UnsafePointer(to=regex).as_unsafe_any_origin()
-    return ASTNode[regex_origin](
+    var regex_ptr = (
+        UnsafePointer(to=regex)
+        .as_immutable()
+        .unsafe_origin_cast[ImmutUntrackedOrigin]()
+    )
+    return ASTNode[ImmutUntrackedOrigin](
         type=WILDCARD,
         regex_ptr=regex_ptr,
         start_idx=start_idx,
@@ -592,15 +610,19 @@ def WildcardElement[
 
 @always_inline
 def SpaceElement[
-    regex_origin: ImmutOrigin,
+    regex_origin: Origin,
 ](
-    ref[regex_origin] regex: Regex[ImmutAnyOrigin],
+    ref[regex_origin] regex: Regex[ImmutUntrackedOrigin],
     start_idx: Int,
     end_idx: Int,
-) -> ASTNode[regex_origin]:
+) -> ASTNode[ImmutUntrackedOrigin]:
     """Create a SpaceElement node."""
-    var regex_ptr = UnsafePointer(to=regex).as_unsafe_any_origin()
-    return ASTNode[regex_origin](
+    var regex_ptr = (
+        UnsafePointer(to=regex)
+        .as_immutable()
+        .unsafe_origin_cast[ImmutUntrackedOrigin]()
+    )
+    return ASTNode[ImmutUntrackedOrigin](
         type=SPACE,
         regex_ptr=regex_ptr,
         start_idx=start_idx,
@@ -612,15 +634,19 @@ def SpaceElement[
 
 @always_inline
 def DigitElement[
-    regex_origin: ImmutOrigin,
+    regex_origin: Origin,
 ](
-    ref[regex_origin] regex: Regex[ImmutAnyOrigin],
+    ref[regex_origin] regex: Regex[ImmutUntrackedOrigin],
     start_idx: Int,
     end_idx: Int,
-) -> ASTNode[regex_origin]:
+) -> ASTNode[ImmutUntrackedOrigin]:
     """Create a DigitElement node."""
-    var regex_ptr = UnsafePointer(to=regex).as_unsafe_any_origin()
-    return ASTNode[regex_origin](
+    var regex_ptr = (
+        UnsafePointer(to=regex)
+        .as_immutable()
+        .unsafe_origin_cast[ImmutUntrackedOrigin]()
+    )
+    return ASTNode[ImmutUntrackedOrigin](
         type=DIGIT,
         regex_ptr=regex_ptr,
         start_idx=start_idx,
@@ -632,15 +658,19 @@ def DigitElement[
 
 @always_inline
 def WordElement[
-    regex_origin: ImmutOrigin,
+    regex_origin: Origin,
 ](
-    ref[regex_origin] regex: Regex[ImmutAnyOrigin],
+    ref[regex_origin] regex: Regex[ImmutUntrackedOrigin],
     start_idx: Int,
     end_idx: Int,
-) -> ASTNode[regex_origin]:
+) -> ASTNode[ImmutUntrackedOrigin]:
     """Create a WordElement node."""
-    var regex_ptr = UnsafePointer(to=regex).as_unsafe_any_origin()
-    return ASTNode[regex_origin](
+    var regex_ptr = (
+        UnsafePointer(to=regex)
+        .as_immutable()
+        .unsafe_origin_cast[ImmutUntrackedOrigin]()
+    )
+    return ASTNode[ImmutUntrackedOrigin](
         type=WORD,
         regex_ptr=regex_ptr,
         start_idx=start_idx,
@@ -682,26 +712,25 @@ def classify_range_kind(pattern: StringSlice) -> Int:
 
 @always_inline
 def RangeElement[
-    regex_origin: ImmutOrigin,
+    regex_origin: Origin,
 ](
-    ref[regex_origin] regex: Regex[ImmutAnyOrigin],
+    ref[regex_origin] regex: Regex[ImmutUntrackedOrigin],
     start_idx: Int,
     end_idx: Int,
     is_positive_logic: Bool = True,
-) -> ASTNode[regex_origin]:
+) -> ASTNode[ImmutUntrackedOrigin]:
     """Create a RangeElement node."""
-    var regex_ptr = UnsafePointer(to=regex).as_unsafe_any_origin()
+    var regex_ptr = (
+        UnsafePointer(to=regex)
+        .as_immutable()
+        .unsafe_origin_cast[ImmutUntrackedOrigin]()
+    )
     # Classify the range pattern once at build time.
     var kind = RANGE_KIND_OTHER
     if start_idx < end_idx:
-        var pat = StringSlice(
-            unsafe_from_utf8=Span[Byte, origin_of(regex.pattern)](
-                ptr=regex.pattern.unsafe_ptr() + start_idx,
-                length=end_idx - start_idx,
-            )
-        )
+        var pat = StringSlice(regex.pattern)[byte=start_idx:end_idx]
         kind = classify_range_kind(pat)
-    return ASTNode[regex_origin](
+    return ASTNode[ImmutUntrackedOrigin](
         type=RANGE,
         regex_ptr=regex_ptr,
         start_idx=start_idx,
@@ -715,15 +744,19 @@ def RangeElement[
 
 @always_inline
 def StartElement[
-    regex_origin: ImmutOrigin,
+    regex_origin: Origin,
 ](
-    ref[regex_origin] regex: Regex[ImmutAnyOrigin],
+    ref[regex_origin] regex: Regex[ImmutUntrackedOrigin],
     start_idx: Int,
     end_idx: Int,
-) -> ASTNode[regex_origin]:
+) -> ASTNode[ImmutUntrackedOrigin]:
     """Create a StartElement node."""
-    var regex_ptr = UnsafePointer(to=regex).as_unsafe_any_origin()
-    return ASTNode[regex_origin](
+    var regex_ptr = (
+        UnsafePointer(to=regex)
+        .as_immutable()
+        .unsafe_origin_cast[ImmutUntrackedOrigin]()
+    )
+    return ASTNode[ImmutUntrackedOrigin](
         type=START,
         regex_ptr=regex_ptr,
         start_idx=start_idx,
@@ -735,15 +768,19 @@ def StartElement[
 
 @always_inline
 def EndElement[
-    regex_origin: ImmutOrigin
+    regex_origin: Origin
 ](
-    ref[regex_origin] regex: Regex[ImmutAnyOrigin],
+    ref[regex_origin] regex: Regex[ImmutUntrackedOrigin],
     start_idx: Int,
     end_idx: Int,
-) -> ASTNode[regex_origin]:
+) -> ASTNode[ImmutUntrackedOrigin]:
     """Create an EndElement node."""
-    var regex_ptr = UnsafePointer(to=regex).as_unsafe_any_origin()
-    return ASTNode[regex_origin](
+    var regex_ptr = (
+        UnsafePointer(to=regex)
+        .as_immutable()
+        .unsafe_origin_cast[ImmutUntrackedOrigin]()
+    )
+    return ASTNode[ImmutUntrackedOrigin](
         type=END,
         regex_ptr=regex_ptr,
         start_idx=start_idx,
@@ -755,17 +792,21 @@ def EndElement[
 
 @always_inline
 def OrNode[
-    regex_origin: ImmutOrigin
+    regex_origin: Origin
 ](
-    ref[regex_origin] regex: Regex[ImmutAnyOrigin],
+    ref[regex_origin] regex: Regex[ImmutUntrackedOrigin],
     left_child_index: UInt16,
     right_child_index: UInt16,
     start_idx: Int,
     end_idx: Int,
-) -> ASTNode[regex_origin]:
+) -> ASTNode[ImmutUntrackedOrigin]:
     """Create an OrNode with left and right children."""
-    var regex_ptr = UnsafePointer(to=regex).as_unsafe_any_origin()
-    return ASTNode[regex_origin](
+    var regex_ptr = (
+        UnsafePointer(to=regex)
+        .as_immutable()
+        .unsafe_origin_cast[ImmutUntrackedOrigin]()
+    )
+    return ASTNode[ImmutUntrackedOrigin](
         type=OR,
         regex_ptr=regex_ptr,
         children_indexes=_make_children_indexes(
@@ -780,16 +821,20 @@ def OrNode[
 
 @always_inline
 def NotNode[
-    regex_origin: ImmutOrigin,
+    regex_origin: Origin,
 ](
-    ref[regex_origin] regex: Regex[ImmutAnyOrigin],
+    ref[regex_origin] regex: Regex[ImmutUntrackedOrigin],
     child_index: UInt16,
     start_idx: Int,
     end_idx: Int,
-) -> ASTNode[regex_origin]:
+) -> ASTNode[ImmutUntrackedOrigin]:
     """Create a NotNode with a child."""
-    var regex_ptr = UnsafePointer(to=regex).as_unsafe_any_origin()
-    return ASTNode[regex_origin](
+    var regex_ptr = (
+        UnsafePointer(to=regex)
+        .as_immutable()
+        .unsafe_origin_cast[ImmutUntrackedOrigin]()
+    )
+    return ASTNode[ImmutUntrackedOrigin](
         type=NOT,
         regex_ptr=regex_ptr,
         children_indexes=_make_children_indexes(child_index),
@@ -800,18 +845,22 @@ def NotNode[
 
 @always_inline
 def GroupNode[
-    regex_origin: ImmutOrigin,
+    regex_origin: Origin,
 ](
-    ref[regex_origin] regex: Regex[ImmutAnyOrigin],
+    ref[regex_origin] regex: Regex[ImmutUntrackedOrigin],
     children_indexes: ChildrenIndexes,
     start_idx: Int,
     end_idx: Int,
     capturing_group: Bool = False,
     group_id: Int = -1,
-) -> ASTNode[regex_origin]:
+) -> ASTNode[ImmutUntrackedOrigin]:
     """Create a GroupNode with children."""
-    var regex_ptr = UnsafePointer(to=regex).as_unsafe_any_origin()
-    var node = ASTNode[regex_origin](
+    var regex_ptr = (
+        UnsafePointer(to=regex)
+        .as_immutable()
+        .unsafe_origin_cast[ImmutUntrackedOrigin]()
+    )
+    var node = ASTNode[ImmutUntrackedOrigin](
         type=GROUP,
         regex_ptr=regex_ptr,
         start_idx=start_idx,

--- a/src/regex/dfa.mojo
+++ b/src/regex/dfa.mojo
@@ -67,10 +67,9 @@ comptime ALL_LETTERS = LOWERCASE_LETTERS + UPPERCASE_LETTERS
 comptime ALPHANUMERIC = LOWERCASE_LETTERS + UPPERCASE_LETTERS + DIGITS
 
 
-def _expand_character_range(
-    node_type: Int,
-    range_str: StringSlice[ImmutAnyOrigin],
-) -> String:
+def _expand_character_range[
+    O: ImmutOrigin
+](node_type: Int, range_str: StringSlice[O],) -> String:
     """Expand a character range like '[a-z]' to 'abcdefghijklmnopqrstuvwxyz'.
 
     Args:
@@ -838,7 +837,7 @@ struct DFAEngine(Engine):
 
         self.start_state = 0
 
-    def compile_alternation(mut self, ast: ASTNode[MutAnyOrigin]) raises:
+    def compile_alternation(mut self, ast: ASTNode[MutUntrackedOrigin]) raises:
         """Compile an alternation pattern like a|b or (cat|dog) into a DFA.
 
         Creates a state machine with parallel branches that converge to accepting states.
@@ -896,7 +895,9 @@ struct DFAEngine(Engine):
                     )
                     current_state_index = next_state_index
 
-    def compile_quantified_group(mut self, ast: ASTNode[MutAnyOrigin]) raises:
+    def compile_quantified_group(
+        mut self, ast: ASTNode[MutUntrackedOrigin]
+    ) raises:
         """Compile a quantified group pattern like (abc)+, (test)*, (a)? into a DFA.
 
         Creates a state machine with loops and optional paths based on quantifiers.
@@ -1040,7 +1041,9 @@ struct DFAEngine(Engine):
                 )
                 current_state_index = next_index
 
-    def compile_simple_quantifier(mut self, ast: ASTNode[MutAnyOrigin]) raises:
+    def compile_simple_quantifier(
+        mut self, ast: ASTNode[MutUntrackedOrigin]
+    ) raises:
         """Compile a simple quantifier pattern like a*, test+, char? into a DFA.
 
         Creates a state machine based on the quantifier type applied to literal sequences.
@@ -1063,7 +1066,6 @@ struct DFAEngine(Engine):
 
         # Extract pattern text and find quantifier info
         var pattern_parts = List[String]()
-        var quantifier_type = String("")
         var quantifier_min = 1
         var quantifier_max = 1
 
@@ -1073,15 +1075,12 @@ struct DFAEngine(Engine):
             ref char_text = String(element.get_value().value())
 
             if element.min == 0 and element.max == -1:  # *
-                quantifier_type = "*"
                 quantifier_min = 0
                 quantifier_max = -1
             elif element.min == 1 and element.max == -1:  # +
-                quantifier_type = "+"
                 quantifier_min = 1
                 quantifier_max = -1
             elif element.min == 0 and element.max == 1:  # ?
-                quantifier_type = "?"
                 quantifier_min = 0
                 quantifier_max = 1
 
@@ -1237,7 +1236,7 @@ struct DFAEngine(Engine):
             return new_state_index
 
     def compile_wildcard_quantifier(
-        mut self, ast: ASTNode[MutAnyOrigin]
+        mut self, ast: ASTNode[MutUntrackedOrigin]
     ) raises:
         """Compile a wildcard quantifier pattern like .*, .+, .? into a DFA.
 
@@ -1330,7 +1329,7 @@ struct DFAEngine(Engine):
                 self.states[0].add_transition(i, accepting_index)
 
     def compile_common_prefix_alternation(
-        mut self, ast: ASTNode[MutAnyOrigin]
+        mut self, ast: ASTNode[MutUntrackedOrigin]
     ) raises:
         """Compile common prefix alternation patterns like (hello|help|helicopter) into a DFA.
 
@@ -1363,7 +1362,7 @@ struct DFAEngine(Engine):
         self._build_prefix_trie(branches)
 
     def _extract_all_prefix_branches(
-        self, node: ASTNode[MutAnyOrigin], mut branches: List[String]
+        self, node: ASTNode[MutUntrackedOrigin], mut branches: List[String]
     ):
         """Extract all string branches from nested OR structure."""
         from regex.ast import OR, GROUP, ELEMENT
@@ -1475,7 +1474,7 @@ struct DFAEngine(Engine):
         self.start_state = 0
 
     def compile_quantified_alternation_group(
-        mut self, ast: ASTNode[MutAnyOrigin]
+        mut self, ast: ASTNode[MutUntrackedOrigin]
     ) raises:
         """Compile quantified alternation groups like (a|b)*, (cat|dog)+ into a DFA.
 
@@ -1524,7 +1523,7 @@ struct DFAEngine(Engine):
             )
 
     def _extract_all_alternation_branches_for_quantified(
-        self, node: ASTNode[MutAnyOrigin], mut branches: List[String]
+        self, node: ASTNode[MutUntrackedOrigin], mut branches: List[String]
     ):
         """Extract all string branches from alternation for quantified groups.
         """
@@ -2352,7 +2351,7 @@ struct BoyerMoore:
         return positions^
 
 
-def compile_dfa_pattern(ast: ASTNode[MutAnyOrigin]) raises -> DFAEngine:
+def compile_dfa_pattern(ast: ASTNode[MutUntrackedOrigin]) raises -> DFAEngine:
     """Compile an AST pattern into a DFA engine.
 
     Args:
@@ -2453,7 +2452,9 @@ def compile_dfa_pattern(ast: ASTNode[MutAnyOrigin]) raises -> DFAEngine:
     return dfa^
 
 
-def _is_simple_character_class_pattern(ast: ASTNode[MutAnyOrigin]) -> Bool:
+def _is_simple_character_class_pattern(
+    ast: ASTNode[MutUntrackedOrigin],
+) -> Bool:
     """Check if pattern is a simple character class (single \\d, \\d+, \\d{3}, [a-z]+, etc.).
 
     Args:
@@ -2485,7 +2486,7 @@ def _is_simple_character_class_pattern(ast: ASTNode[MutAnyOrigin]) -> Bool:
 
 
 def _extract_character_class_info(
-    ast: ASTNode[ImmutAnyOrigin],
+    ast: ASTNode[ImmutUntrackedOrigin],
 ) -> Tuple[Optional[String], Int, Int, Bool, Bool, Bool]:
     """Extract character class information from AST.
 
@@ -2505,7 +2506,7 @@ def _extract_character_class_info(
     var positive_logic = True
 
     # Find the character class node (DIGIT, WORD, or RANGE)
-    var class_node: ASTNode[ImmutAnyOrigin]
+    var class_node: ASTNode[ImmutUntrackedOrigin]
     if ast.type == DIGIT or ast.type == WORD or ast.type == RANGE:
         class_node = ast
     elif ast.type == RE and ast.get_children_len() == 1:
@@ -2557,7 +2558,7 @@ def _extract_character_class_info(
     )
 
 
-def _is_pure_anchor_pattern(ast: ASTNode[MutAnyOrigin]) -> Bool:
+def _is_pure_anchor_pattern(ast: ASTNode[MutUntrackedOrigin]) -> Bool:
     """Check if pattern is just anchors (^, $, or ^$).
 
     Args:
@@ -2585,7 +2586,7 @@ def _is_pure_anchor_pattern(ast: ASTNode[MutAnyOrigin]) -> Bool:
 
 
 def _is_sequential_character_class_pattern(
-    ast: ASTNode[MutAnyOrigin],
+    ast: ASTNode[MutUntrackedOrigin],
 ) -> Bool:
     """Check if pattern is a sequence of character classes with quantifiers.
 
@@ -2619,7 +2620,7 @@ def _is_sequential_character_class_pattern(
 
 
 def _extract_sequential_pattern_info(
-    ast: ASTNode[MutAnyOrigin],
+    ast: ASTNode[MutUntrackedOrigin],
 ) -> SequentialPatternInfo:
     """Extract information about a sequential pattern.
 
@@ -2663,7 +2664,7 @@ def _extract_sequential_pattern_info(
     return info^
 
 
-def _is_char_class_group(node: ASTNode[MutAnyOrigin]) -> Bool:
+def _is_char_class_group(node: ASTNode[MutUntrackedOrigin]) -> Bool:
     """Check if a GROUP node contains only character classes and literals.
 
     This allows capturing groups like ([A-Z]{3}[0-9]{4}) to be flattened
@@ -2688,7 +2689,7 @@ def _is_char_class_group(node: ASTNode[MutAnyOrigin]) -> Bool:
     return has_char_class
 
 
-def _is_literal_alternation_group(node: ASTNode[MutAnyOrigin]) -> Bool:
+def _is_literal_alternation_group(node: ASTNode[MutUntrackedOrigin]) -> Bool:
     """Check if a GROUP node contains only OR with literal branches.
 
     Examples: (?:00|33|44|55|66|77|88), (?:hello|world|test)
@@ -2705,7 +2706,7 @@ def _is_literal_alternation_group(node: ASTNode[MutAnyOrigin]) -> Bool:
 
     # Walk the OR tree iteratively to verify all branches are literal
     var has_branch = False
-    var stack = List[ASTNode[MutAnyOrigin]](capacity=16)
+    var stack = List[ASTNode[MutUntrackedOrigin]](capacity=16)
     stack.append(child)
 
     while len(stack) > 0:
@@ -2727,7 +2728,7 @@ def _is_literal_alternation_group(node: ASTNode[MutAnyOrigin]) -> Bool:
 
 
 def _collect_alternation_branches(
-    node: ASTNode[MutAnyOrigin],
+    node: ASTNode[MutUntrackedOrigin],
 ) -> List[String]:
     """Collect all literal branch strings from a literal alternation GROUP."""
     from regex.ast import GROUP, OR, ELEMENT
@@ -2735,7 +2736,7 @@ def _collect_alternation_branches(
     var branches = List[String](capacity=16)
     # Walk the OR tree iteratively using a stack
     var stack = List[Int](capacity=16)
-    var nodes = List[ASTNode[MutAnyOrigin]](capacity=16)
+    var nodes = List[ASTNode[MutUntrackedOrigin]](capacity=16)
     if node.get_children_len() > 0:
         nodes.append(node.get_child(0))
         stack.append(0)
@@ -2761,7 +2762,9 @@ def _collect_alternation_branches(
     return branches^
 
 
-def _is_multi_character_class_sequence(ast: ASTNode[MutAnyOrigin]) -> Bool:
+def _is_multi_character_class_sequence(
+    ast: ASTNode[MutUntrackedOrigin],
+) -> Bool:
     """Check if pattern is a sequence of multiple character classes.
 
     Examples: [a-z]+[0-9]+, digit+word+, [A-Z][a-z]*[0-9]{2,4}
@@ -2830,7 +2833,7 @@ def _is_multi_character_class_sequence(ast: ASTNode[MutAnyOrigin]) -> Bool:
 
 
 @always_inline
-def _element_to_char_class(element: ASTNode[MutAnyOrigin]) -> String:
+def _element_to_char_class(element: ASTNode[MutUntrackedOrigin]) -> String:
     """Convert an AST element node to its character class string.
 
     Returns empty string if the element type is not recognized.
@@ -2856,7 +2859,7 @@ def _element_to_char_class(element: ASTNode[MutAnyOrigin]) -> String:
 
 
 def _extract_multi_class_sequence_info(
-    ast: ASTNode[MutAnyOrigin],
+    ast: ASTNode[MutUntrackedOrigin],
 ) -> SequentialPatternInfo:
     """Extract information about a multi-character class sequence.
 
@@ -2917,7 +2920,7 @@ def _extract_multi_class_sequence_info(
     return info^
 
 
-def _is_mixed_sequential_pattern(ast: ASTNode[MutAnyOrigin]) -> Bool:
+def _is_mixed_sequential_pattern(ast: ASTNode[MutUntrackedOrigin]) -> Bool:
     """Check if pattern is a mixed sequential pattern with optional literals.
 
     Examples: [0-9]+\\.?[0-9]*, [a-z]+@[a-z]+\\.[a-z]+
@@ -2963,7 +2966,7 @@ def _is_mixed_sequential_pattern(ast: ASTNode[MutAnyOrigin]) -> Bool:
 
 
 def _extract_mixed_sequential_pattern_info(
-    ast: ASTNode[MutAnyOrigin],
+    ast: ASTNode[MutUntrackedOrigin],
 ) -> SequentialPatternInfo:
     """Extract information about a mixed sequential pattern.
 
@@ -2978,7 +2981,7 @@ def _extract_mixed_sequential_pattern_info(
     return _extract_multi_class_sequence_info(ast)
 
 
-def _is_alternation_pattern(ast: ASTNode[MutAnyOrigin]) -> Bool:
+def _is_alternation_pattern(ast: ASTNode[MutUntrackedOrigin]) -> Bool:
     """Check if pattern is a simple alternation like a|b, cat|dog, (a|b).
 
     Args:
@@ -2998,7 +3001,7 @@ def _is_alternation_pattern(ast: ASTNode[MutAnyOrigin]) -> Bool:
     return _is_pure_alternation_pattern(ast)
 
 
-def _is_simple_alternation_branches(ast: ASTNode[MutAnyOrigin]) -> Bool:
+def _is_simple_alternation_branches(ast: ASTNode[MutUntrackedOrigin]) -> Bool:
     """Check if alternation branches are simple (literal elements only).
 
     Args:
@@ -3044,7 +3047,7 @@ def _is_simple_alternation_branches(ast: ASTNode[MutAnyOrigin]) -> Bool:
     return True
 
 
-def _group_contains_only_literals(group: ASTNode[MutAnyOrigin]) -> Bool:
+def _group_contains_only_literals(group: ASTNode[MutUntrackedOrigin]) -> Bool:
     """Check if a group contains only literal elements.
 
     Args:
@@ -3067,7 +3070,7 @@ def _group_contains_only_literals(group: ASTNode[MutAnyOrigin]) -> Bool:
     return True
 
 
-def _find_and_check_or_node(ast: ASTNode[MutAnyOrigin]) -> Bool:
+def _find_and_check_or_node(ast: ASTNode[MutUntrackedOrigin]) -> Bool:
     """Recursively search for an OR node and check if its branches are simple.
 
     Args:
@@ -3091,8 +3094,8 @@ def _find_and_check_or_node(ast: ASTNode[MutAnyOrigin]) -> Bool:
 
 
 def _find_or_node(
-    ast: ASTNode[MutAnyOrigin],
-) -> Optional[ASTNode[MutAnyOrigin]]:
+    ast: ASTNode[MutUntrackedOrigin],
+) -> Optional[ASTNode[MutUntrackedOrigin]]:
     """Recursively find the first OR node in the AST.
 
     Args:
@@ -3116,7 +3119,7 @@ def _find_or_node(
     return None
 
 
-def _extract_branch_text(branch: ASTNode[MutAnyOrigin]) -> String:
+def _extract_branch_text(branch: ASTNode[MutUntrackedOrigin]) -> String:
     """Extract the literal text from an alternation branch.
 
     Args:
@@ -3141,7 +3144,7 @@ def _extract_branch_text(branch: ASTNode[MutAnyOrigin]) -> String:
     return String("")
 
 
-def _is_quantified_group(ast: ASTNode[MutAnyOrigin]) -> Bool:
+def _is_quantified_group(ast: ASTNode[MutUntrackedOrigin]) -> Bool:
     """Check if pattern is a simple quantified group like (abc)+, (test)*, (a)?.
 
     Args:
@@ -3166,7 +3169,7 @@ def _is_quantified_group(ast: ASTNode[MutAnyOrigin]) -> Bool:
     return False
 
 
-def _group_content_is_simple(group: ASTNode[MutAnyOrigin]) -> Bool:
+def _group_content_is_simple(group: ASTNode[MutUntrackedOrigin]) -> Bool:
     """Check if a quantified group contains simple literal content.
 
     Args:
@@ -3189,7 +3192,7 @@ def _group_content_is_simple(group: ASTNode[MutAnyOrigin]) -> Bool:
     return True
 
 
-def _extract_group_text(group: ASTNode[MutAnyOrigin]) -> String:
+def _extract_group_text(group: ASTNode[MutUntrackedOrigin]) -> String:
     """Extract the literal text from a quantified group.
 
     Args:
@@ -3210,7 +3213,7 @@ def _extract_group_text(group: ASTNode[MutAnyOrigin]) -> String:
 
 
 def _collect_all_alternation_branches(
-    or_node: ASTNode[MutAnyOrigin],
+    or_node: ASTNode[MutUntrackedOrigin],
 ) -> List[String]:
     """Recursively collect all branch texts from a potentially nested OR structure.
 
@@ -3253,7 +3256,7 @@ def _collect_all_alternation_branches(
     return branches^
 
 
-def _is_pure_alternation_pattern(ast: ASTNode[MutAnyOrigin]) -> Bool:
+def _is_pure_alternation_pattern(ast: ASTNode[MutUntrackedOrigin]) -> Bool:
     """Check if pattern is a pure alternation without other complex operators.
 
     Only allows simple structures like:
@@ -3289,7 +3292,7 @@ def _is_pure_alternation_pattern(ast: ASTNode[MutAnyOrigin]) -> Bool:
     return False
 
 
-def _is_simple_quantifier_pattern(ast: ASTNode[MutAnyOrigin]) -> Bool:
+def _is_simple_quantifier_pattern(ast: ASTNode[MutUntrackedOrigin]) -> Bool:
     """Check if pattern is a simple quantifier like a*, test+, char?.
 
     Args:
@@ -3330,7 +3333,7 @@ def _is_simple_quantifier_pattern(ast: ASTNode[MutAnyOrigin]) -> Bool:
     return has_quantifier
 
 
-def _is_wildcard_quantifier_pattern(ast: ASTNode[MutAnyOrigin]) -> Bool:
+def _is_wildcard_quantifier_pattern(ast: ASTNode[MutUntrackedOrigin]) -> Bool:
     """Check if pattern is a wildcard quantifier like .*, .+, .?.
 
     Args:
@@ -3363,7 +3366,7 @@ def _is_wildcard_quantifier_pattern(ast: ASTNode[MutAnyOrigin]) -> Bool:
 
 
 def _is_common_prefix_alternation_pattern(
-    ast: ASTNode[MutAnyOrigin],
+    ast: ASTNode[MutUntrackedOrigin],
 ) -> Bool:
     """Check if pattern is a common prefix alternation like (hello|help|helicopter).
 
@@ -3407,7 +3410,7 @@ def _is_common_prefix_alternation_pattern(
 
 
 def _extract_literal_branches(
-    node: ASTNode[MutAnyOrigin], mut branches: List[String]
+    node: ASTNode[MutUntrackedOrigin], mut branches: List[String]
 ) -> Bool:
     """Extract literal string branches from OR tree. Returns False if non-literal elements found.
     """
@@ -3469,7 +3472,7 @@ def _compute_common_prefix(branches: List[String]) -> String:
     return prefix
 
 
-def _is_quantified_alternation_group(ast: ASTNode[MutAnyOrigin]) -> Bool:
+def _is_quantified_alternation_group(ast: ASTNode[MutUntrackedOrigin]) -> Bool:
     """Check if pattern is a quantified alternation group like (a|b)*, (cat|dog)+.
 
     Args:
@@ -3510,7 +3513,7 @@ def _is_quantified_alternation_group(ast: ASTNode[MutAnyOrigin]) -> Bool:
 
 
 def _extract_literal_alternation_branches(
-    node: ASTNode[MutAnyOrigin], mut branches: List[String]
+    node: ASTNode[MutUntrackedOrigin], mut branches: List[String]
 ) -> Bool:
     """Extract literal branches from alternation. Returns False if non-literal elements found.
     """

--- a/src/regex/literal_optimizer.mojo
+++ b/src/regex/literal_optimizer.mojo
@@ -29,7 +29,9 @@ struct LiteralInfo[node_origin: ImmutOrigin](ImplicitlyCopyable, Movable):
     that lets `node_ptr` be a safe `Optional[Pointer[...]]` borrow instead of
     a raw `UnsafePointer`."""
 
-    var node_ptr: Optional[Pointer[ASTNode[ImmutAnyOrigin], Self.node_origin]]
+    var node_ptr: Optional[
+        Pointer[ASTNode[ImmutUntrackedOrigin], Self.node_origin]
+    ]
     """Origin-tracked borrow of the AST node containing the literal (for
     single nodes). `None` when this LiteralInfo refers to a string-index
     literal instead. The borrow rides `node_origin`, so the compiler keeps
@@ -47,7 +49,7 @@ struct LiteralInfo[node_origin: ImmutOrigin](ImplicitlyCopyable, Movable):
 
     def __init__(
         out self,
-        ref[Self.node_origin] node: ASTNode[ImmutAnyOrigin],
+        ref[Self.node_origin] node: ASTNode[ImmutUntrackedOrigin],
         start_offset: Int = 0,
         is_prefix: Bool = False,
         is_suffix: Bool = False,
@@ -214,7 +216,9 @@ struct LiteralSet[node_origin: ImmutOrigin](Movable, Sized):
 
 def extract_literals[
     node_origin: ImmutOrigin
-](ref[node_origin] ast: ASTNode[ImmutAnyOrigin]) -> LiteralSet[node_origin]:
+](ref[node_origin] ast: ASTNode[ImmutUntrackedOrigin]) -> LiteralSet[
+    node_origin
+]:
     """Extract all literals from a regex AST.
 
     Args:
@@ -239,7 +243,7 @@ def extract_literals[
 def _extract_from_node[
     node_origin: ImmutOrigin
 ](
-    node: ASTNode[ImmutAnyOrigin],
+    node: ASTNode[ImmutUntrackedOrigin],
     mut result: LiteralSet[node_origin],
     offset: Int,
     is_required: Bool,
@@ -456,7 +460,7 @@ def _longest_common_prefix(s1: String, s2: String) -> String:
     return String(s1[byte=:i])
 
 
-def has_literal_prefix(ast: ASTNode[MutAnyOrigin]) -> Bool:
+def has_literal_prefix(ast: ASTNode[MutUntrackedOrigin]) -> Bool:
     """Check if pattern starts with a literal that can be used for optimization.
 
     Args:
@@ -493,7 +497,7 @@ def _has_literal_prefix_node(node: ASTNode) -> Bool:
         return False
 
 
-def extract_literal_prefix(ast: ASTNode[MutAnyOrigin]) -> String:
+def extract_literal_prefix(ast: ASTNode[MutUntrackedOrigin]) -> String:
     """Extract the literal prefix from a pattern, if any.
 
     Args:

--- a/src/regex/matcher.mojo
+++ b/src/regex/matcher.mojo
@@ -119,7 +119,7 @@ def _program_has_end_anchor(program: Program) -> Bool:
 
 
 def _find_rare_required_byte(
-    ast: ASTNode[MutAnyOrigin],
+    ast: ASTNode[MutUntrackedOrigin],
     first_class_lookup: SIMD[DType.uint8, 256],
 ) -> Int:
     """Walk the top-level sequence of `ast` looking for a required,
@@ -164,7 +164,7 @@ def _find_rare_required_byte(
     return -1
 
 
-def check_ast_for_anchors(ast: ASTNode[MutAnyOrigin]) -> Bool:
+def check_ast_for_anchors(ast: ASTNode[MutUntrackedOrigin]) -> Bool:
     """Check if AST contains start or end anchors."""
     from regex.ast import START, END, RE, GROUP
 
@@ -211,7 +211,7 @@ trait RegexMatcher:
 struct DFAMatcher(Boolable, Copyable, Movable, RegexMatcher):
     """High-performance DFA-based matcher for simple patterns."""
 
-    var engine_ptr: Optional[UnsafePointer[DFAEngine, MutAnyOrigin]]
+    var engine_ptr: Optional[UnsafePointer[DFAEngine, MutUntrackedOrigin]]
     """The underlying DFA engine for pattern matching. None when the
     matcher was default-constructed and no AST has been compiled into
     it (1.0.0b1 forbids null UnsafePointer, so absence goes through
@@ -222,7 +222,7 @@ struct DFAMatcher(Boolable, Copyable, Movable, RegexMatcher):
         self.engine_ptr = None
 
     def __init__(
-        out self, var ast: ASTNode[MutAnyOrigin], pattern: String
+        out self, var ast: ASTNode[MutUntrackedOrigin], pattern: String
     ) raises:
         """Initialize DFA matcher by compiling the AST.
 
@@ -285,19 +285,19 @@ struct NFAMatcher(Copyable, Movable, RegexMatcher):
 
     var engine: NFAEngine
     """The underlying NFA engine for pattern matching."""
-    var ast: ASTNode[MutAnyOrigin]
+    var ast: ASTNode[MutUntrackedOrigin]
     """The parsed AST representation of the regex pattern."""
-    var _lazy_dfa_ptr: Optional[UnsafePointer[LazyDFA, MutAnyOrigin]]
+    var _lazy_dfa_ptr: Optional[UnsafePointer[LazyDFA, MutUntrackedOrigin]]
     """Heap-allocated lazy DFA. None when the pattern is not eligible
     for lazy-DFA acceleration (e.g., PikeVM program exceeds MAX_STATES).
     """
-    var _onepass_ptr: Optional[UnsafePointer[OnePassNFA, MutAnyOrigin]]
+    var _onepass_ptr: Optional[UnsafePointer[OnePassNFA, MutUntrackedOrigin]]
     """Heap-allocated OnePass NFA for unambiguous patterns. None when
     the pattern failed the one-pass check. Preferred over the lazy DFA
     and the backtracking NFA when available since it does not pay per-
     call setup cost or rely on state-set caching."""
 
-    def __init__(out self, ast: ASTNode[MutAnyOrigin], pattern: String):
+    def __init__(out self, ast: ASTNode[MutUntrackedOrigin], pattern: String):
         """Initialize NFA matcher with OnePass and LazyDFA acceleration."""
         self.engine = NFAEngine(pattern)
         self.ast = ast
@@ -607,7 +607,7 @@ struct HybridMatcher(Copyable, Movable, RegexMatcher):
 
         if should_analyze_prefilter:
             # Extract literal information using optimized implementation
-            # Use MutAnyOrigin since that's what the AST has
+            # Use MutUntrackedOrigin since that's what the AST has
             var literal_set = extract_literals(ast)
             var has_anchors = check_ast_for_anchors(ast)
 
@@ -1178,10 +1178,10 @@ def _init_regex_cache() -> RegexCache:
     return RegexCache()
 
 
-def _get_regex_cache() -> UnsafePointer[RegexCache, MutAnyOrigin]:
+def _get_regex_cache() -> UnsafePointer[RegexCache, MutUntrackedOrigin]:
     """Returns an pointer to the global regex cache."""
     try:
-        return _CACHE_GLOBAL.get_or_create_ptr().as_unsafe_any_origin()
+        return _CACHE_GLOBAL.get_or_create_ptr()
     except e:
         abort[prefix="ERROR:"](String(e))
 
@@ -1232,16 +1232,16 @@ def _init_last_sub_cache() -> _LastSubCache:
     )
 
 
-def _get_last_sub_cache() -> UnsafePointer[_LastSubCache, MutAnyOrigin]:
+def _get_last_sub_cache() -> UnsafePointer[_LastSubCache, MutUntrackedOrigin]:
     try:
-        return _LAST_SUB_CACHE_GLOBAL.get_or_create_ptr().as_unsafe_any_origin()
+        return _LAST_SUB_CACHE_GLOBAL.get_or_create_ptr()
     except e:
         abort[prefix="ERROR:"](String(e))
 
 
 def _compile_and_cache(
     pattern: ImmSlice,
-) raises -> UnsafePointer[CompiledRegex, MutAnyOrigin]:
+) raises -> UnsafePointer[CompiledRegex, MutUntrackedOrigin]:
     """Compile a regex pattern and return a pointer into the global cache.
 
     Returns an UnsafePointer to the cached CompiledRegex, avoiding the
@@ -1256,7 +1256,7 @@ def _compile_and_cache(
 def _compile_and_cache_with_key(
     pattern: ImmSlice,
     key: UInt64,
-) raises -> UnsafePointer[CompiledRegex, MutAnyOrigin]:
+) raises -> UnsafePointer[CompiledRegex, MutUntrackedOrigin]:
     """Variant of `_compile_and_cache` that takes a precomputed hash.
 
     Used by `sub()` with a pointer-identity fast path so repeat calls

--- a/src/regex/matching.mojo
+++ b/src/regex/matching.mojo
@@ -59,7 +59,7 @@ struct MatchList[origin: ImmutOrigin](Copyable, Movable, Sized):
     comptime DEFAULT_RESERVE_SIZE = 8
     """Default number of matches to reserve on first allocation."""
 
-    var _data: UnsafePointer[Match[Self.origin], MutAnyOrigin]
+    var _data: UnsafePointer[Match[Self.origin], MutUntrackedOrigin]
     """Internal list storing the matches. Dangling (and never read
     from) until the first allocation runs through `_realloc`; tracked
     via `_capacity > 0` since 1.0.0b1 forbids null UnsafePointer
@@ -73,7 +73,7 @@ struct MatchList[origin: ImmutOrigin](Copyable, Movable, Sized):
     ):
         """Initialize empty Matches container."""
         self._data = UnsafePointer[
-            Match[Self.origin], MutAnyOrigin
+            Match[Self.origin], MutUntrackedOrigin
         ].unsafe_dangling()
         self._capacity = 0
         self._len = 0
@@ -88,7 +88,7 @@ struct MatchList[origin: ImmutOrigin](Copyable, Movable, Sized):
     ):
         """Copy constructor."""
         self._data = UnsafePointer[
-            Match[Self.origin], MutAnyOrigin
+            Match[Self.origin], MutUntrackedOrigin
         ].unsafe_dangling()
         self._len = 0
         self._capacity = 0
@@ -133,7 +133,7 @@ struct MatchList[origin: ImmutOrigin](Copyable, Movable, Sized):
         if self._capacity > 0:
             memcpy(dest=new_data, src=self._data, count=len(self))
             self._data.free()
-        self._data = new_data.as_unsafe_any_origin()
+        self._data = new_data
         self._capacity = new_capacity
 
     def append(

--- a/src/regex/nfa.mojo
+++ b/src/regex/nfa.mojo
@@ -70,9 +70,9 @@ struct NFAEngine(Copyable, Engine):
     """The regex pattern string to match against."""
     var prev_re: String
     """Previously parsed regex pattern for caching."""
-    var prev_ast: Optional[ASTNode[MutAnyOrigin]]
+    var prev_ast: Optional[ASTNode[MutUntrackedOrigin]]
     """Cached AST from previous regex compilation."""
-    var regex: Optional[ASTNode[MutAnyOrigin]]
+    var regex: Optional[ASTNode[MutUntrackedOrigin]]
     """Compiled AST representation of the current regex pattern."""
     var literal_prefix: String
     """Extracted literal prefix for optimization."""
@@ -101,7 +101,7 @@ struct NFAEngine(Copyable, Engine):
             if self.regex:
                 ref ast = self.regex.value()
                 var analyzer = PatternAnalyzer()
-                var complexity = analyzer.classify(ast)
+                _ = analyzer.classify(ast)
 
                 var literal_set = extract_literals(ast)
 
@@ -453,7 +453,7 @@ struct NFAEngine(Copyable, Engine):
                 if self.literal_prefix and not self.is_prefix_literal:
                     try_pos = max(0, literal_pos - self.pattern_len)
 
-                var end_pos = min(
+                _ = min(
                     text.byte_length(),
                     literal_pos + self.literal_prefix.byte_length(),
                 )

--- a/src/regex/onepass.mojo
+++ b/src/regex/onepass.mojo
@@ -178,7 +178,7 @@ def _hash_set(nfa_set: SIMD[DType.uint8, MAX_STATES]) -> UInt64:
 
 def compile_onepass(
     var program: Program,
-) -> Optional[UnsafePointer[OnePassNFA, MutAnyOrigin]]:
+) -> Optional[UnsafePointer[OnePassNFA, MutUntrackedOrigin]]:
     # Compile a PikeVM program into a OnePass NFA and heap-allocate it.
     # Returns None when the pattern is not one-pass (caller falls back
     # to another engine).

--- a/src/regex/optimizer.mojo
+++ b/src/regex/optimizer.mojo
@@ -107,7 +107,7 @@ struct PatternAnalyzer:
         """Initialize the pattern analyzer."""
         pass
 
-    def classify(self, ast: ASTNode[MutAnyOrigin]) -> PatternComplexity:
+    def classify(self, ast: ASTNode[MutUntrackedOrigin]) -> PatternComplexity:
         """Analyze AST to determine pattern complexity.
 
         Args:
@@ -119,7 +119,7 @@ struct PatternAnalyzer:
         return self._analyze_node(ast, depth=0)
 
     def analyze_optimizations(
-        self, ast: ASTNode[MutAnyOrigin]
+        self, ast: ASTNode[MutUntrackedOrigin]
     ) -> OptimizationInfo:
         """Analyze pattern for optimization opportunities.
 
@@ -171,7 +171,7 @@ struct PatternAnalyzer:
 
         return info^
 
-    def should_use_pure_dfa(self, ast: ASTNode[MutAnyOrigin]) -> Bool:
+    def should_use_pure_dfa(self, ast: ASTNode[MutUntrackedOrigin]) -> Bool:
         """Determine if pattern should use pure DFA without SIMD integration.
 
         Pure DFA is best for simple patterns where SIMD overhead exceeds benefits.

--- a/src/regex/parser.mojo
+++ b/src/regex/parser.mojo
@@ -130,14 +130,14 @@ def get_range_str(start: String, end: String) -> String:
 def parse_token_list[
     regex_origin: Origin[mut=True]
 ](
-    ref[regex_origin] regex: Regex[ImmutAnyOrigin],
+    ref[regex_origin] regex: Regex[ImmutUntrackedOrigin],
     var tokens: List[Token],
     mut group_counter: Int,
-) raises -> ASTNode[MutAnyOrigin]:
+) raises -> ASTNode[MutUntrackedOrigin]:
     """Parse a list of tokens into an AST node (used for recursive parsing of groups).
     """
     if len(tokens) == 0:
-        var group_node = GroupNode[ImmutAnyOrigin](
+        var group_node = GroupNode(
             regex=regex,
             children_indexes=ChildrenIndexes(),
             start_idx=0,
@@ -160,14 +160,14 @@ def parse_token_list[
             var right_tokens = List[Token](tokens[k + 1 :])
 
             # Parse both sides
-            var left_ast: ASTNode[MutAnyOrigin]
+            var left_ast: ASTNode[MutUntrackedOrigin]
             if len(left_tokens) > 0:
                 var left_result = parse_token_list(
                     regex, left_tokens^, group_counter
                 )
-                left_ast = rebind[ASTNode[MutAnyOrigin]](left_result)
+                left_ast = rebind[ASTNode[MutUntrackedOrigin]](left_result)
             else:
-                var empty_group = GroupNode[ImmutAnyOrigin](
+                var empty_group = GroupNode(
                     regex=regex,
                     children_indexes=ChildrenIndexes(),
                     start_idx=0,
@@ -175,16 +175,16 @@ def parse_token_list[
                     capturing_group=True,
                     group_id=0,
                 )
-                left_ast = rebind[ASTNode[MutAnyOrigin]](empty_group)
+                left_ast = rebind[ASTNode[MutUntrackedOrigin]](empty_group)
 
-            var right_ast: ASTNode[MutAnyOrigin]
+            var right_ast: ASTNode[MutUntrackedOrigin]
             if len(right_tokens) > 0:
                 var right_result = parse_token_list(
                     regex, right_tokens^, group_counter
                 )
-                right_ast = rebind[ASTNode[MutAnyOrigin]](right_result)
+                right_ast = rebind[ASTNode[MutUntrackedOrigin]](right_result)
             else:
-                var empty_group_2 = GroupNode[ImmutAnyOrigin](
+                var empty_group_2 = GroupNode(
                     regex=regex,
                     children_indexes=ChildrenIndexes(),
                     start_idx=0,
@@ -192,7 +192,7 @@ def parse_token_list[
                     capturing_group=True,
                     group_id=0,
                 )
-                right_ast = rebind[ASTNode[MutAnyOrigin]](empty_group_2)
+                right_ast = rebind[ASTNode[MutUntrackedOrigin]](empty_group_2)
 
             # Add children to regex and get their indices
             var left_index = UInt16(
@@ -204,7 +204,7 @@ def parse_token_list[
             )  # +1 because we use 1-based indexing
             regex.append_child(right_ast)
 
-            var or_node = OrNode[ImmutAnyOrigin](
+            var or_node = OrNode(
                 regex=regex,
                 left_child_index=left_index,
                 right_child_index=right_index,
@@ -238,7 +238,7 @@ def parse_token_list[
                 )
 
     # No OR found, parse elements sequentially
-    var elements = List[ASTNode[MutAnyOrigin]](capacity=len(tokens))
+    var elements = List[ASTNode[MutUntrackedOrigin]](capacity=len(tokens))
     var i = 0
 
     while i < len(tokens):
@@ -252,20 +252,20 @@ def parse_token_list[
             )
             # Check for quantifiers after the element
             if i + 1 < len(tokens):
-                check_for_quantifiers[ImmutAnyOrigin](i, elem, tokens)
+                check_for_quantifiers[ImmutUntrackedOrigin](i, elem, tokens)
             elements.append(elem^)
         elif token.type == Token.WILDCARD:
-            var elem = WildcardElement[ImmutAnyOrigin](
+            var elem = WildcardElement(
                 regex=regex,
                 start_idx=token.start_pos,
                 end_idx=token.start_pos + 1,
             )
             # Check for quantifiers after the wildcard
             if i + 1 < len(tokens):
-                check_for_quantifiers[ImmutAnyOrigin](i, elem, tokens)
+                check_for_quantifiers[ImmutUntrackedOrigin](i, elem, tokens)
             elements.append(elem^)
         elif token.type == Token.SPACE:
-            var elem = SpaceElement[ImmutAnyOrigin](
+            var elem = SpaceElement(
                 regex=regex,
                 start_idx=token.start_pos,
                 end_idx=token.start_pos
@@ -273,10 +273,10 @@ def parse_token_list[
             )
             # Check for quantifiers after the space
             if i + 1 < len(tokens):
-                check_for_quantifiers[ImmutAnyOrigin](i, elem, tokens)
+                check_for_quantifiers[ImmutUntrackedOrigin](i, elem, tokens)
             elements.append(elem^)
         elif token.type == Token.DIGIT:
-            var elem = DigitElement[ImmutAnyOrigin](
+            var elem = DigitElement(
                 regex=regex,
                 start_idx=token.start_pos,
                 end_idx=token.start_pos
@@ -284,10 +284,10 @@ def parse_token_list[
             )
             # Check for quantifiers after the digit
             if i + 1 < len(tokens):
-                check_for_quantifiers[ImmutAnyOrigin](i, elem, tokens)
+                check_for_quantifiers[ImmutUntrackedOrigin](i, elem, tokens)
             elements.append(elem^)
         elif token.type == Token.WORD:
-            var elem = WordElement[ImmutAnyOrigin](
+            var elem = WordElement(
                 regex=regex,
                 start_idx=token.start_pos,
                 end_idx=token.start_pos
@@ -295,17 +295,17 @@ def parse_token_list[
             )
             # Check for quantifiers after the word
             if i + 1 < len(tokens):
-                check_for_quantifiers[ImmutAnyOrigin](i, elem, tokens)
+                check_for_quantifiers[ImmutUntrackedOrigin](i, elem, tokens)
             elements.append(elem^)
         elif token.type == Token.START:
-            var start_elem = StartElement[ImmutAnyOrigin](
+            var start_elem = StartElement(
                 regex=regex,
                 start_idx=token.start_pos,
                 end_idx=token.start_pos + 1,
             )
             elements.append(start_elem^)
         elif token.type == Token.END:
-            var end_elem = EndElement[ImmutAnyOrigin](
+            var end_elem = EndElement(
                 regex=regex,
                 start_idx=token.start_pos,
                 end_idx=token.start_pos + 1,
@@ -343,7 +343,7 @@ def parse_token_list[
             # Calculate proper end position - should be after the closing bracket
             var bracket_end_pos = tokens[i].start_pos + 1
 
-            var range_elem = RangeElement[ImmutAnyOrigin](
+            var range_elem = RangeElement(
                 regex=regex,
                 start_idx=bracket_start_pos,
                 end_idx=bracket_end_pos,
@@ -351,7 +351,9 @@ def parse_token_list[
             )
             # Check for quantifiers after the range
             if i + 1 < len(tokens):
-                check_for_quantifiers[ImmutAnyOrigin](i, range_elem, tokens)
+                check_for_quantifiers[ImmutUntrackedOrigin](
+                    i, range_elem, tokens
+                )
             elements.append(range_elem^)
         elif token.type == Token.DASH:
             # Dash outside brackets is a literal '-' character
@@ -361,7 +363,7 @@ def parse_token_list[
                 end_idx=token.start_pos + 1,
             )
             if i + 1 < len(tokens):
-                check_for_quantifiers[ImmutAnyOrigin](i, elem, tokens)
+                check_for_quantifiers[ImmutUntrackedOrigin](i, elem, tokens)
             elements.append(elem^)
         elif token.type == Token.LEFTPARENTHESIS:
             # Handle nested grouping - check for non-capturing group (?:...)
@@ -412,23 +414,25 @@ def parse_token_list[
             var group_ast = parse_token_list(
                 regex, group_tokens^, group_counter
             )
-            var group: ASTNode[MutAnyOrigin]
+            var group: ASTNode[MutUntrackedOrigin]
             if group_ast.type == GROUP:
                 # If it's already a group, use it directly
-                group = rebind[ASTNode[MutAnyOrigin]](group_ast)
+                group = rebind[ASTNode[MutUntrackedOrigin]](group_ast)
                 group.capturing_group = is_capturing
                 group.group_id = gid
                 group.start_idx = group_content_start_pos
                 group.end_idx = paren_end_pos
             else:
                 # Otherwise wrap in a group - add to regex.get_children_len() and create group node
-                var group_ast_mut = rebind[ASTNode[MutAnyOrigin]](group_ast)
+                var group_ast_mut = rebind[ASTNode[MutUntrackedOrigin]](
+                    group_ast
+                )
                 var child_index = UInt16(
                     regex.get_children_len() + 1
                 )  # +1 because we use 1-based indexing
                 regex.append_child(group_ast_mut^)
 
-                var group_node = GroupNode[ImmutAnyOrigin](
+                var group_node = GroupNode(
                     regex=regex,
                     children_indexes=_make_children_indexes(child_index),
                     start_idx=group_content_start_pos,
@@ -436,10 +440,10 @@ def parse_token_list[
                     capturing_group=is_capturing,
                     group_id=gid,
                 )
-                group = rebind[ASTNode[MutAnyOrigin]](group_node)
+                group = rebind[ASTNode[MutUntrackedOrigin]](group_node)
             # Check for quantifiers after the group
             if i + 1 < len(tokens):
-                check_for_quantifiers[MutAnyOrigin](i, group, tokens)
+                check_for_quantifiers[MutUntrackedOrigin](i, group, tokens)
             elements.append(group)
 
         i += 1
@@ -452,7 +456,7 @@ def parse_token_list[
         )  # +1 because we use 1-based indexing
         regex.append_child(element)
 
-    var final_group = GroupNode[ImmutAnyOrigin](
+    var final_group = GroupNode(
         regex=regex,
         children_indexes=children_indexes,
         start_idx=0,
@@ -463,7 +467,7 @@ def parse_token_list[
     return final_group^
 
 
-def parse(pattern: String) raises -> ASTNode[ImmutAnyOrigin]:
+def parse(pattern: String) raises -> ASTNode[ImmutUntrackedOrigin]:
     """Parses a regular expression.
 
     Parses a regex and returns the corresponding AST.
@@ -477,32 +481,30 @@ def parse(pattern: String) raises -> ASTNode[ImmutAnyOrigin]:
     """
     # Create a persistent Regex object to hold the pattern and children
     # Allocate on heap to ensure it survives function return
-    var regex_ptr = alloc[Regex[ImmutAnyOrigin]](1)
-    regex_ptr.init_pointee_move(Regex[ImmutAnyOrigin](pattern))
+    var regex_ptr = alloc[Regex[ImmutUntrackedOrigin]](1)
+    regex_ptr.init_pointee_move(Regex[ImmutUntrackedOrigin](pattern))
 
     # Tokenize the pattern
     var tokens = scan(pattern)
 
     # Use parse_token_list to do the actual parsing
     var group_counter = 0
-    var parsed_ast = parse_token_list[MutAnyOrigin](
-        regex_ptr[], tokens^, group_counter
-    )
+    var parsed_ast = parse_token_list(regex_ptr[], tokens^, group_counter)
 
     var children_len = regex_ptr[].get_children_len()
 
     # Create a RE root node that wraps the parsed result
     # The tests expect the root to be of type RE with a GROUP child
-    var parsed_ast_immutable = rebind[ASTNode[ImmutAnyOrigin]](parsed_ast)
+    var parsed_ast_immutable = rebind[ASTNode[ImmutUntrackedOrigin]](parsed_ast)
     var root_child_index = UInt16(
         children_len + 1
     )  # +1 because we use 1-based indexing
     regex_ptr[].append_child(parsed_ast_immutable)
 
     # Use the heap-allocated regex pointer directly
-    var re_root = ASTNode[ImmutAnyOrigin](
+    var re_root = ASTNode[ImmutUntrackedOrigin](
         type=RE,
-        regex_ptr=regex_ptr.as_unsafe_any_origin(),
+        regex_ptr=regex_ptr,
         start_idx=0,
         end_idx=pattern.byte_length(),
         children_indexes=_make_children_indexes(root_child_index),

--- a/src/regex/prefilter.mojo
+++ b/src/regex/prefilter.mojo
@@ -104,7 +104,7 @@ struct LiteralExtractor:
         """Initialize the literal extractor."""
         pass
 
-    def extract(self, ast: ASTNode[MutAnyOrigin]) -> LiteralInfo:
+    def extract(self, ast: ASTNode[MutUntrackedOrigin]) -> LiteralInfo:
         """Extract literal information from an AST pattern.
 
         Args:
@@ -135,11 +135,13 @@ struct LiteralExtractor:
 
         return info^
 
-    def _has_anchors(self, ast: ASTNode[MutAnyOrigin]) -> Bool:
+    def _has_anchors(self, ast: ASTNode[MutUntrackedOrigin]) -> Bool:
         """Check if pattern has start or end anchors."""
         return self._check_anchors_recursive(ast)
 
-    def _check_anchors_recursive(self, ast: ASTNode[MutAnyOrigin]) -> Bool:
+    def _check_anchors_recursive(
+        self, ast: ASTNode[MutUntrackedOrigin]
+    ) -> Bool:
         """Recursively check for anchors in AST."""
         if ast.type == START or ast.type == END:
             return True
@@ -150,7 +152,7 @@ struct LiteralExtractor:
         return False
 
     def _extract_from_node(
-        self, ast: ASTNode[MutAnyOrigin], mut info: LiteralInfo
+        self, ast: ASTNode[MutUntrackedOrigin], mut info: LiteralInfo
     ):
         """Extract literals from a specific AST node."""
         if ast.type == RE:
@@ -190,7 +192,9 @@ struct LiteralExtractor:
                     if self._is_at_end(ast):
                         info.literal_suffixes.append(char_str)
 
-    def _extract_literal_sequence(self, ast: ASTNode[MutAnyOrigin]) -> String:
+    def _extract_literal_sequence(
+        self, ast: ASTNode[MutUntrackedOrigin]
+    ) -> String:
         """Extract literal string from a sequence of ELEMENT nodes."""
         if ast.type == ELEMENT:
             if ast.min == 1 and ast.max == 1:
@@ -213,7 +217,7 @@ struct LiteralExtractor:
         return EMPTY_STRING
 
     def _extract_alternation_literals(
-        self, ast: ASTNode[MutAnyOrigin], mut info: LiteralInfo
+        self, ast: ASTNode[MutUntrackedOrigin], mut info: LiteralInfo
     ):
         """Extract literals from alternation patterns (a|b|c)."""
         var branches = List[String]()
@@ -245,7 +249,7 @@ struct LiteralExtractor:
                 info.literal_suffixes.append(common_suffix)
 
     def _collect_alternation_branches(
-        self, ast: ASTNode[MutAnyOrigin], mut branches: List[String]
+        self, ast: ASTNode[MutUntrackedOrigin], mut branches: List[String]
     ):
         """Collect literal branches from alternation tree."""
         if ast.type == OR:
@@ -327,13 +331,13 @@ struct LiteralExtractor:
 
         return suffix^
 
-    def _is_at_beginning(self, ast: ASTNode[MutAnyOrigin]) -> Bool:
+    def _is_at_beginning(self, ast: ASTNode[MutUntrackedOrigin]) -> Bool:
         """Check if this node is at the beginning of the pattern."""
         # Simplified check - in a full implementation, this would check
         # the position within the parent's children
         return True  # Conservative approach for now
 
-    def _is_at_end(self, ast: ASTNode[MutAnyOrigin]) -> Bool:
+    def _is_at_end(self, ast: ASTNode[MutUntrackedOrigin]) -> Bool:
         """Check if this node is at the end of the pattern."""
         # Simplified check - in a full implementation, this would check
         # the position within the parent's children

--- a/src/regex/simd_matchers.mojo
+++ b/src/regex/simd_matchers.mojo
@@ -387,10 +387,10 @@ def _init_range_matchers() -> RangeMatchers:
     return matchers^
 
 
-def _get_range_matchers() -> UnsafePointer[RangeMatchers, MutAnyOrigin]:
+def _get_range_matchers() -> UnsafePointer[RangeMatchers, MutUntrackedOrigin]:
     """Returns a pointer to the global range matchers dictionary."""
     try:
-        return _RANGE_MATCHERS_GLOBAL.get_or_create_ptr().as_unsafe_any_origin()
+        return _RANGE_MATCHERS_GLOBAL.get_or_create_ptr()
     except e:
         abort[prefix="ERROR:"](String(e))
 
@@ -408,12 +408,10 @@ def _init_nibble_matchers() -> NibbleMatchers:
     return matchers^
 
 
-def _get_nibble_matchers() -> UnsafePointer[NibbleMatchers, MutAnyOrigin]:
+def _get_nibble_matchers() -> UnsafePointer[NibbleMatchers, MutUntrackedOrigin]:
     """Returns a pointer to the global nibble matchers dictionary."""
     try:
-        return (
-            _NIBBLE_MATCHERS_GLOBAL.get_or_create_ptr().as_unsafe_any_origin()
-        )
+        return _NIBBLE_MATCHERS_GLOBAL.get_or_create_ptr()
     except e:
         abort[prefix="ERROR:"](String(e))
 

--- a/src/regex/simd_ops.mojo
+++ b/src/regex/simd_ops.mojo
@@ -1111,10 +1111,10 @@ def _init_simd_matchers() -> SIMDMatchers:
     return matchers^
 
 
-def _get_simd_matchers() -> UnsafePointer[SIMDMatchers, MutAnyOrigin]:
+def _get_simd_matchers() -> UnsafePointer[SIMDMatchers, MutUntrackedOrigin]:
     """Returns a pointer to the global SIMD matchers dictionary."""
     try:
-        return _SIMD_MATCHERS_GLOBAL.get_or_create_ptr().as_unsafe_any_origin()
+        return _SIMD_MATCHERS_GLOBAL.get_or_create_ptr()
     except e:
         abort[prefix="ERROR:"](String(e))
 

--- a/tests/test_ast.mojo
+++ b/tests/test_ast.mojo
@@ -29,9 +29,13 @@ from regex.ast import (
 
 def test_ASTNode() raises:
     var pattern = String("")
-    var regex = Regex[ImmutAnyOrigin](pattern)
-    var regex_ptr = UnsafePointer(to=regex).as_unsafe_any_origin()
-    var ast_node = ASTNode[ImmutAnyOrigin](
+    var regex = Regex[ImmutUntrackedOrigin](pattern)
+    var regex_ptr = (
+        UnsafePointer(to=regex)
+        .as_immutable()
+        .unsafe_origin_cast[ImmutUntrackedOrigin]()
+    )
+    var ast_node = ASTNode[ImmutUntrackedOrigin](
         type=ELEMENT, regex_ptr=regex_ptr, start_idx=0, end_idx=0
     )
     assert_true(ast_node.__bool__())
@@ -39,19 +43,20 @@ def test_ASTNode() raises:
 
 def test_Element() raises:
     var pattern = String("a")
-    var regex = Regex[ImmutAnyOrigin](pattern)
-    var elem = Element[MutAnyOrigin](regex, start_idx=0, end_idx=1)
+    var regex = Regex[ImmutUntrackedOrigin](pattern)
+    var elem = Element(regex, start_idx=0, end_idx=1)
     assert_true(elem.__bool__())
     assert_equal(elem.type, ELEMENT)
     assert_equal(elem.get_value().value(), "a")
     assert_true(elem.is_match("a"))
     assert_false(elem.is_match("b"))
+    _ = regex^
 
 
 def test_WildcardElement() raises:
     var pattern = String(".")
-    var regex = Regex[ImmutAnyOrigin](pattern)
-    var we = WildcardElement[MutAnyOrigin](regex, start_idx=0, end_idx=1)
+    var regex = Regex[ImmutUntrackedOrigin](pattern)
+    var we = WildcardElement(regex, start_idx=0, end_idx=1)
     assert_true(we.__bool__())
     assert_equal(we.type, WILDCARD)
     assert_true(we.is_match("a"))
@@ -61,8 +66,8 @@ def test_WildcardElement() raises:
 
 def test_SpaceElement() raises:
     var pattern = String("\\s")
-    var regex = Regex[ImmutAnyOrigin](pattern)
-    var se = SpaceElement[MutAnyOrigin](regex, start_idx=0, end_idx=2)
+    var regex = Regex[ImmutUntrackedOrigin](pattern)
+    var se = SpaceElement(regex, start_idx=0, end_idx=2)
     assert_true(se.__bool__())
     assert_equal(se.type, SPACE)
     assert_true(se.is_match(" "))
@@ -75,10 +80,8 @@ def test_SpaceElement() raises:
 
 def test_RangeElement_positive_logic() raises:
     var pattern = String("[abc]")
-    var regex = Regex[ImmutAnyOrigin](pattern)
-    var re = RangeElement[MutAnyOrigin](
-        regex, start_idx=1, end_idx=4, is_positive_logic=True
-    )
+    var regex = Regex[ImmutUntrackedOrigin](pattern)
+    var re = RangeElement(regex, start_idx=1, end_idx=4, is_positive_logic=True)
     assert_true(re.__bool__())
     assert_equal(re.type, RANGE)
     assert_equal(re.min, 1)
@@ -87,12 +90,13 @@ def test_RangeElement_positive_logic() raises:
     assert_true(re.is_match("b"))
     assert_true(re.is_match("c"))
     assert_false(re.is_match("x"))
+    _ = regex^
 
 
 def test_RangeElement_negative_logic() raises:
     var pattern = String("[^abc]")
-    var regex = Regex[ImmutAnyOrigin](pattern)
-    var nre = RangeElement[MutAnyOrigin](
+    var regex = Regex[ImmutUntrackedOrigin](pattern)
+    var nre = RangeElement(
         regex, start_idx=2, end_idx=5, is_positive_logic=False
     )
     assert_true(nre.__bool__())
@@ -103,12 +107,13 @@ def test_RangeElement_negative_logic() raises:
     assert_false(nre.is_match("b"))
     assert_false(nre.is_match("c"))
     assert_true(nre.is_match("x"))
+    _ = regex^
 
 
 def test_StartElement() raises:
     var pattern = String("^")
-    var regex = Regex[ImmutAnyOrigin](pattern)
-    var start = StartElement[MutAnyOrigin](regex, start_idx=0, end_idx=1)
+    var regex = Regex[ImmutUntrackedOrigin](pattern)
+    var start = StartElement(regex, start_idx=0, end_idx=1)
     assert_true(start.__bool__())
     assert_equal(start.type, START)
     assert_true(start.is_match("", 0, 10))
@@ -117,8 +122,8 @@ def test_StartElement() raises:
 
 def test_EndElement() raises:
     var pattern = String("$")
-    var regex = Regex[ImmutAnyOrigin](pattern)
-    var end = EndElement[MutAnyOrigin](regex, start_idx=0, end_idx=1)
+    var regex = Regex[ImmutUntrackedOrigin](pattern)
+    var end = EndElement(regex, start_idx=0, end_idx=1)
     assert_true(end.__bool__())
     assert_equal(end.type, END)
     assert_true(end.is_match("", 10, 10))
@@ -127,16 +132,16 @@ def test_EndElement() raises:
 
 def test_OrNode() raises:
     var pattern = String("a|b")
-    var mut_regex = Regex[MutAnyOrigin](pattern)
+    var mut_regex = Regex[MutUntrackedOrigin](pattern)
     var regex = mut_regex.get_immutable()
-    var left = Element[MutAnyOrigin](regex, start_idx=0, end_idx=1)
-    var right = Element[MutAnyOrigin](regex, start_idx=2, end_idx=3)
+    var left = Element(regex, start_idx=0, end_idx=1)
+    var right = Element(regex, start_idx=2, end_idx=3)
 
     # Add children to mutable regex
     mut_regex.append_child(left)
     mut_regex.append_child(right)
 
-    var or_node = OrNode[MutAnyOrigin](
+    var or_node = OrNode(
         regex,
         left_child_index=1,
         right_child_index=2,
@@ -156,16 +161,14 @@ def test_OrNode() raises:
 
 def test_NotNode() raises:
     var pattern = String("^e")
-    var mut_regex = Regex[MutAnyOrigin](pattern)
+    var mut_regex = Regex[MutUntrackedOrigin](pattern)
     var regex = mut_regex.get_immutable()
-    var element = Element[MutAnyOrigin](regex, start_idx=1, end_idx=2)
+    var element = Element(regex, start_idx=1, end_idx=2)
 
     # Add child to mutable regex
     mut_regex.append_child(element)
 
-    var not_node = NotNode[MutAnyOrigin](
-        regex, child_index=1, start_idx=0, end_idx=2
-    )
+    var not_node = NotNode(regex, child_index=1, start_idx=0, end_idx=2)
     assert_true(not_node.__bool__())
     assert_equal(not_node.type, NOT)
     assert_equal(not_node.get_children_len(), 1)
@@ -176,17 +179,17 @@ def test_NotNode() raises:
 
 def test_GroupNode() raises:
     var pattern = String("(ab)")
-    var mut_regex = Regex[MutAnyOrigin](pattern)
+    var mut_regex = Regex[MutUntrackedOrigin](pattern)
     var regex = mut_regex.get_immutable()
-    var elem1 = Element[MutAnyOrigin](regex, start_idx=1, end_idx=2)
-    var elem2 = Element[MutAnyOrigin](regex, start_idx=2, end_idx=3)
+    var elem1 = Element(regex, start_idx=1, end_idx=2)
+    var elem2 = Element(regex, start_idx=2, end_idx=3)
 
     # Add children to mutable regex
     mut_regex.append_child(elem1)
     mut_regex.append_child(elem2)
 
     var children_indexes = _make_children_indexes(UInt16(1), UInt16(2))
-    var group = GroupNode[MutAnyOrigin](
+    var group = GroupNode(
         regex,
         children_indexes=children_indexes,
         start_idx=0,
@@ -201,15 +204,15 @@ def test_GroupNode() raises:
 
 def test_GroupNode_default_name() raises:
     var pattern = String("(a)")
-    var mut_regex = Regex[MutAnyOrigin](pattern)
+    var mut_regex = Regex[MutUntrackedOrigin](pattern)
     var regex = mut_regex.get_immutable()
-    var elem = Element[MutAnyOrigin](regex, start_idx=1, end_idx=2)
+    var elem = Element(regex, start_idx=1, end_idx=2)
 
     # Add child to mutable regex
     mut_regex.append_child(elem)
 
     var children_indexes = _make_children_indexes(UInt16(1))
-    var group = GroupNode[MutAnyOrigin](
+    var group = GroupNode(
         regex,
         children_indexes=children_indexes,
         start_idx=0,
@@ -221,19 +224,19 @@ def test_GroupNode_default_name() raises:
 
 def test_is_leaf() raises:
     var pattern = String("a.^$[abc]a|b()")
-    var mut_regex = Regex[MutAnyOrigin](pattern)
+    var mut_regex = Regex[MutUntrackedOrigin](pattern)
     var regex = mut_regex.get_immutable()
-    var element = Element[MutAnyOrigin](regex, start_idx=0, end_idx=1)
-    var wildcard = WildcardElement[MutAnyOrigin](regex, start_idx=1, end_idx=2)
-    var start_elem = StartElement[MutAnyOrigin](regex, start_idx=2, end_idx=3)
-    var end_elem = EndElement[MutAnyOrigin](regex, start_idx=3, end_idx=4)
-    var range_elem = RangeElement[MutAnyOrigin](regex, start_idx=5, end_idx=8)
+    var element = Element(regex, start_idx=0, end_idx=1)
+    var wildcard = WildcardElement(regex, start_idx=1, end_idx=2)
+    var start_elem = StartElement(regex, start_idx=2, end_idx=3)
+    var end_elem = EndElement(regex, start_idx=3, end_idx=4)
+    var range_elem = RangeElement(regex, start_idx=5, end_idx=8)
 
     # Add children to mutable regex for complex nodes
     mut_regex.append_child(element)
     mut_regex.append_child(wildcard)
 
-    var or_node = OrNode[MutAnyOrigin](
+    var or_node = OrNode(
         regex,
         left_child_index=1,
         right_child_index=2,
@@ -241,7 +244,7 @@ def test_is_leaf() raises:
         end_idx=12,
     )
     var empty_children_indexes = ChildrenIndexes()
-    var group = GroupNode[MutAnyOrigin](
+    var group = GroupNode(
         regex,
         children_indexes=empty_children_indexes,
         start_idx=13,

--- a/tests/test_onepass.mojo
+++ b/tests/test_onepass.mojo
@@ -10,7 +10,7 @@ from regex.aliases import ImmSlice
 
 def _build_onepass(
     pattern: String,
-) raises -> Optional[UnsafePointer[OnePassNFA, MutAnyOrigin]]:
+) raises -> Optional[UnsafePointer[OnePassNFA, MutUntrackedOrigin]]:
     """Parse a pattern, compile to PikeVM bytecode, attempt OnePass
     compilation, and return the heap pointer (None if not one-pass)."""
     var ast = parse(pattern)


### PR DESCRIPTION
Updating to the latest nightly (`1.0.0b3.dev2026062806`), which lands a **large breaking change** to the origin model.

## What this nightly broke

1. **Struct fields may no longer expose `AnyOrigin`** in their type (100+ hard errors).
2. **`alloc` / `_Global.get_or_create_ptr` now return `*UntrackedOrigin`** pointers, and **`StringSlice` no longer implicitly converts a concrete origin to an erased one**.
3. **`fn` is fully removed** (the codebase was already `def`-only — no changes needed).

## Migration

- The erased-origin convention for the AST arena and owning pointers (`ASTNode`/`Regex` parameter values; the `children_ptr` / `MatchList._data` / engine-pointer fields) moves from `AnyOrigin` → **`UntrackedOrigin`** — the sanctioned "not lifetime-tracked" origin that `alloc` returns and that *is* allowed in fields. Values straight from `alloc` / `get_or_create_ptr` need no cast (the `.as_unsafe_any_origin()` calls are dropped); the node factories erase the borrowed `regex` ref with `.as_immutable().unsafe_origin_cast[ImmutUntrackedOrigin]()`.
- **`ImmSlice` stays `StringSlice[ImmutAnyOrigin]`** — it's a *parameter* type (the field ban doesn't apply) and `String` still converts to an any-origin slice, which `Untracked`/`External` origins reject.
- Node factories now **infer `regex_origin` from the caller's ref** (instead of a forced explicit origin) and return `ASTNode[ImmutUntrackedOrigin]`; `Regex.__init__` takes the pattern by value; `_expand_character_range` is parameterized on the slice origin.
- New **unused-assignment warnings** fixed (dead `quantifier_type` in dfa; discarded `complexity` / `end_pos` in nfa).

## A subtle lifetime fix

Three manual-construction AST unit tests point a node at a **stack** `Regex` and call `is_match`, which reads the pattern through the node's now-`Untracked` back-pointer. Since that borrow is no longer lifetime-tracked, the stack `Regex` is ASAP-destroyed before the read → the tests get an explicit `_ = regex^` keepalive. The library itself is unaffected: its `Regex` is heap-allocated and owned by the `CompiledRegex`, so its nodes always point at live memory.

## Verification

- **0 errors, 0 warnings** across `src/`, `tests/`, and all benchmark binaries.
- All **377 tests pass**.
- Changes are origin-level (compile-time, erased at runtime); a benchmark sanity run shows unchanged numbers.