### PR TITLE
Bump mojo to 1.0.0b3.dev2026071505 nightly

### DIFF
--- a/benchmarks/bench_engine.mojo
+++ b/benchmarks/bench_engine.mojo
@@ -125,12 +125,12 @@ def _dev_mode() -> Bool:
     return _arg_has("--dev")
 
 
-def _min_sample_ns() -> UInt:
-    return UInt(MIN_SAMPLE_NS_DEV) if _dev_mode() else UInt(MIN_SAMPLE_NS_PROD)
+def _min_sample_ns() -> Int:
+    return Int(MIN_SAMPLE_NS_DEV) if _dev_mode() else Int(MIN_SAMPLE_NS_PROD)
 
 
-def _target_runtime_ns() -> UInt:
-    return UInt(TARGET_RUNTIME_NS_DEV) if _dev_mode() else UInt(
+def _target_runtime_ns() -> Int:
+    return Int(TARGET_RUNTIME_NS_DEV) if _dev_mode() else Int(
         TARGET_RUNTIME_NS_PROD
     )
 
@@ -205,13 +205,10 @@ def benchmark_match_first(
 
     # Collect per-iteration times
     var times = List[Float64]()
-    var total_time: UInt = 0
+    var total_time: Int = 0
     var actual_iterations = 0
 
-    while (
-        total_time < UInt(target_runtime_ns)
-        and actual_iterations < MAX_ITERATIONS
-    ):
+    while total_time < target_runtime_ns and actual_iterations < MAX_ITERATIONS:
         var start_time = perf_counter_ns()
 
         for _ in range(iters):
@@ -259,13 +256,10 @@ def benchmark_search(
         iters = iters * multiplier
 
     var times = List[Float64]()
-    var total_time: UInt = 0
+    var total_time: Int = 0
     var actual_iterations = 0
 
-    while (
-        total_time < UInt(target_runtime_ns)
-        and actual_iterations < MAX_ITERATIONS
-    ):
+    while total_time < target_runtime_ns and actual_iterations < MAX_ITERATIONS:
         var start_time = perf_counter_ns()
 
         for _ in range(iters):
@@ -318,13 +312,10 @@ def benchmark_search_comptime[
         iters = iters * multiplier
 
     var times = List[Float64]()
-    var total_time: UInt = 0
+    var total_time: Int = 0
     var actual_iterations = 0
 
-    while (
-        total_time < UInt(target_runtime_ns)
-        and actual_iterations < MAX_ITERATIONS
-    ):
+    while total_time < target_runtime_ns and actual_iterations < MAX_ITERATIONS:
         var start_time = perf_counter_ns()
 
         for _ in range(iters):
@@ -374,13 +365,10 @@ def benchmark_search_runtime_api(
         iters = iters * multiplier
 
     var times = List[Float64]()
-    var total_time: UInt = 0
+    var total_time: Int = 0
     var actual_iterations = 0
 
-    while (
-        total_time < UInt(target_runtime_ns)
-        and actual_iterations < MAX_ITERATIONS
-    ):
+    while total_time < target_runtime_ns and actual_iterations < MAX_ITERATIONS:
         var start_time = perf_counter_ns()
 
         for _ in range(iters):
@@ -429,13 +417,10 @@ def benchmark_findall(
         iters = iters * multiplier
 
     var times = List[Float64]()
-    var total_time: UInt = 0
+    var total_time: Int = 0
     var actual_iterations = 0
 
-    while (
-        total_time < UInt(target_runtime_ns)
-        and actual_iterations < MAX_ITERATIONS
-    ):
+    while total_time < target_runtime_ns and actual_iterations < MAX_ITERATIONS:
         var start_time = perf_counter_ns()
 
         for _ in range(iters):
@@ -483,13 +468,10 @@ def benchmark_is_match(
 
     # Collect per-iteration times
     var times = List[Float64]()
-    var total_time: UInt = 0
+    var total_time: Int = 0
     var actual_iterations = 0
 
-    while (
-        total_time < UInt(target_runtime_ns)
-        and actual_iterations < MAX_ITERATIONS
-    ):
+    while total_time < target_runtime_ns and actual_iterations < MAX_ITERATIONS:
         var start_time = perf_counter_ns()
 
         for _ in range(iters):
@@ -536,13 +518,10 @@ def benchmark_sub(
         iters = iters * multiplier
 
     var times = List[Float64]()
-    var total_time: UInt = 0
+    var total_time: Int = 0
     var actual_iterations = 0
 
-    while (
-        total_time < UInt(target_runtime_ns)
-        and actual_iterations < MAX_ITERATIONS
-    ):
+    while total_time < target_runtime_ns and actual_iterations < MAX_ITERATIONS:
         var start_time = perf_counter_ns()
 
         for _ in range(iters):

--- a/pixi.lock
+++ b/pixi.lock
@@ -32,10 +32,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026062806-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026062806-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026062806-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026062806-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026071505-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026071505-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026071505-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026071505-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
@@ -76,10 +76,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.22-h1a92334_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.1-h1b79a29_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026062806-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026062806-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026062806-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026062806-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026071505-release.conda
+      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026071505-release.conda
+      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026071505-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026071505-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
@@ -133,10 +133,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026062806-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026062806-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026062806-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026062806-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026071505-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026071505-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026071505-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026071505-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
@@ -179,10 +179,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.22-h1a92334_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.1-h1b79a29_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026062806-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026062806-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026062806-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026062806-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026071505-release.conda
+      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026071505-release.conda
+      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026071505-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026071505-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
@@ -585,10 +585,10 @@ packages:
   license_family: Other
   size: 47759
   timestamp: 1774072956767
-- conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026062806-release.conda
+- conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026071505-release.conda
   noarch: python
-  sha256: dfaae72b44ad19644ad90b44e034231baadf7f02791335caaaec97ff2b6c7b10
-  md5: 37d44a6f9eed4d2d2b53c041f5361397
+  sha256: e8a5ca867d5c2ed7e792e55e02e0823431ac2a754f331d864aa8ae42c018dd27
+  md5: 8898e2b16174879dffcb56d327e8143a
   depends:
   - python >=3.10
   - click >=8.0.0
@@ -598,55 +598,55 @@ packages:
   - platformdirs >=2
   - tomli >=1.1.0
   license: LicenseRef-Modular-Proprietary
-  size: 134645
-  timestamp: 1782628802579
-- conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026062806-release.conda
-  sha256: ea8438bc30ce2bbfdc15f6dfd293d1f6a2347abbb078aa5068f99fadaf9ba2f7
-  md5: 88464b6cc2bb1324351eea2731f245a8
+  size: 135928
+  timestamp: 1784095099246
+- conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026071505-release.conda
+  sha256: 3791890a6d528f532ce615f7e9b7bc985e2e70574a0c22a069d10f1c67caf0eb
+  md5: 166a6d53f945888ad756e49409add54d
   depends:
   - python >=3.10
-  - mojo-compiler ==1.0.0b3.dev2026062806
-  - mblack ==26.5.0.dev2026062806
+  - mojo-compiler ==1.0.0b3.dev2026071505
+  - mblack ==26.5.0.dev2026071505
   - jupyter_client >=8.6.2,<8.7
   license: LicenseRef-Modular-Proprietary
-  size: 114370329
-  timestamp: 1782628970657
-- conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026062806-release.conda
-  sha256: 473fd9954822d04458064fb349d3cd4702fd6a426ad384535f7e492fd198c6a3
-  md5: 71cefdf2277ab5c468a7e2b9875b32db
+  size: 114214533
+  timestamp: 1784095247495
+- conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026071505-release.conda
+  sha256: 777eb27b603495edf7382dcff550098a3b5550aeddeb4f2ff1a67965c82bfdc2
+  md5: 2a33e96ef41b9752d46d391252d4c168
   depends:
   - python >=3.10
-  - mojo-compiler ==1.0.0b3.dev2026062806
-  - mblack ==26.5.0.dev2026062806
+  - mojo-compiler ==1.0.0b3.dev2026071505
+  - mblack ==26.5.0.dev2026071505
   - jupyter_client >=8.6.2,<8.7
   license: LicenseRef-Modular-Proprietary
-  size: 99942071
-  timestamp: 1782629175524
-- conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026062806-release.conda
-  sha256: 02a9510b861673629b49b3a39d7f20690dd9bd75201aca519e2a965a2f4e3284
-  md5: 9e07563cb01fe15a30f8f84744c961de
+  size: 99845678
+  timestamp: 1784095384768
+- conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026071505-release.conda
+  sha256: 5a4a74104a833d263501f840a0a2f53cb6a193b465c1521ea84dc4ec366fe6bb
+  md5: c9d367b9e0d09a2bbec34fa7710bf174
   depends:
-  - mojo-python ==1.0.0b3.dev2026062806
+  - mojo-python ==1.0.0b3.dev2026071505
   license: LicenseRef-Modular-Proprietary
-  size: 81488718
-  timestamp: 1782628993842
-- conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026062806-release.conda
-  sha256: 03c4a79e38a45a8d9857b81bde334c535b4cd92846c3104ff06ccfc1a67d03b1
-  md5: 796f909a7ed7c32c98661769d6c49949
+  size: 81520821
+  timestamp: 1784095269810
+- conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026071505-release.conda
+  sha256: 63aa13790b3f0a8b9787aa5f5797bd7dbf85fcfa6d493c7d1b1110ccd581911c
+  md5: 9e002dc7b31460708d391c8a6fc2910b
   depends:
-  - mojo-python ==1.0.0b3.dev2026062806
+  - mojo-python ==1.0.0b3.dev2026071505
   license: LicenseRef-Modular-Proprietary
-  size: 62989159
-  timestamp: 1782629181997
-- conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026062806-release.conda
+  size: 63006140
+  timestamp: 1784095386731
+- conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026071505-release.conda
   noarch: python
-  sha256: 4b4b39680bebf929e105cccc6266da06f9b3feca020154aa6a049fc176ea2a63
-  md5: 1f384f8afdd161f7b8746e8a935ffc77
+  sha256: bccdffb277d6db1d75b5367be3e93042eeffaa35b8f592a093be9dd67ad78aff
+  md5: 07f38dcb5d809e36d26a9692e55097ec
   depends:
   - python >=3.10
   license: LicenseRef-Modular-Proprietary
-  size: 24111
-  timestamp: 1782628802253
+  size: 24101
+  timestamp: 1784095098880
 - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
   sha256: 6ed158e4e5dd8f6a10ad9e525631e35cee8557718f83de7a4e3966b1f772c4b1
   md5: e9c622e0d00fa24a6292279af3ab6d06

--- a/pixi.toml
+++ b/pixi.toml
@@ -19,7 +19,7 @@ version = "0.21.0"
 backend = { name = "pixi-build-rattler-build", version = "*" }
 
 [dependencies]
-mojo = "==1.0.0b3.dev2026062806"
+mojo = "==1.0.0b3.dev2026071505"
 
 [tasks]
 test = "bash -c 'status=0; for f in tests/test_*.mojo; do echo \"Running $f...\"; out=$(mktemp -d); mojo build -I ./src -debug-level=line-tables \"$f\" -o \"$out/exe\" && \"$out/exe\" || status=1; rm -rf \"$out\"; done; exit $status'"

--- a/src/regex/ast.mojo
+++ b/src/regex/ast.mojo
@@ -1,4 +1,4 @@
-from std.memory import Pointer, UnsafePointer, memcpy, alloc
+from std.memory import Pointer, UnsafePointer, unsafe_memcpy, alloc
 from std.os import abort
 
 from regex.aliases import (
@@ -162,7 +162,7 @@ struct Regex[origin: Origin](Copyable, Equatable, Movable, Writable):
         #     ": ",
         #     child,
         # )
-        (self.children_ptr + self.children_len).init_pointee_move(child^)
+        (self.children_ptr + self.children_len).unsafe_write(child^)
         self.children_len += 1
 
 

--- a/src/regex/matcher.mojo
+++ b/src/regex/matcher.mojo
@@ -232,7 +232,7 @@ struct DFAMatcher(Boolable, Copyable, Movable, RegexMatcher):
         """
         engine = compile_dfa_pattern(ast)
         var ptr = alloc[DFAEngine](1)
-        ptr.init_pointee_move(engine^)
+        ptr.unsafe_write(engine^)
         self.engine_ptr = ptr
 
     def __init__(out self, *, copy: Self):
@@ -311,11 +311,11 @@ struct NFAMatcher(Copyable, Movable, RegexMatcher):
             if _program_has_end_anchor(vm.program):
                 self._onepass_ptr = compile_onepass(vm.program.copy())
             var ptr = alloc[LazyDFA](1)
-            # `init_pointee_move` constructs into uninitialized memory.
+            # `unsafe_write` constructs into uninitialized memory.
             # The previous `self._lazy_dfa_ptr[] = LazyDFA(vm^)` form ran
             # move-assignment into garbage storage, which was the source
             # of the flaky double-free at process exit (issue #97).
-            ptr.init_pointee_move(LazyDFA(vm^))
+            ptr.unsafe_write(LazyDFA(vm^))
             self._lazy_dfa_ptr = ptr
         else:
             self._lazy_dfa_ptr = None
@@ -326,13 +326,13 @@ struct NFAMatcher(Copyable, Movable, RegexMatcher):
         self.ast = copy.ast
         if copy._lazy_dfa_ptr:
             var ptr = alloc[LazyDFA](1)
-            ptr.init_pointee_move(copy._lazy_dfa_ptr.value()[].copy())
+            ptr.unsafe_write(copy._lazy_dfa_ptr.value()[].copy())
             self._lazy_dfa_ptr = ptr
         else:
             self._lazy_dfa_ptr = None
         if copy._onepass_ptr:
             var ptr = alloc[OnePassNFA](1)
-            ptr.init_pointee_move(copy._onepass_ptr.value()[].copy())
+            ptr.unsafe_write(copy._onepass_ptr.value()[].copy())
             self._onepass_ptr = ptr
         else:
             self._onepass_ptr = None
@@ -349,11 +349,11 @@ struct NFAMatcher(Copyable, Movable, RegexMatcher):
         """Free the heap-allocated engines if we still own them."""
         if self._lazy_dfa_ptr:
             var ptr = self._lazy_dfa_ptr.value()
-            ptr.destroy_pointee()
+            ptr.unsafe_deinit_pointee()
             ptr.free()
         if self._onepass_ptr:
             var ptr = self._onepass_ptr.value()
-            ptr.destroy_pointee()
+            ptr.unsafe_deinit_pointee()
             ptr.free()
 
     @always_inline

--- a/src/regex/matching.mojo
+++ b/src/regex/matching.mojo
@@ -1,4 +1,4 @@
-from std.memory import UnsafePointer, memcpy, alloc
+from std.memory import UnsafePointer, unsafe_memcpy, alloc
 
 
 struct Match[origin: ImmutOrigin](Copyable, Movable, TrivialRegisterPassable):
@@ -94,7 +94,7 @@ struct MatchList[origin: ImmutOrigin](Copyable, Movable, Sized):
         self._capacity = 0
         if copy._len > 0:
             self._realloc(copy._capacity)
-            memcpy(dest=self._data, src=copy._data, count=copy._len)
+            unsafe_memcpy(dest=self._data, src=copy._data, count=copy._len)
             self._len = copy._len
         # # Comment when debug is done
         # var call_location = __call_location()
@@ -131,7 +131,7 @@ struct MatchList[origin: ImmutOrigin](Copyable, Movable, Sized):
         var new_data = alloc[Match[Self.origin]](new_capacity)
 
         if self._capacity > 0:
-            memcpy(dest=new_data, src=self._data, count=len(self))
+            unsafe_memcpy(dest=new_data, src=self._data, count=len(self))
             self._data.free()
         self._data = new_data
         self._capacity = new_capacity

--- a/src/regex/onepass.mojo
+++ b/src/regex/onepass.mojo
@@ -338,7 +338,7 @@ def compile_onepass(
         is_end_match_flags.append(states[i].is_end_match)
 
     var ptr = alloc[OnePassNFA](1)
-    ptr.init_pointee_move(
+    ptr.unsafe_write(
         OnePassNFA(
             runtime_transitions^,
             is_match_flags^,

--- a/src/regex/parser.mojo
+++ b/src/regex/parser.mojo
@@ -482,7 +482,7 @@ def parse(pattern: String) raises -> ASTNode[ImmutUntrackedOrigin]:
     # Create a persistent Regex object to hold the pattern and children
     # Allocate on heap to ensure it survives function return
     var regex_ptr = alloc[Regex[ImmutUntrackedOrigin]](1)
-    regex_ptr.init_pointee_move(Regex[ImmutUntrackedOrigin](pattern))
+    regex_ptr.unsafe_write(Regex[ImmutUntrackedOrigin](pattern))
 
     # Tokenize the pattern
     var tokens = scan(pattern)

--- a/tests/test_onepass.mojo
+++ b/tests/test_onepass.mojo
@@ -24,7 +24,7 @@ def test_onepass_compiles_simple_literal() raises:
     assert_true(Bool(opt_ptr))
     if opt_ptr:
         var ptr = opt_ptr.value()
-        ptr.destroy_pointee()
+        ptr.unsafe_deinit_pointee()
         ptr.free()
 
 
@@ -37,7 +37,7 @@ def test_onepass_compiles_phone_validation() raises:
     assert_true(Bool(opt_ptr))
     if opt_ptr:
         var ptr = opt_ptr.value()
-        ptr.destroy_pointee()
+        ptr.unsafe_deinit_pointee()
         ptr.free()
 
 
@@ -55,7 +55,7 @@ def test_onepass_literal_matches() raises:
     if m_good:
         assert_equal(m_good.value().start_idx, 0)
         assert_equal(m_good.value().end_idx, 3)
-    ptr.destroy_pointee()
+    ptr.unsafe_deinit_pointee()
     ptr.free()
 
 
@@ -73,7 +73,7 @@ def test_onepass_end_anchor() raises:
     assert_false(Bool(m_miss))
     if m_hit:
         assert_equal(m_hit.value().end_idx, 4)
-    ptr.destroy_pointee()
+    ptr.unsafe_deinit_pointee()
     ptr.free()
 
 


### PR DESCRIPTION
Routine toolchain bump from `1.0.0b3.dev2026062806` to the latest nightly `1.0.0b3.dev2026071505`. Two adaptations were required.

## 1. UnsafePointer method renames

The nightly deprecated three names; drop-in replacements verified against the pinned toolchain:

| Old | New |
|---|---|
| `init_pointee_move` | `unsafe_write` |
| `destroy_pointee` | `unsafe_deinit_pointee` |
| `memcpy` (free fn from `std.memory`) | `unsafe_memcpy` |

Applied across `ast`, `matcher`, `matching`, `onepass`, `parser` and `tests/test_onepass`.

## 2. `perf_counter_ns()` now returns `Int` (was `UInt`)

Int and UInt no longer convert implicitly, so the benchmark timing infra clashed (`cal_elapsed < min_sample_ns` → `Int < UInt` error). Switched `_min_sample_ns` / `_target_runtime_ns` return types, the `total_time` accumulators and the target-runtime comparisons from `UInt` to `Int`. No behavioral change (durations are always positive and fit in Int64).

## Verification

- **389 tests pass**, zero failures.
- **Zero compiler warnings** across `src`, `tests` and the `bench_engine` build.
- Benchmark binary builds clean.

Folds into the in-flight v0.21.0 per the mid-version rules (no version bump; the recipe rev updates when v0.21.0 is unblocked on the stable channel).