### PR TITLE
Unlock char classes in comptime regex via cache-free matcher construction (step 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## v0.21.0 (2026-07-04)
 
+### Comptime regex step 2: character classes at compile time (PR #168)
+
+- `compile_dfa_pattern` gains a comptime `use_matcher_cache: Bool = True` parameter threaded to the two SIMD-matcher acquisition sites; `use_matcher_cache=False` constructs matchers directly via the new `create_character_class_matcher`, bypassing the `_Global` cache whose FFI call the comptime interpreter cannot execute. The comptime probe drops its AST whitelist: char classes (`[0-9]+`, `[^abc]+`), shorthands (`\d`, `\w`), wildcards, bounded quantifiers (`[0-9]{3}`) and multi-class sequences (`[a-z]+[0-9]+`) now build at compile time, verified across a 16-pattern matrix; remaining DFA rejections are catchable raises that fall back to the runtime engine.
+- Runtime path is provably unchanged: a normalized objdump diff of `bench_engine` with and without the change shows identical instruction counts and opcodes, differing only in source-line immediates on assert paths. 389 tests pass, zero warnings.
+
 ### Comptime regex: compile-time pattern specialization (PR #167)
 
 - New `regex.comptime_regex` module: pass the pattern as a comptime parameter (`search["hello"](text)`, plus `match_first` / `findall`) and the parser and DFA compiler run inside Mojo's comptime interpreter, embedding the automaton in the binary. Matching needs no runtime compilation, no pattern hashing and no cache probe; the engine is materialized once per pattern per process into a `_Global` slot. Invalid patterns fail the build via `comptime assert`. Patterns outside the verified envelope (literals, anchors, quantifiers, alternations) transparently fall back to the runtime engine with identical semantics.

--- a/README.md
+++ b/README.md
@@ -62,14 +62,15 @@ var all = findall["(x|y)"](text)
   needs no runtime compilation, no pattern hashing and no cache
   lookup.
 - Invalid patterns fail the *build* instead of raising at runtime.
-- Patterns outside the compile-time envelope (currently: literals,
-  anchors, quantifiers and alternations) transparently fall back to
-  the runtime engine with identical semantics, so any pattern is
-  safe to use.
+- The compile-time envelope covers everything the DFA compiler
+  accepts: literals, anchors, quantifiers, alternations, character
+  classes (`[a-z]`, `[^abc]`), shorthands (`\d`, `\w`), wildcards,
+  bounded quantifiers and multi-class sequences. Anything the DFA
+  rejects transparently falls back to the runtime engine with
+  identical semantics, so any pattern is safe to use.
 
 See [proposals/comptime-regex.md](proposals/comptime-regex.md) for
-the design, the verified envelope and the roadmap (character classes
-are next).
+the design and the verified envelope.
 
 ## Performance
 

--- a/proposals/comptime-regex.md
+++ b/proposals/comptime-regex.md
@@ -1,16 +1,23 @@
 # Comptime regex: compile-time pattern specialization, revisited
 
 Date: 2026-07-04
-Status: step 1 implemented (PR #167, `src/regex/comptime_regex.mojo`);
-steps 2-4 pending
+Status: steps 1-2 implemented (PRs #167, #168;
+`src/regex/comptime_regex.mojo`); steps 3-4 pending
 Supersedes: PR #54 (closed)
 
 > Implementation note (post step 1): the probe cannot try/except its
 > way through the char-class path. The `_Global` FFI call is a *hard*
-> comptime-interpreter error, not a catchable exception, so the probe
-> whitelists AST node types before attempting the comptime DFA build.
-> This makes the step-2 cache-free `CharacterClassSIMD` refactor a
-> prerequisite for widening the envelope, not just an optimization.
+> comptime-interpreter error, not a catchable exception, so step 1
+> whitelisted AST node types before attempting the comptime DFA build.
+>
+> Post step 2: `compile_dfa_pattern[use_matcher_cache=False]` constructs
+> SIMD matchers directly (no `_Global`), which removed the whitelist
+> entirely: char classes, negated classes, shorthands, wildcards,
+> bounded quantifiers and multi-class sequences all build at comptime,
+> and every remaining DFA rejection is a catchable raise that falls
+> back to the runtime engine. `is_compile_time()` exists in newer
+> nightlies (`kgen.is_compile_time` is unregistered on this pin) and
+> would let the cache branch internally; revisit on the next bump.
 
 ## TL;DR
 

--- a/src/regex/comptime_regex.mojo
+++ b/src/regex/comptime_regex.mojo
@@ -14,7 +14,9 @@ Dispatch happens at compile time:
 
 - Invalid patterns (parse errors) fail the build via `comptime assert`.
 - Patterns the DFA compiler supports (literals, anchors, quantifiers,
-  alternations) use the comptime-built engine.
+  alternations, character classes, `\\d`/`\\w` shorthands, wildcards,
+  bounded quantifiers, multi-class sequences) use the comptime-built
+  engine.
 - Everything else falls back to the runtime engine (`regex.matcher`),
   keeping full feature parity.
 
@@ -30,7 +32,6 @@ from std.collections.string.string_slice import get_static_string
 from std.os import abort
 
 from regex.aliases import ImmSlice, imm_slice_from_ptr
-from regex.ast import ASTNode, RE, ELEMENT, GROUP, OR, START, END
 from regex.dfa import DFAEngine, compile_dfa_pattern
 from regex.matching import Match, MatchList
 from regex.matcher import (
@@ -56,43 +57,17 @@ struct _CtProbe(Copyable, Movable):
     """True when the full comptime DFA pipeline is available."""
 
 
-def _ast_in_ct_envelope(ast: ASTNode[ImmutUntrackedOrigin]) -> Bool:
-    """True when every node is in the verified comptime envelope.
-
-    Whitelist: literals, groups, alternations and anchors (quantifiers
-    are node attributes, not node types). Everything else (character
-    classes, `\\d`/`\\s` shorthands, wildcard, negations) is excluded
-    because the char-class DFA path calls the `_Global` SIMD-matcher
-    cache, and that external FFI call is a *hard* comptime-interpreter
-    error, not a catchable exception: it cannot be probed with
-    try/except and must be rejected up front. See the proposal's
-    "Pattern envelope" section.
-    """
-    var t = ast.type
-    if not (
-        t == RE
-        or t == ELEMENT
-        or t == GROUP
-        or t == OR
-        or t == START
-        or t == END
-    ):
-        return False
-    for i in range(ast.get_children_len()):
-        if not _ast_in_ct_envelope(ast.get_child(i)):
-            return False
-    return True
-
-
 def _probe(pattern: StaticString) -> _CtProbe:
     """Classify a pattern at comptime.
 
-    Runs the real parser inside the comptime interpreter, checks the
-    AST against the envelope whitelist, and only then attempts the DFA
-    build (whose remaining failure mode, "pattern too complex", is a
-    regular catchable exception). The functions are `raises`, and
-    raising functions cannot initialize a `comptime` value, so failures
-    are folded into flags.
+    Runs the real parser and the real DFA compiler inside the comptime
+    interpreter. The DFA build uses `use_matcher_cache=False` so SIMD
+    char-class matchers are constructed directly: the `_Global` cache's
+    external FFI call is a hard comptime-interpreter error, while every
+    remaining failure mode ("pattern too complex") is a regular
+    catchable exception. The functions are `raises`, and raising
+    functions cannot initialize a `comptime` value, so failures are
+    folded into flags.
 
     Args:
         pattern: The regex pattern (comptime value).
@@ -102,14 +77,12 @@ def _probe(pattern: StaticString) -> _CtProbe:
     """
     try:
         var ast = parse(String(pattern))
-        if not _ast_in_ct_envelope(ast):
-            return _CtProbe(parse_ok=True, dfa_ok=False)
         try:
-            _ = compile_dfa_pattern(ast)
+            _ = compile_dfa_pattern[use_matcher_cache=False](ast)
             return _CtProbe(parse_ok=True, dfa_ok=True)
         except:
-            # Valid regex inside the envelope but still rejected by
-            # the DFA compiler; falls back to the runtime engine.
+            # Valid regex, but rejected by the DFA compiler; falls back
+            # to the runtime engine.
             return _CtProbe(parse_ok=True, dfa_ok=False)
     except:
         return _CtProbe(parse_ok=False, dfa_ok=False)
@@ -130,7 +103,7 @@ def _build_engine(pattern: StaticString) -> DFAEngine:
     """
     try:
         var ast = parse(String(pattern))
-        return compile_dfa_pattern(ast)
+        return compile_dfa_pattern[use_matcher_cache=False](ast)
     except e:
         abort(String(e))
 

--- a/src/regex/dfa.mojo
+++ b/src/regex/dfa.mojo
@@ -38,6 +38,7 @@ from regex.tokens import (
 from regex.simd_ops import (
     CharacterClassSIMD,
     SIMD_WIDTH,
+    create_character_class_matcher,
     get_character_class_matcher,
     apply_quantifier_simd_generic,
     find_in_text_simd,
@@ -348,21 +349,30 @@ struct DFAEngine(Engine):
 
         self.start_state = 0
 
-    def compile_character_class(
+    def compile_character_class[
+        use_matcher_cache: Bool = True
+    ](
         mut self, var char_class: String, min_matches: Int, max_matches: Int
     ) raises:
         """Compile a character class pattern like [a-z]+ into a DFA.
+
+        Parameters:
+            use_matcher_cache: When False, SIMD matchers are constructed
+                directly instead of through the `_Global` cache (comptime
+                interpreter compatibility).
 
         Args:
             char_class: Character class string (e.g., "abcdefghijklmnopqrstuvwxyz" for [a-z]).
             min_matches: Minimum number of matches required.
             max_matches: Maximum number of matches (-1 for unlimited).
         """
-        self.compile_character_class_with_logic(
+        self.compile_character_class_with_logic[use_matcher_cache](
             char_class^, min_matches, max_matches, True
         )
 
-    def compile_character_class_with_logic(
+    def compile_character_class_with_logic[
+        use_matcher_cache: Bool = True
+    ](
         mut self,
         var char_class: String,
         min_matches: Int,
@@ -370,6 +380,11 @@ struct DFAEngine(Engine):
         positive_logic: Bool,
     ) raises:
         """Compile a character class pattern like [a-z]+ or [^a-z]+ into a DFA.
+
+        Parameters:
+            use_matcher_cache: When False, SIMD matchers are constructed
+                directly instead of through the `_Global` cache, whose FFI
+                call the comptime interpreter cannot execute.
 
         Args:
             char_class: Character class string (e.g., "abcdefghijklmnopqrstuvwxyz" for [a-z]).
@@ -379,7 +394,14 @@ struct DFAEngine(Engine):
         """
         # Try to use SIMD optimization for simple character class patterns
         if min_matches >= 0 and positive_logic:
-            self._simd_char_matcher = get_character_class_matcher(char_class)
+            comptime if use_matcher_cache:
+                self._simd_char_matcher = get_character_class_matcher(
+                    char_class
+                )
+            else:
+                self._simd_char_matcher = create_character_class_matcher(
+                    char_class
+                )
             self._has_simd_matcher = True
             # Unlimited quantifiers (+ or *) are eligible for SIMD scan
             self._simd_scan_eligible = max_matches == -1
@@ -580,10 +602,15 @@ struct DFAEngine(Engine):
 
         self.start_state = 0
 
-    def compile_multi_character_class_sequence(
-        mut self, var sequence_info: SequentialPatternInfo
-    ) raises:
+    def compile_multi_character_class_sequence[
+        use_matcher_cache: Bool = True
+    ](mut self, var sequence_info: SequentialPatternInfo) raises:
         """Compile a multi-character class sequence like [a-z]+[0-9]+ into a DFA.
+
+        Parameters:
+            use_matcher_cache: When False, SIMD matchers are constructed
+                directly instead of through the `_Global` cache, whose FFI
+                call the comptime interpreter cannot execute.
 
         Args:
             sequence_info: Information about the character class sequence elements.
@@ -602,9 +629,14 @@ struct DFAEngine(Engine):
             len(sequence_info.elements[0].alternation_branches) == 0
             and sequence_info.elements[0].char_class.byte_length() > 0
         ):
-            self._simd_char_matcher = get_character_class_matcher(
-                sequence_info.elements[0].char_class
-            )
+            comptime if use_matcher_cache:
+                self._simd_char_matcher = get_character_class_matcher(
+                    sequence_info.elements[0].char_class
+                )
+            else:
+                self._simd_char_matcher = create_character_class_matcher(
+                    sequence_info.elements[0].char_class
+                )
             self._has_simd_matcher = True
             # Not scan eligible - this is a multi-element pattern that needs
             # the full DFA state machine, not just consecutive char counting
@@ -2351,8 +2383,17 @@ struct BoyerMoore:
         return positions^
 
 
-def compile_dfa_pattern(ast: ASTNode[MutUntrackedOrigin]) raises -> DFAEngine:
+def compile_dfa_pattern[
+    use_matcher_cache: Bool = True
+](ast: ASTNode[MutUntrackedOrigin]) raises -> DFAEngine:
     """Compile an AST pattern into a DFA engine.
+
+    Parameters:
+        use_matcher_cache: When False, SIMD char-class matchers are
+            constructed directly instead of through the `_Global` cache.
+            Required when running under the comptime interpreter, which
+            cannot execute the cache's external FFI call. Runtime callers
+            should keep the default.
 
     Args:
         ast: AST representing a pattern that may include character classes.
@@ -2383,7 +2424,7 @@ def compile_dfa_pattern(ast: ASTNode[MutUntrackedOrigin]) raises -> DFAEngine:
         var expanded_char_class = _expand_character_range(
             ast.type, char_class_str
         )
-        dfa.compile_character_class_with_logic(
+        dfa.compile_character_class_with_logic[use_matcher_cache](
             expanded_char_class,
             min_matches,
             max_matches,
@@ -2394,7 +2435,9 @@ def compile_dfa_pattern(ast: ASTNode[MutUntrackedOrigin]) raises -> DFAEngine:
     elif _is_multi_character_class_sequence(ast):
         # Handle multi-character class sequences like [a-z]+[0-9]+, \d+\w+
         sequence_info = _extract_multi_class_sequence_info(ast)
-        dfa.compile_multi_character_class_sequence(sequence_info^)
+        dfa.compile_multi_character_class_sequence[use_matcher_cache](
+            sequence_info^
+        )
     elif _is_sequential_character_class_pattern(ast):
         # Handle sequential character class patterns like [+]*\d+[-]*\d+
         sequence_info = _extract_sequential_pattern_info(ast)
@@ -2402,7 +2445,9 @@ def compile_dfa_pattern(ast: ASTNode[MutUntrackedOrigin]) raises -> DFAEngine:
     elif _is_mixed_sequential_pattern(ast):
         # Handle mixed patterns like [0-9]+\.?[0-9]* (numbers with optional decimal)
         sequence_info = _extract_mixed_sequential_pattern_info(ast)
-        dfa.compile_multi_character_class_sequence(sequence_info^)
+        dfa.compile_multi_character_class_sequence[use_matcher_cache](
+            sequence_info^
+        )
     elif _is_alternation_pattern(ast):
         # Handle alternation patterns like a|b, cat|dog, (a|b)
         dfa.compile_alternation(ast)

--- a/src/regex/simd_ops.mojo
+++ b/src/regex/simd_ops.mojo
@@ -1201,6 +1201,53 @@ def get_character_class_matcher(char_class: StringSlice) -> CharacterClassSIMD:
         return CharacterClassSIMD(char_class)
 
 
+@always_inline
+def create_character_class_matcher(
+    char_class: StringSlice,
+) -> CharacterClassSIMD:
+    """Construct a matcher for a character class string, bypassing the
+    `_Global` cache.
+
+    Same string-to-matcher mapping as `get_character_class_matcher`, but
+    every matcher is built directly. This exists for the comptime DFA
+    build path (`compile_dfa_pattern[use_matcher_cache=False]`): the
+    `_Global` storage bottoms out in an external runtime call
+    (`KGEN_CompilerRT_GetOrCreateGlobal`) that the comptime interpreter
+    cannot execute, and the failure is a hard interpreter error rather
+    than a catchable exception. Runtime callers should keep using the
+    cached getter.
+
+    Args:
+        char_class: Character class string (e.g., "0123456789", "[a-z]").
+
+    Returns:
+        A freshly constructed CharacterClassSIMD matcher.
+    """
+    if char_class == DIGITS:
+        return _create_ascii_digits()
+    elif char_class == WORD_CHARS:
+        return _create_word_chars()
+    elif char_class == " \t\n\r\f":  # Common whitespace pattern
+        return _create_whitespace()
+    elif char_class == " \t\n\r\f\v":  # Extended whitespace with vertical tab
+        return _create_whitespace()
+    elif char_class == "abcdefghijklmnopqrstuvwxyz":  # [a-z]
+        return _create_ascii_lowercase()
+    elif char_class == "ABCDEFGHIJKLMNOPQRSTUVWXYZ":  # [A-Z]
+        return _create_ascii_uppercase()
+    elif (
+        char_class == "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    ):  # [a-zA-Z]
+        return _create_ascii_alpha()
+    elif (
+        char_class
+        == "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+    ):  # [a-zA-Z0-9]
+        return _create_ascii_alphanumeric()
+    else:
+        return CharacterClassSIMD(char_class)
+
+
 def process_text_with_matcher[
     T: SIMDMatcher
 ](matcher: T, text: String, start: Int = 0) -> List[Int]:

--- a/tests/test_comptime_regex.mojo
+++ b/tests/test_comptime_regex.mojo
@@ -41,10 +41,11 @@ def test_search_alternation() raises:
     assert_false(search["(x|y)"]("abc"))
 
 
-def test_search_fallback_char_class() raises:
-    # [0-9]+ is outside the comptime DFA envelope (char-class SIMD
-    # matcher uses a _Global); must transparently fall back to the
-    # runtime engine with identical semantics.
+def test_search_char_class() raises:
+    # Since the use_matcher_cache=False DFA path landed, char classes
+    # build at comptime (previously they fell back to the runtime
+    # engine because the _Global SIMD-matcher cache FFI call is not
+    # interpretable).
     var m = search["[0-9]+"]("order 1234 shipped")
     assert_true(m)
     assert_equal(m.value().start_idx, 6)
@@ -52,12 +53,46 @@ def test_search_fallback_char_class() raises:
     assert_false(search["[0-9]+"]("no digits"))
 
 
+def test_search_char_class_families() raises:
+    # Negated class
+    var neg = search["[^abc]+"]("abxyc")
+    assert_true(neg)
+    assert_equal(neg.value().start_idx, 2)
+    assert_equal(neg.value().end_idx, 4)
+    # Word shorthand
+    assert_true(search["\\w+"]("...abc..."))
+    # Bounded quantifier
+    var bounded = search["[0-9]{3}"]("id 4567")
+    assert_true(bounded)
+    assert_equal(bounded.value().start_idx, 3)
+    assert_equal(bounded.value().end_idx, 6)
+    # Multi-class sequence
+    var seq = search["[a-z]+[0-9]+"]("QQab12ZZ")
+    assert_true(seq)
+    assert_equal(seq.value().start_idx, 2)
+    assert_equal(seq.value().end_idx, 6)
+
+
+def test_search_fallback_complex() raises:
+    # These raise "pattern too complex" in the DFA compiler, so they
+    # transparently fall back to the runtime engine.
+    var m = search["(a|b)x"]("zbxq")
+    assert_true(m)
+    assert_equal(m.value().start_idx, 1)
+    assert_equal(m.value().end_idx, 3)
+    assert_false(search["(a|b)x"]("zzz"))
+    var m2 = search["h[ae]llo"]("say hallo")
+    assert_true(m2)
+    assert_equal(m2.value().start_idx, 4)
+
+
 def test_match_first_literal() raises:
     assert_true(match_first["hello"]("hello world"))
     assert_false(match_first["hello"]("say hello"))
 
 
-def test_match_first_fallback() raises:
+def test_match_first_char_class() raises:
+    # \\d+ builds at comptime since the cache-free DFA path landed.
     assert_true(match_first["\\d+"]("42 is the answer"))
     assert_false(match_first["\\d+"]("answer is 42"))
 
@@ -69,7 +104,7 @@ def test_findall_literal() raises:
     assert_equal(matches[3].start_idx, 8)
 
 
-def test_findall_fallback() raises:
+def test_findall_char_class() raises:
     var matches = findall["[0-9]+"]("1 22 333")
     assert_equal(len(matches), 3)
     assert_equal(matches[2].start_idx, 5)


### PR DESCRIPTION
Implements **step 2** of `proposals/comptime-regex.md`: character classes now build at compile time.

## Problem

The comptime DFA build was limited to literals, anchors, quantifiers and alternations: the char-class path acquires its SIMD matcher through the `_Global` cache, whose external FFI call (`KGEN_CompilerRT_GetOrCreateGlobal`) is a **hard comptime-interpreter error**, not a catchable exception.

## Change

- **`simd_ops.mojo`**: new `create_character_class_matcher`, the same string-to-matcher mapping as `get_character_class_matcher` but constructing every matcher directly, no `_Global` involved.
- **`dfa.mojo`**: a comptime `use_matcher_cache: Bool = True` parameter threaded through `compile_dfa_pattern` -> `compile_character_class(_with_logic)` / `compile_multi_character_class_sequence`; the two live acquisition sites select cached getter vs direct factory with `comptime if`. Default `True` keeps every existing caller source- and behavior-identical.
- **`comptime_regex.mojo`**: probe + engine build use `compile_dfa_pattern[use_matcher_cache=False]`, and the AST node-type whitelist is **removed**: with the FFI out of the path, every remaining DFA rejection is a catchable raise that falls back to the runtime engine.

## Envelope (verified across a 16-pattern matrix)

Now building at comptime: `[0-9]+`, `[a-z]+`, `[a-zA-Z0-9]+`, `[^abc]+`, `\d+`, `\w+`, `.*`, `[0-9]{3}`, `[a-z]+[0-9]+`, `(abc)+`, `[0-9]+\.?[0-9]*`, `[+-]?[0-9]+`. Falling back via catchable raise: `\s`, `h[ae]llo`, `^[a-z]+$`, `(a|b)x` (same patterns the runtime DFA rejects).

## Runtime impact: none, proven

Machine load (5-9) made benchmark timing unusable (swings both directions between interleaved runs), so instead of timing: a **normalized objdump diff** of `bench_engine` built with and without the change shows identical instruction counts (239,794) and opcodes; the only differences are source-line-number immediates in assert paths.

Also recorded in the proposal: `is_compile_time()` (`kgen.is_compile_time`) is unregistered on the pinned nightly but exists in newer ones; once the toolchain catches up, the cache getter could branch internally and the parameter threading could be retired.

## Testing

- 12 tests in `test_comptime_regex.mojo` (new char-class family coverage: negated classes, `\w`, bounded quantifiers, multi-class sequences; genuine too-complex fallbacks).
- Full suite: **389 tests pass, zero warnings**.

Folds a section into the in-flight v0.21.0 changelog block per the mid-version release rules.