### PR TITLE
Document failed mut-out and result-buffer prealloc experiments

### DIFF
--- a/proposals/copy-profile-findings.md
+++ b/proposals/copy-profile-findings.md
@@ -131,6 +131,70 @@ allocations may hide:
   (15-20 dispatches per match). This is structural Mojo compilation
   cost, not copy cost.
 
+## Failed attempt: `mut out: String` for template appliers (2026-05-05)
+
+Tried refactoring `_apply_template_fixed` and `_apply_template_groups`
+to take `mut out: String` and append directly into the caller's
+`result` buffer instead of allocating a fresh `String(capacity=32)`
+per match and being `+=`'d. Tests passed.
+
+**Result**: `sub_group_word_swap` regressed **31%** in 3-median
+stable mode (median 0.067 ms baseline → 0.088 ms with change). Same
+failure shape as a prior session's `_into` overload attempt.
+
+**Best guess on why**: the temp-String pattern is cache-friendlier
+than direct append. Each match writes to a fresh 32-byte buffer hot
+in L1 then bulk-`memcpy`s into `result`. Direct append on the larger
+`result` (sized at `text_len + 64`) probably triggers
+capacity-grow reallocs and may also disturb register allocation /
+inlining of the surrounding NFA loop. The fixed-width path
+(`_apply_template_fixed`, used by `sub_group_phone_fmt` /
+`sub_group_date_fmt`) showed a modest improvement in single-stable
+runs, but that signal was never confirmed with a 3-median pass.
+
+**Implication**: simple "skip the alloc" refactors do not win here.
+The `result` buffer's capacity-growth behavior dominates over the
+saved temp-alloc. A follow-up prerequisite was suggested here
+(pre-allocate `result` much larger, then re-test the `mut out`
+refactor), but the pre-allocation experiment below invalidated it.
+
+Branch with the failed attempt is *not* preserved; the diff is
+trivial to recreate. The lesson — "don't redo this without first
+understanding `result` growth" — is the load-bearing part.
+
+## Failed attempt: pre-allocate `result` buffer (2026-05-05)
+
+Hypothesis: `_sub_impl_with_repl` creates the result buffer at
+`String(capacity=text_len + 64)`. If the output exceeds this (e.g.
+group references that expand the text), the buffer grows via
+realloc + memcpy. Bumping the initial capacity to `text_len * 4 +
+256` should eliminate any growth realloc and speed up the per-match
+append path.
+
+**Result**: `sub_group_word_swap` regressed **52%** in 3-median
+stable mode (median 0.067 ms baseline → 0.102 ms with bump). The
+3-run variance also expanded sharply: with-bump runs spread from
+0.076 to 0.129 ms (70% range) vs baseline 0.056 to 0.071 ms (27%
+range).
+
+**Best guess on why**: a larger initial heap allocation moves
+`result` to a different memory region with worse cache locality.
+The 4x-larger buffer evicts more of the surrounding hot data
+(NFA state, capture-group lists, template segments) from L1 / L2,
+and the higher run-to-run variance is consistent with cache
+thrashing.
+
+**Implication**: the existing `text_len + 64` capacity is at or
+near a sweet spot. The original code probably never grows `result`
+for typical workloads, so there is nothing to save by pre-allocating
+more. A larger buffer purely costs cache footprint with no
+realloc-elimination upside.
+
+This invalidates the prerequisite suggested in the `mut out: String`
+attempt above ("pre-allocate `result` then re-test the `mut out`
+refactor"). Both attempts on the `_apply_template_groups` path
+regressed; the win, if any, lies elsewhere.
+
 To extend the trace, instrument the same way on the additional types.
 The pattern is: add `@always_inline` to the copy ctor (if missing),
 import `call_location` from `std.reflection.location`, and add


### PR DESCRIPTION
Consolidates #150 and #151 into a single PR, since both append failed-experiment sections to `proposals/copy-profile-findings.md` and the second experiment invalidates a prerequisite suggested by the first.

## Contents

- **Failed attempt: `mut out: String` for template appliers.** Refactoring `_apply_template_fixed` / `_apply_template_groups` to append directly into the caller's `result` buffer regressed `sub_group_word_swap` **31%** (3-median stable). Best guess: the fresh 32-byte temp String is cache-friendlier than direct append into the large buffer.

- **Failed attempt: pre-allocate `result` buffer.** Bumping the initial capacity from `text_len + 64` to `text_len * 4 + 256` regressed the same benchmark **52%** and tripled run-to-run variance, consistent with cache thrashing from the larger allocation. This invalidates the follow-up suggested by the first experiment.

The cross-references between the two sections were adjusted so they read coherently as one document. No code changes; docs only.