### PR TITLE
Bump mojo to 1.0.0b3.dev2026071705 nightly

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -32,10 +32,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026071505-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026071505-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026071505-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026071505-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026071705-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026071705-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026071705-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026071705-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
@@ -76,10 +76,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.22-h1a92334_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.1-h1b79a29_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026071505-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026071505-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026071505-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026071505-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026071705-release.conda
+      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026071705-release.conda
+      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026071705-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026071705-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
@@ -133,10 +133,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026071505-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026071505-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026071505-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026071505-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026071705-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026071705-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026071705-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026071705-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
@@ -179,10 +179,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.22-h1a92334_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.1-h1b79a29_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026071505-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026071505-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026071505-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026071505-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026071705-release.conda
+      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026071705-release.conda
+      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026071705-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026071705-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
@@ -585,10 +585,10 @@ packages:
   license_family: Other
   size: 47759
   timestamp: 1774072956767
-- conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026071505-release.conda
+- conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026071705-release.conda
   noarch: python
-  sha256: e8a5ca867d5c2ed7e792e55e02e0823431ac2a754f331d864aa8ae42c018dd27
-  md5: 8898e2b16174879dffcb56d327e8143a
+  sha256: 63c8b6a4b423f42812f5d24f0f03fa15da51643f886bbeee88875b76741f5874
+  md5: f1a4f14e1e0056a7d360bd7bc16996aa
   depends:
   - python >=3.10
   - click >=8.0.0
@@ -598,55 +598,55 @@ packages:
   - platformdirs >=2
   - tomli >=1.1.0
   license: LicenseRef-Modular-Proprietary
-  size: 135928
-  timestamp: 1784095099246
-- conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026071505-release.conda
-  sha256: 3791890a6d528f532ce615f7e9b7bc985e2e70574a0c22a069d10f1c67caf0eb
-  md5: 166a6d53f945888ad756e49409add54d
+  size: 135943
+  timestamp: 1784268163251
+- conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026071705-release.conda
+  sha256: 518400dd792b9b24a2a50ad8015d101575b6405b5bf631176875dc0f6ab9cafa
+  md5: 8962c9660783de6a3a311d395a385083
   depends:
   - python >=3.10
-  - mojo-compiler ==1.0.0b3.dev2026071505
-  - mblack ==26.5.0.dev2026071505
+  - mojo-compiler ==1.0.0b3.dev2026071705
+  - mblack ==26.5.0.dev2026071705
   - jupyter_client >=8.6.2,<8.7
   license: LicenseRef-Modular-Proprietary
-  size: 114214533
-  timestamp: 1784095247495
-- conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026071505-release.conda
-  sha256: 777eb27b603495edf7382dcff550098a3b5550aeddeb4f2ff1a67965c82bfdc2
-  md5: 2a33e96ef41b9752d46d391252d4c168
+  size: 114213351
+  timestamp: 1784268239550
+- conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026071705-release.conda
+  sha256: f0605c35588031a4515bf52fae4c662c0d876f69f01c9b33df1c8853b754b6be
+  md5: f8ddc87d9ac6299a6a701d296aa424c1
   depends:
   - python >=3.10
-  - mojo-compiler ==1.0.0b3.dev2026071505
-  - mblack ==26.5.0.dev2026071505
+  - mojo-compiler ==1.0.0b3.dev2026071705
+  - mblack ==26.5.0.dev2026071705
   - jupyter_client >=8.6.2,<8.7
   license: LicenseRef-Modular-Proprietary
-  size: 99845678
-  timestamp: 1784095384768
-- conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026071505-release.conda
-  sha256: 5a4a74104a833d263501f840a0a2f53cb6a193b465c1521ea84dc4ec366fe6bb
-  md5: c9d367b9e0d09a2bbec34fa7710bf174
+  size: 99862436
+  timestamp: 1784268593139
+- conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026071705-release.conda
+  sha256: 5774e1fc0d9d0c8ec32f8181378c335b02febd1d9dc5f94f85d323306282039f
+  md5: 0cf012a14b751b3cb561e2f247d1a748
   depends:
-  - mojo-python ==1.0.0b3.dev2026071505
+  - mojo-python ==1.0.0b3.dev2026071705
   license: LicenseRef-Modular-Proprietary
-  size: 81520821
-  timestamp: 1784095269810
-- conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026071505-release.conda
-  sha256: 63aa13790b3f0a8b9787aa5f5797bd7dbf85fcfa6d493c7d1b1110ccd581911c
-  md5: 9e002dc7b31460708d391c8a6fc2910b
+  size: 81540428
+  timestamp: 1784268272284
+- conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026071705-release.conda
+  sha256: 92d6e0174c67f29094ca8f3a80285cf61a906d4a11a663fd7b26ab4957b5eb56
+  md5: fa580e9d91519c6468ccd271f0d9be86
   depends:
-  - mojo-python ==1.0.0b3.dev2026071505
+  - mojo-python ==1.0.0b3.dev2026071705
   license: LicenseRef-Modular-Proprietary
-  size: 63006140
-  timestamp: 1784095386731
-- conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026071505-release.conda
+  size: 63024178
+  timestamp: 1784268450841
+- conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026071705-release.conda
   noarch: python
-  sha256: bccdffb277d6db1d75b5367be3e93042eeffaa35b8f592a093be9dd67ad78aff
-  md5: 07f38dcb5d809e36d26a9692e55097ec
+  sha256: 342a24388cfd41cd806d4c660b21f0b5adbfac9d548535b9f743e654e2c3aa6b
+  md5: 125efdc3db83b9e4f0ab36e275247877
   depends:
   - python >=3.10
   license: LicenseRef-Modular-Proprietary
-  size: 24101
-  timestamp: 1784095098880
+  size: 24126
+  timestamp: 1784268163344
 - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
   sha256: 6ed158e4e5dd8f6a10ad9e525631e35cee8557718f83de7a4e3966b1f772c4b1
   md5: e9c622e0d00fa24a6292279af3ab6d06

--- a/pixi.toml
+++ b/pixi.toml
@@ -19,7 +19,7 @@ version = "0.21.0"
 backend = { name = "pixi-build-rattler-build", version = "*" }
 
 [dependencies]
-mojo = "==1.0.0b3.dev2026071505"
+mojo = "==1.0.0b3.dev2026071705"
 
 [tasks]
 test = "bash -c 'status=0; for f in tests/test_*.mojo; do echo \"Running $f...\"; out=$(mktemp -d); mojo build -I ./src -debug-level=line-tables \"$f\" -o \"$out/exe\" && \"$out/exe\" || status=1; rm -rf \"$out\"; done; exit $status'"

--- a/src/regex/ast.mojo
+++ b/src/regex/ast.mojo
@@ -80,11 +80,11 @@ def _make_children_indexes(*values: UInt16) -> ChildrenIndexes:
 
 
 struct Regex[origin: Origin](Copyable, Equatable, Movable, Writable):
-    comptime ImmOrigin = ImmutOrigin(Self.origin)
+    comptime ImmOrigin = ImmOrigin(Self.origin)
     comptime Immutable = Regex[origin=Self.ImmOrigin]
     var pattern: String
     var children_ptr: UnsafePointer[
-        ASTNode[ImmutUntrackedOrigin], MutUntrackedOrigin
+        ASTNode[ImmUntrackedOrigin], MutUntrackedOrigin
     ]
     var children_len: Int
     """Regex struct for representing a regular expression pattern."""
@@ -93,7 +93,7 @@ struct Regex[origin: Origin](Copyable, Equatable, Movable, Writable):
         """Initialize a Regex with a pattern."""
         self.pattern = pattern
         self.children_len = 0
-        self.children_ptr = alloc[ASTNode[ImmutUntrackedOrigin]](
+        self.children_ptr = alloc[ASTNode[ImmUntrackedOrigin]](
             pattern.byte_length() * 2
         )  # Allocate enough space for children
 
@@ -144,7 +144,7 @@ struct Regex[origin: Origin](Copyable, Equatable, Movable, Writable):
         return rebind[Self.Immutable](self).copy()
 
     @always_inline
-    def get_child(self, i: Int) -> ASTNode[ImmutUntrackedOrigin]:
+    def get_child(self, i: Int) -> ASTNode[ImmUntrackedOrigin]:
         """Get the child ASTNode at index `i`."""
         return self.children_ptr[i]
 
@@ -154,7 +154,7 @@ struct Regex[origin: Origin](Copyable, Equatable, Movable, Writable):
         return self.children_len
 
     @always_inline
-    def append_child(mut self, var child: ASTNode[ImmutUntrackedOrigin]):
+    def append_child(mut self, var child: ASTNode[ImmUntrackedOrigin]):
         """Append a child ASTNode to the Regex."""
         # print(
         #     "Appending child to Regex at ",
@@ -166,7 +166,7 @@ struct Regex[origin: Origin](Copyable, Equatable, Movable, Writable):
         self.children_len += 1
 
 
-struct ASTNode[regex_origin: ImmutOrigin](
+struct ASTNode[regex_origin: ImmOrigin](
     Boolable,
     Equatable,
     ImplicitlyCopyable,
@@ -181,9 +181,7 @@ struct ASTNode[regex_origin: ImmutOrigin](
 
     var type: Int
     """The type of AST node (e.g., ELEMENT, GROUP, RANGE, etc.)."""
-    var regex_ptr: UnsafePointer[
-        Regex[ImmutUntrackedOrigin], ImmutUntrackedOrigin
-    ]
+    var regex_ptr: UnsafePointer[Regex[ImmUntrackedOrigin], ImmUntrackedOrigin]
     """Pointer to the parent regex object containing the pattern string."""
     var start_idx: Int
     """Starting position of this node in the original pattern string."""
@@ -211,9 +209,7 @@ struct ASTNode[regex_origin: ImmutOrigin](
     def __init__(
         out self,
         type: Int,
-        regex_ptr: UnsafePointer[
-            Regex[ImmutUntrackedOrigin], ImmutUntrackedOrigin
-        ],
+        regex_ptr: UnsafePointer[Regex[ImmUntrackedOrigin], ImmUntrackedOrigin],
         start_idx: Int,
         end_idx: Int,
         capturing_group: Bool = False,
@@ -240,9 +236,7 @@ struct ASTNode[regex_origin: ImmutOrigin](
 
     def __init__(
         out self,
-        regex_ptr: UnsafePointer[
-            Regex[ImmutUntrackedOrigin], ImmutUntrackedOrigin
-        ],
+        regex_ptr: UnsafePointer[Regex[ImmUntrackedOrigin], ImmUntrackedOrigin],
         type: Int,
         child_index: UInt16,
         start_idx: Int,
@@ -270,9 +264,7 @@ struct ASTNode[regex_origin: ImmutOrigin](
 
     def __init__(
         out self,
-        regex_ptr: UnsafePointer[
-            Regex[ImmutUntrackedOrigin], ImmutUntrackedOrigin
-        ],
+        regex_ptr: UnsafePointer[Regex[ImmUntrackedOrigin], ImmUntrackedOrigin],
         type: Int,
         children_indexes: ChildrenIndexes,
         start_idx: Int,
@@ -542,7 +534,7 @@ struct ASTNode[regex_origin: ImmutOrigin](
         return self.get_children_len() > 0
 
     @always_inline
-    def get_child(self, i: Int) -> ASTNode[ImmutUntrackedOrigin]:
+    def get_child(self, i: Int) -> ASTNode[ImmUntrackedOrigin]:
         """Get the children of the AST node."""
         return self.regex_ptr[].get_child(Int(self.children_indexes[i] - 1))
 
@@ -564,17 +556,17 @@ struct ASTNode[regex_origin: ImmutOrigin](
 def Element[
     regex_origin: Origin,
 ](
-    ref[regex_origin] regex: Regex[ImmutUntrackedOrigin],
+    ref[regex_origin] regex: Regex[ImmUntrackedOrigin],
     start_idx: Int,
     end_idx: Int,
-) -> ASTNode[ImmutUntrackedOrigin]:
+) -> ASTNode[ImmUntrackedOrigin]:
     """Create an Element node with a value string."""
     var regex_ptr = (
         UnsafePointer(to=regex)
         .as_immutable()
-        .unsafe_origin_cast[ImmutUntrackedOrigin]()
+        .unsafe_origin_cast[ImmUntrackedOrigin]()
     )
-    return ASTNode[ImmutUntrackedOrigin](
+    return ASTNode[ImmUntrackedOrigin](
         type=ELEMENT,
         regex_ptr=regex_ptr,
         start_idx=start_idx,
@@ -588,17 +580,17 @@ def Element[
 def WildcardElement[
     regex_origin: Origin,
 ](
-    ref[regex_origin] regex: Regex[ImmutUntrackedOrigin],
+    ref[regex_origin] regex: Regex[ImmUntrackedOrigin],
     start_idx: Int,
     end_idx: Int,
-) -> ASTNode[ImmutUntrackedOrigin]:
+) -> ASTNode[ImmUntrackedOrigin]:
     """Create a WildcardElement node."""
     var regex_ptr = (
         UnsafePointer(to=regex)
         .as_immutable()
-        .unsafe_origin_cast[ImmutUntrackedOrigin]()
+        .unsafe_origin_cast[ImmUntrackedOrigin]()
     )
-    return ASTNode[ImmutUntrackedOrigin](
+    return ASTNode[ImmUntrackedOrigin](
         type=WILDCARD,
         regex_ptr=regex_ptr,
         start_idx=start_idx,
@@ -612,17 +604,17 @@ def WildcardElement[
 def SpaceElement[
     regex_origin: Origin,
 ](
-    ref[regex_origin] regex: Regex[ImmutUntrackedOrigin],
+    ref[regex_origin] regex: Regex[ImmUntrackedOrigin],
     start_idx: Int,
     end_idx: Int,
-) -> ASTNode[ImmutUntrackedOrigin]:
+) -> ASTNode[ImmUntrackedOrigin]:
     """Create a SpaceElement node."""
     var regex_ptr = (
         UnsafePointer(to=regex)
         .as_immutable()
-        .unsafe_origin_cast[ImmutUntrackedOrigin]()
+        .unsafe_origin_cast[ImmUntrackedOrigin]()
     )
-    return ASTNode[ImmutUntrackedOrigin](
+    return ASTNode[ImmUntrackedOrigin](
         type=SPACE,
         regex_ptr=regex_ptr,
         start_idx=start_idx,
@@ -636,17 +628,17 @@ def SpaceElement[
 def DigitElement[
     regex_origin: Origin,
 ](
-    ref[regex_origin] regex: Regex[ImmutUntrackedOrigin],
+    ref[regex_origin] regex: Regex[ImmUntrackedOrigin],
     start_idx: Int,
     end_idx: Int,
-) -> ASTNode[ImmutUntrackedOrigin]:
+) -> ASTNode[ImmUntrackedOrigin]:
     """Create a DigitElement node."""
     var regex_ptr = (
         UnsafePointer(to=regex)
         .as_immutable()
-        .unsafe_origin_cast[ImmutUntrackedOrigin]()
+        .unsafe_origin_cast[ImmUntrackedOrigin]()
     )
-    return ASTNode[ImmutUntrackedOrigin](
+    return ASTNode[ImmUntrackedOrigin](
         type=DIGIT,
         regex_ptr=regex_ptr,
         start_idx=start_idx,
@@ -660,17 +652,17 @@ def DigitElement[
 def WordElement[
     regex_origin: Origin,
 ](
-    ref[regex_origin] regex: Regex[ImmutUntrackedOrigin],
+    ref[regex_origin] regex: Regex[ImmUntrackedOrigin],
     start_idx: Int,
     end_idx: Int,
-) -> ASTNode[ImmutUntrackedOrigin]:
+) -> ASTNode[ImmUntrackedOrigin]:
     """Create a WordElement node."""
     var regex_ptr = (
         UnsafePointer(to=regex)
         .as_immutable()
-        .unsafe_origin_cast[ImmutUntrackedOrigin]()
+        .unsafe_origin_cast[ImmUntrackedOrigin]()
     )
-    return ASTNode[ImmutUntrackedOrigin](
+    return ASTNode[ImmUntrackedOrigin](
         type=WORD,
         regex_ptr=regex_ptr,
         start_idx=start_idx,
@@ -714,23 +706,23 @@ def classify_range_kind(pattern: StringSlice) -> Int:
 def RangeElement[
     regex_origin: Origin,
 ](
-    ref[regex_origin] regex: Regex[ImmutUntrackedOrigin],
+    ref[regex_origin] regex: Regex[ImmUntrackedOrigin],
     start_idx: Int,
     end_idx: Int,
     is_positive_logic: Bool = True,
-) -> ASTNode[ImmutUntrackedOrigin]:
+) -> ASTNode[ImmUntrackedOrigin]:
     """Create a RangeElement node."""
     var regex_ptr = (
         UnsafePointer(to=regex)
         .as_immutable()
-        .unsafe_origin_cast[ImmutUntrackedOrigin]()
+        .unsafe_origin_cast[ImmUntrackedOrigin]()
     )
     # Classify the range pattern once at build time.
     var kind = RANGE_KIND_OTHER
     if start_idx < end_idx:
         var pat = StringSlice(regex.pattern)[byte=start_idx:end_idx]
         kind = classify_range_kind(pat)
-    return ASTNode[ImmutUntrackedOrigin](
+    return ASTNode[ImmUntrackedOrigin](
         type=RANGE,
         regex_ptr=regex_ptr,
         start_idx=start_idx,
@@ -746,17 +738,17 @@ def RangeElement[
 def StartElement[
     regex_origin: Origin,
 ](
-    ref[regex_origin] regex: Regex[ImmutUntrackedOrigin],
+    ref[regex_origin] regex: Regex[ImmUntrackedOrigin],
     start_idx: Int,
     end_idx: Int,
-) -> ASTNode[ImmutUntrackedOrigin]:
+) -> ASTNode[ImmUntrackedOrigin]:
     """Create a StartElement node."""
     var regex_ptr = (
         UnsafePointer(to=regex)
         .as_immutable()
-        .unsafe_origin_cast[ImmutUntrackedOrigin]()
+        .unsafe_origin_cast[ImmUntrackedOrigin]()
     )
-    return ASTNode[ImmutUntrackedOrigin](
+    return ASTNode[ImmUntrackedOrigin](
         type=START,
         regex_ptr=regex_ptr,
         start_idx=start_idx,
@@ -770,17 +762,17 @@ def StartElement[
 def EndElement[
     regex_origin: Origin
 ](
-    ref[regex_origin] regex: Regex[ImmutUntrackedOrigin],
+    ref[regex_origin] regex: Regex[ImmUntrackedOrigin],
     start_idx: Int,
     end_idx: Int,
-) -> ASTNode[ImmutUntrackedOrigin]:
+) -> ASTNode[ImmUntrackedOrigin]:
     """Create an EndElement node."""
     var regex_ptr = (
         UnsafePointer(to=regex)
         .as_immutable()
-        .unsafe_origin_cast[ImmutUntrackedOrigin]()
+        .unsafe_origin_cast[ImmUntrackedOrigin]()
     )
-    return ASTNode[ImmutUntrackedOrigin](
+    return ASTNode[ImmUntrackedOrigin](
         type=END,
         regex_ptr=regex_ptr,
         start_idx=start_idx,
@@ -794,19 +786,19 @@ def EndElement[
 def OrNode[
     regex_origin: Origin
 ](
-    ref[regex_origin] regex: Regex[ImmutUntrackedOrigin],
+    ref[regex_origin] regex: Regex[ImmUntrackedOrigin],
     left_child_index: UInt16,
     right_child_index: UInt16,
     start_idx: Int,
     end_idx: Int,
-) -> ASTNode[ImmutUntrackedOrigin]:
+) -> ASTNode[ImmUntrackedOrigin]:
     """Create an OrNode with left and right children."""
     var regex_ptr = (
         UnsafePointer(to=regex)
         .as_immutable()
-        .unsafe_origin_cast[ImmutUntrackedOrigin]()
+        .unsafe_origin_cast[ImmUntrackedOrigin]()
     )
-    return ASTNode[ImmutUntrackedOrigin](
+    return ASTNode[ImmUntrackedOrigin](
         type=OR,
         regex_ptr=regex_ptr,
         children_indexes=_make_children_indexes(
@@ -823,18 +815,18 @@ def OrNode[
 def NotNode[
     regex_origin: Origin,
 ](
-    ref[regex_origin] regex: Regex[ImmutUntrackedOrigin],
+    ref[regex_origin] regex: Regex[ImmUntrackedOrigin],
     child_index: UInt16,
     start_idx: Int,
     end_idx: Int,
-) -> ASTNode[ImmutUntrackedOrigin]:
+) -> ASTNode[ImmUntrackedOrigin]:
     """Create a NotNode with a child."""
     var regex_ptr = (
         UnsafePointer(to=regex)
         .as_immutable()
-        .unsafe_origin_cast[ImmutUntrackedOrigin]()
+        .unsafe_origin_cast[ImmUntrackedOrigin]()
     )
-    return ASTNode[ImmutUntrackedOrigin](
+    return ASTNode[ImmUntrackedOrigin](
         type=NOT,
         regex_ptr=regex_ptr,
         children_indexes=_make_children_indexes(child_index),
@@ -847,20 +839,20 @@ def NotNode[
 def GroupNode[
     regex_origin: Origin,
 ](
-    ref[regex_origin] regex: Regex[ImmutUntrackedOrigin],
+    ref[regex_origin] regex: Regex[ImmUntrackedOrigin],
     children_indexes: ChildrenIndexes,
     start_idx: Int,
     end_idx: Int,
     capturing_group: Bool = False,
     group_id: Int = -1,
-) -> ASTNode[ImmutUntrackedOrigin]:
+) -> ASTNode[ImmUntrackedOrigin]:
     """Create a GroupNode with children."""
     var regex_ptr = (
         UnsafePointer(to=regex)
         .as_immutable()
-        .unsafe_origin_cast[ImmutUntrackedOrigin]()
+        .unsafe_origin_cast[ImmUntrackedOrigin]()
     )
-    var node = ASTNode[ImmutUntrackedOrigin](
+    var node = ASTNode[ImmUntrackedOrigin](
         type=GROUP,
         regex_ptr=regex_ptr,
         start_idx=start_idx,

--- a/src/regex/comptime_regex.mojo
+++ b/src/regex/comptime_regex.mojo
@@ -152,7 +152,7 @@ def _pattern_slice[pattern: StaticString]() -> ImmSlice:
 
 
 def search[
-    O: ImmutOrigin, //, pattern: StaticString
+    O: ImmOrigin, //, pattern: StaticString
 ](text: StringSlice[O]) raises -> Optional[Match[O]]:
     """Search for `pattern` in `text` (equivalent to `re.search`).
 
@@ -178,7 +178,7 @@ def search[
 
 
 def match_first[
-    O: ImmutOrigin, //, pattern: StaticString
+    O: ImmOrigin, //, pattern: StaticString
 ](text: StringSlice[O]) raises -> Optional[Match[O]]:
     """Match `pattern` at the beginning of `text` (like `re.match`).
 
@@ -207,7 +207,7 @@ def match_first[
 
 
 def findall[
-    O: ImmutOrigin, //, pattern: StaticString
+    O: ImmOrigin, //, pattern: StaticString
 ](text: StringSlice[O]) raises -> MatchList[O]:
     """Find all matches of `pattern` in `text` (like `re.findall`).
 

--- a/src/regex/dfa.mojo
+++ b/src/regex/dfa.mojo
@@ -69,7 +69,7 @@ comptime ALPHANUMERIC = LOWERCASE_LETTERS + UPPERCASE_LETTERS + DIGITS
 
 
 def _expand_character_range[
-    O: ImmutOrigin
+    O: ImmOrigin
 ](node_type: Int, range_str: StringSlice[O],) -> String:
     """Expand a character range like '[a-z]' to 'abcdefghijklmnopqrstuvwxyz'.
 
@@ -1818,7 +1818,7 @@ struct DFAEngine(Engine):
 
     @always_inline
     def is_match[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](self, text: StringSlice[O], start: Int = 0) -> Bool:
         """Check if pattern matches at the given position without computing
         match boundaries. Much faster than match_first for simple checks.
@@ -1855,7 +1855,7 @@ struct DFAEngine(Engine):
 
     @always_inline
     def match_first[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](self, text: StringSlice[O], start: Int = 0) -> Optional[Match[O]]:
         """Execute DFA matching against input text. To be Python compatible,
         it will not match if the start position is not at the beginning of a line.
@@ -1878,7 +1878,7 @@ struct DFAEngine(Engine):
 
     @always_inline
     def match_next[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](self, text: StringSlice[O], start: Int = 0) -> Optional[Match[O]]:
         """Execute DFA matching against input text. It will match from the given start
         position.
@@ -1909,7 +1909,7 @@ struct DFAEngine(Engine):
 
     @always_inline
     def _try_match_at_position[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](
         self,
         text: StringSlice[O],
@@ -2028,7 +2028,7 @@ struct DFAEngine(Engine):
 
         return None
 
-    def match_all[O: ImmutOrigin](self, text: StringSlice[O]) -> MatchList[O]:
+    def match_all[O: ImmOrigin](self, text: StringSlice[O]) -> MatchList[O]:
         """Find all non-overlapping matches using DFA.
 
         Args:
@@ -2134,7 +2134,7 @@ struct DFAEngine(Engine):
 
     @always_inline
     def _try_match_simd[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](self, text: StringSlice[O], start_pos: Int) -> Optional[Match[O]]:
         """SIMD-optimized matching for character class patterns with quantifier support.
 
@@ -2201,7 +2201,7 @@ struct DFAEngine(Engine):
 
     @always_inline
     def _optimized_simd_search[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](self, text: StringSlice[O], start: Int) -> Optional[Match[O]]:
         """Optimized SIMD-based search for character class patterns.
 
@@ -2256,7 +2256,7 @@ struct DFAEngine(Engine):
         return None
 
     def _find_next_matching_char[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](
         self, text: StringSlice[O], start: Int, simd_matcher: CharacterClassSIMD
     ) -> Int:
@@ -2531,7 +2531,7 @@ def _is_simple_character_class_pattern(
 
 
 def _extract_character_class_info(
-    ast: ASTNode[ImmutUntrackedOrigin],
+    ast: ASTNode[ImmUntrackedOrigin],
 ) -> Tuple[Optional[String], Int, Int, Bool, Bool, Bool]:
     """Extract character class information from AST.
 
@@ -2551,7 +2551,7 @@ def _extract_character_class_info(
     var positive_logic = True
 
     # Find the character class node (DIGIT, WORD, or RANGE)
-    var class_node: ASTNode[ImmutUntrackedOrigin]
+    var class_node: ASTNode[ImmUntrackedOrigin]
     if ast.type == DIGIT or ast.type == WORD or ast.type == RANGE:
         class_node = ast
     elif ast.type == RE and ast.get_children_len() == 1:

--- a/src/regex/engine.mojo
+++ b/src/regex/engine.mojo
@@ -11,7 +11,7 @@ trait Engine(Copyable, Movable):
         ...
 
     def match_first[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](self, text: StringSlice[O], start: Int = 0) -> Optional[Match[O]]:
         """Execute DFA matching against input text. To be Python compatible,
         it will not match if the start position is not at the beginning of a line.
@@ -25,7 +25,7 @@ trait Engine(Copyable, Movable):
         """
         ...
 
-    def match_all[O: ImmutOrigin](self, text: StringSlice[O]) -> MatchList[O]:
+    def match_all[O: ImmOrigin](self, text: StringSlice[O]) -> MatchList[O]:
         """Find all non-overlapping matches using Engine.
 
         Args:

--- a/src/regex/literal_optimizer.mojo
+++ b/src/regex/literal_optimizer.mojo
@@ -21,7 +21,7 @@ from regex.ast import (
 )
 
 
-struct LiteralInfo[node_origin: ImmutOrigin](ImplicitlyCopyable, Movable):
+struct LiteralInfo[node_origin: ImmOrigin](ImplicitlyCopyable, Movable):
     """Information about a literal substring found in a regex pattern.
 
     Built only during regex compilation (pattern analysis), never on the
@@ -30,7 +30,7 @@ struct LiteralInfo[node_origin: ImmutOrigin](ImplicitlyCopyable, Movable):
     a raw `UnsafePointer`."""
 
     var node_ptr: Optional[
-        Pointer[ASTNode[ImmutUntrackedOrigin], Self.node_origin]
+        Pointer[ASTNode[ImmUntrackedOrigin], Self.node_origin]
     ]
     """Origin-tracked borrow of the AST node containing the literal (for
     single nodes). `None` when this LiteralInfo refers to a string-index
@@ -49,7 +49,7 @@ struct LiteralInfo[node_origin: ImmutOrigin](ImplicitlyCopyable, Movable):
 
     def __init__(
         out self,
-        ref[Self.node_origin] node: ASTNode[ImmutUntrackedOrigin],
+        ref[Self.node_origin] node: ASTNode[ImmUntrackedOrigin],
         start_offset: Int = 0,
         is_prefix: Bool = False,
         is_suffix: Bool = False,
@@ -117,7 +117,7 @@ struct LiteralInfo[node_origin: ImmutOrigin](ImplicitlyCopyable, Movable):
 
 
 @fieldwise_init
-struct LiteralSet[node_origin: ImmutOrigin](Movable, Sized):
+struct LiteralSet[node_origin: ImmOrigin](Movable, Sized):
     """A set of literals extracted from a regex pattern."""
 
     var literals: List[LiteralInfo[Self.node_origin]]
@@ -215,10 +215,8 @@ struct LiteralSet[node_origin: ImmutOrigin](Movable, Sized):
 
 
 def extract_literals[
-    node_origin: ImmutOrigin
-](ref[node_origin] ast: ASTNode[ImmutUntrackedOrigin]) -> LiteralSet[
-    node_origin
-]:
+    node_origin: ImmOrigin
+](ref[node_origin] ast: ASTNode[ImmUntrackedOrigin]) -> LiteralSet[node_origin]:
     """Extract all literals from a regex AST.
 
     Args:
@@ -241,9 +239,9 @@ def extract_literals[
 
 
 def _extract_from_node[
-    node_origin: ImmutOrigin
+    node_origin: ImmOrigin
 ](
-    node: ASTNode[ImmutUntrackedOrigin],
+    node: ASTNode[ImmUntrackedOrigin],
     mut result: LiteralSet[node_origin],
     offset: Int,
     is_required: Bool,
@@ -333,7 +331,7 @@ def _extract_from_node[
 
 
 def _extract_sequence[
-    node_origin: ImmutOrigin
+    node_origin: ImmOrigin
 ](
     group: ASTNode,
     start_offset: Int,

--- a/src/regex/matcher.mojo
+++ b/src/regex/matcher.mojo
@@ -181,7 +181,7 @@ trait RegexMatcher:
     """Interface for different regex matching engines."""
 
     def match_first[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](self, text: StringSlice[O], start: Int = 0) -> Optional[Match[O]]:
         """Find the first match in text starting from the given position.
 
@@ -195,7 +195,7 @@ trait RegexMatcher:
         ...
 
     def match_all[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](self, text: StringSlice[O]) raises -> MatchList[O]:
         """Find all non-overlapping matches in text.
 
@@ -250,20 +250,20 @@ struct DFAMatcher(Boolable, Copyable, Movable, RegexMatcher):
 
     @always_inline
     def match_first[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](self, text: StringSlice[O], start: Int = 0) -> Optional[Match[O]]:
         """Find first match using DFA execution."""
         return self.engine_ptr.value()[].match_first(text, start)
 
     @always_inline
     def match_next[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](self, text: StringSlice[O], start: Int = 0) -> Optional[Match[O]]:
         """Find first match using DFA execution."""
         return self.engine_ptr.value()[].match_next(text, start)
 
     def match_all[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](self, text: StringSlice[O]) raises -> MatchList[O]:
         """Find all matches using DFA execution."""
         return self.engine_ptr.value()[].match_all(text)
@@ -358,7 +358,7 @@ struct NFAMatcher(Copyable, Movable, RegexMatcher):
 
     @always_inline
     def match_first[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](self, text: StringSlice[O], start: Int = 0) -> Optional[Match[O]]:
         """Find first match. Routing order:
         - LazyDFA when available and the pattern has no `$` anchor
@@ -409,7 +409,7 @@ struct NFAMatcher(Copyable, Movable, RegexMatcher):
 
     @always_inline
     def match_next[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](self, text: StringSlice[O], start: Int = 0) -> Optional[Match[O]]:
         """Search for match."""
         if self._use_lazy_dfa_for_search():
@@ -420,7 +420,7 @@ struct NFAMatcher(Copyable, Movable, RegexMatcher):
 
     @always_inline
     def match_all[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](self, text: StringSlice[O]) raises -> MatchList[O]:
         """Find all matches."""
         if self._use_lazy_dfa_for_search():
@@ -731,7 +731,7 @@ struct HybridMatcher(Copyable, Movable, RegexMatcher):
 
     @always_inline
     def match_first[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](self, text: StringSlice[O], start: Int = 0) -> Optional[Match[O]]:
         """Find first match using optimal engine. This equivalent to re.match in Python.
         """
@@ -753,7 +753,7 @@ struct HybridMatcher(Copyable, Movable, RegexMatcher):
 
     @always_inline
     def match_next[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](self, text: StringSlice[O], start: Int = 0) -> Optional[Match[O]]:
         """Find first match using optimal engine. This is equivalent to re.search in Python.
         """
@@ -801,7 +801,7 @@ struct HybridMatcher(Copyable, Movable, RegexMatcher):
             return self.nfa_matcher.match_next(text, start)
 
     def match_all[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](self, text: StringSlice[O]) raises -> MatchList[O]:
         """Find all matches using optimal engine."""
         # Fast path: Wildcard match any (.* pattern) matches entire text once
@@ -861,7 +861,7 @@ struct HybridMatcher(Copyable, Movable, RegexMatcher):
             return self.nfa_matcher.match_all(text)
 
     def _match_all_required_byte[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](self, text: StringSlice[O]) raises -> MatchList[O]:
         """findall fast path for patterns with a rare required byte."""
         var text_len = text.byte_length()
@@ -1044,7 +1044,7 @@ struct CompiledRegex(ImplicitlyCopyable, Movable):
 
     @always_inline
     def match_first[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](self, text: StringSlice[O], start: Int = 0) -> Optional[Match[O]]:
         """Find first match in text. This is equivalent to re.match in Python.
 
@@ -1059,7 +1059,7 @@ struct CompiledRegex(ImplicitlyCopyable, Movable):
 
     @always_inline
     def match_next[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](self, text: StringSlice[O], start: Int = 0) -> Optional[Match[O]]:
         """Find first match in text. This is equivalent to re.search in Python.
 
@@ -1073,7 +1073,7 @@ struct CompiledRegex(ImplicitlyCopyable, Movable):
         return self.matcher.match_next(text, start)
 
     def match_all[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](self, text: StringSlice[O]) raises -> MatchList[O]:
         """Find all matches in text.
 
@@ -1320,7 +1320,7 @@ def clear_regex_cache():
 
 # High-level convenience functions that match Python's re module interface
 def search[
-    O: ImmutOrigin
+    O: ImmOrigin
 ](pattern: ImmSlice, text: StringSlice[O]) raises -> Optional[Match[O]]:
     """Search for pattern in text (equivalent to re.search in Python).
 
@@ -1336,7 +1336,7 @@ def search[
 
 
 def findall[
-    O: ImmutOrigin
+    O: ImmOrigin
 ](pattern: ImmSlice, text: StringSlice[O]) raises -> MatchList[O]:
     """Find all matches of pattern in text (equivalent to re.findall in Python).
 
@@ -1352,7 +1352,7 @@ def findall[
 
 
 def match_first[
-    O: ImmutOrigin
+    O: ImmOrigin
 ](pattern: ImmSlice, text: StringSlice[O]) raises -> Optional[Match[O]]:
     """Match pattern at beginning of text (equivalent to re.match in Python).
 
@@ -1569,7 +1569,7 @@ def _apply_template_fixed(
 
 @always_inline
 def _apply_template_groups[
-    O: ImmutOrigin
+    O: ImmOrigin
 ](
     template: List[_ReplSegment],
     repl_ptr: UnsafePointer[Byte, ImmutAnyOrigin],
@@ -1626,7 +1626,7 @@ def _sub_impl_with_repl(
     text: ImmSlice,
     count: Int,
     use_groups: Bool,
-    read template: List[_ReplSegment],
+    imm template: List[_ReplSegment],
 ) raises -> String:
     """Core sub() body with pre-parsed repl info passed in.
 

--- a/src/regex/matching.mojo
+++ b/src/regex/matching.mojo
@@ -1,7 +1,7 @@
 from std.memory import UnsafePointer, unsafe_memcpy, alloc
 
 
-struct Match[origin: ImmutOrigin](Copyable, Movable, TrivialRegisterPassable):
+struct Match[origin: ImmOrigin](Copyable, Movable, TrivialRegisterPassable):
     """Contains the information of a match in a regular expression.
 
     Parameterized on the origin of the backing text, so the borrow into
@@ -45,7 +45,7 @@ struct Match[origin: ImmutOrigin](Copyable, Movable, TrivialRegisterPassable):
         )
 
 
-struct MatchList[origin: ImmutOrigin](Copyable, Movable, Sized):
+struct MatchList[origin: ImmOrigin](Copyable, Movable, Sized):
     """Smart container for regex matches with lazy allocation and optimal reservation.
 
     This struct provides zero allocation until the first match is added, then

--- a/src/regex/nfa.mojo
+++ b/src/regex/nfa.mojo
@@ -167,7 +167,7 @@ struct NFAEngine(Copyable, Engine):
         return rebind[Span[Byte, ImmutAnyOrigin]](self.pattern.as_bytes())
 
     def match_all[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](self, text: StringSlice[O],) -> MatchList[O]:
         """Searches a regex in a test string.
 
@@ -340,7 +340,7 @@ struct NFAEngine(Copyable, Engine):
         return matches^
 
     def match_first[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](self, text: StringSlice[O], start: Int = 0) -> Optional[Match[O]]:
         """Same as match_all, but always returns after the first match.
         Equivalent to re.match in Python.
@@ -389,7 +389,7 @@ struct NFAEngine(Copyable, Engine):
 
     @always_inline
     def match_next[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](self, text: StringSlice[O], start: Int = 0) -> Optional[Match[O]]:
         """Same as match_all, but always returns after the first match.
         It's equivalent to re.search in Python.
@@ -498,7 +498,7 @@ struct NFAEngine(Copyable, Engine):
         return None
 
     def match_next_with_groups[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](self, text: StringSlice[O], start: Int = 0) -> Tuple[
         Optional[Match[O]], List[Match[O]]
     ]:
@@ -575,7 +575,7 @@ struct NFAEngine(Copyable, Engine):
 
     @always_inline
     def _find_last_literal[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](self, text: StringSlice[O], start: Int) -> Int:
         """Find the last occurrence of the literal prefix in text from start."""
         # Use rfind for O(n) reverse search instead of repeated forward search
@@ -638,7 +638,7 @@ struct NFAEngine(Copyable, Engine):
 
     @always_inline
     def _match_contains_literal[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](self, text: StringSlice[O], start: Int, end: Int) -> Bool:
         """Verify that a match contains the required literal."""
         if (
@@ -653,7 +653,7 @@ struct NFAEngine(Copyable, Engine):
 
     @always_inline
     def _match_node[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](
         self,
         ast: ASTNode,
@@ -753,7 +753,7 @@ struct NFAEngine(Copyable, Engine):
 
     @always_inline
     def _match_element[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](
         self,
         ast: ASTNode,
@@ -780,7 +780,7 @@ struct NFAEngine(Copyable, Engine):
 
     @always_inline
     def _match_wildcard[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](
         self,
         ast: ASTNode,
@@ -804,7 +804,7 @@ struct NFAEngine(Copyable, Engine):
 
     @always_inline
     def _match_space[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](
         self,
         ast: ASTNode,
@@ -836,7 +836,7 @@ struct NFAEngine(Copyable, Engine):
 
     @always_inline
     def _match_digit[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](
         self,
         ast: ASTNode,
@@ -878,7 +878,7 @@ struct NFAEngine(Copyable, Engine):
 
     @always_inline
     def _match_word[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](
         self,
         ast: ASTNode,
@@ -925,7 +925,7 @@ struct NFAEngine(Copyable, Engine):
 
     @always_inline
     def _match_range[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](
         self,
         ast: ASTNode,
@@ -1001,7 +1001,7 @@ struct NFAEngine(Copyable, Engine):
 
     @always_inline
     def _match_end[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](self, ast: ASTNode, str: StringSlice[O], str_i: Int) capturing -> Tuple[
         Bool, Int
     ]:
@@ -1012,7 +1012,7 @@ struct NFAEngine(Copyable, Engine):
             return (False, str_i)
 
     def _match_or[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](
         self,
         ast: ASTNode,
@@ -1050,7 +1050,7 @@ struct NFAEngine(Copyable, Engine):
         return right_result
 
     def _match_group[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](
         self,
         ast: ASTNode,
@@ -1098,7 +1098,7 @@ struct NFAEngine(Copyable, Engine):
         return result
 
     def _match_group_with_quantifier[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](
         self,
         ast: ASTNode,
@@ -1151,7 +1151,7 @@ struct NFAEngine(Copyable, Engine):
             return (False, str_i)
 
     def _match_sequence[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](
         self,
         ast_parent: ASTNode,
@@ -1224,7 +1224,7 @@ struct NFAEngine(Copyable, Engine):
 
     @always_inline
     def _match_with_backtracking[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](
         self,
         quantified_node: ASTNode,
@@ -1306,7 +1306,7 @@ struct NFAEngine(Copyable, Engine):
 
     @always_inline
     def _try_match_count[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](
         self,
         ast: ASTNode,
@@ -1344,7 +1344,7 @@ struct NFAEngine(Copyable, Engine):
             return -1
 
     def _match_re[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](
         self,
         ast: ASTNode,
@@ -1368,7 +1368,7 @@ struct NFAEngine(Copyable, Engine):
         )
 
     def _apply_quantifier[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](
         self,
         ast: ASTNode,
@@ -1439,7 +1439,7 @@ struct NFAEngine(Copyable, Engine):
 
     @always_inline
     def _apply_quantifier_simd[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](
         self,
         ast: ASTNode,
@@ -1661,7 +1661,7 @@ struct NFAEngine(Copyable, Engine):
 
     @always_inline
     def _quantifier_negated_loop[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](
         self,
         matcher: RangeBasedMatcher,
@@ -1690,7 +1690,7 @@ struct NFAEngine(Copyable, Engine):
 
     @always_inline
     def _quantifier_range_loop[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](
         self,
         range_start: Int,
@@ -1722,7 +1722,7 @@ struct NFAEngine(Copyable, Engine):
 
 
 def findall[
-    O: ImmutOrigin
+    O: ImmOrigin
 ](pattern: String, text: StringSlice[O]) raises -> MatchList[O]:
     """Find all matches of pattern in text (equivalent to re.findall in Python).
 
@@ -1738,7 +1738,7 @@ def findall[
 
 
 def match_first[
-    O: ImmutOrigin
+    O: ImmOrigin
 ](pattern: String, text: StringSlice[O]) raises -> Optional[Match[O]]:
     """Match pattern at beginning of text (equivalent to re.match in Python).
 

--- a/src/regex/onepass.mojo
+++ b/src/regex/onepass.mojo
@@ -61,7 +61,7 @@ blow-ups. ONEPASS_MAX_STATES is comfortably within Int16 range."""
 
 def _epsilon_close(
     program: Program,
-    read start_pcs: InlineArray[Int, MAX_STATES],
+    imm start_pcs: InlineArray[Int, MAX_STATES],
     start_count: Int,
     at_start: Bool,
     at_end: Bool = False,
@@ -467,7 +467,7 @@ struct OnePassNFA(Copyable, Movable):
 
     @always_inline
     def match_first[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](self, text: StringSlice[O], start: Int = 0) -> Optional[Match[O]]:
         """Match the pattern starting exactly at `start`. Returns None
         if the pattern cannot match here (e.g. `^` anchor with start > 0,
@@ -508,7 +508,7 @@ struct OnePassNFA(Copyable, Movable):
 
     @always_inline
     def match_next[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](self, text: StringSlice[O], start: Int = 0) -> Optional[Match[O]]:
         """Search for the first match at or after `start` (like
         `re.search`). Honours `^` by only trying position 0."""
@@ -524,7 +524,7 @@ struct OnePassNFA(Copyable, Movable):
         return None
 
     @always_inline
-    def match_all[O: ImmutOrigin](self, text: StringSlice[O]) -> MatchList[O]:
+    def match_all[O: ImmOrigin](self, text: StringSlice[O]) -> MatchList[O]:
         var text_len = text.byte_length()
         var matches = MatchList[O](
             capacity=text_len >> 7 if text_len >= 1024 else 0

--- a/src/regex/parser.mojo
+++ b/src/regex/parser.mojo
@@ -54,8 +54,8 @@ from regex.ast import (
 
 @always_inline
 def check_for_quantifiers[
-    regex_origin: ImmutOrigin
-](mut i: Int, mut elem: ASTNode[regex_origin], read tokens: List[Token]) raises:
+    regex_origin: ImmOrigin
+](mut i: Int, mut elem: ASTNode[regex_origin], imm tokens: List[Token]) raises:
     """Check for quantifiers after an element and set min/max accordingly."""
     ref next_token = tokens[i + 1]
     if next_token.type == Token.ASTERISK:
@@ -130,7 +130,7 @@ def get_range_str(start: String, end: String) -> String:
 def parse_token_list[
     regex_origin: Origin[mut=True]
 ](
-    ref[regex_origin] regex: Regex[ImmutUntrackedOrigin],
+    ref[regex_origin] regex: Regex[ImmUntrackedOrigin],
     var tokens: List[Token],
     mut group_counter: Int,
 ) raises -> ASTNode[MutUntrackedOrigin]:
@@ -252,7 +252,7 @@ def parse_token_list[
             )
             # Check for quantifiers after the element
             if i + 1 < len(tokens):
-                check_for_quantifiers[ImmutUntrackedOrigin](i, elem, tokens)
+                check_for_quantifiers[ImmUntrackedOrigin](i, elem, tokens)
             elements.append(elem^)
         elif token.type == Token.WILDCARD:
             var elem = WildcardElement(
@@ -262,7 +262,7 @@ def parse_token_list[
             )
             # Check for quantifiers after the wildcard
             if i + 1 < len(tokens):
-                check_for_quantifiers[ImmutUntrackedOrigin](i, elem, tokens)
+                check_for_quantifiers[ImmUntrackedOrigin](i, elem, tokens)
             elements.append(elem^)
         elif token.type == Token.SPACE:
             var elem = SpaceElement(
@@ -273,7 +273,7 @@ def parse_token_list[
             )
             # Check for quantifiers after the space
             if i + 1 < len(tokens):
-                check_for_quantifiers[ImmutUntrackedOrigin](i, elem, tokens)
+                check_for_quantifiers[ImmUntrackedOrigin](i, elem, tokens)
             elements.append(elem^)
         elif token.type == Token.DIGIT:
             var elem = DigitElement(
@@ -284,7 +284,7 @@ def parse_token_list[
             )
             # Check for quantifiers after the digit
             if i + 1 < len(tokens):
-                check_for_quantifiers[ImmutUntrackedOrigin](i, elem, tokens)
+                check_for_quantifiers[ImmUntrackedOrigin](i, elem, tokens)
             elements.append(elem^)
         elif token.type == Token.WORD:
             var elem = WordElement(
@@ -295,7 +295,7 @@ def parse_token_list[
             )
             # Check for quantifiers after the word
             if i + 1 < len(tokens):
-                check_for_quantifiers[ImmutUntrackedOrigin](i, elem, tokens)
+                check_for_quantifiers[ImmUntrackedOrigin](i, elem, tokens)
             elements.append(elem^)
         elif token.type == Token.START:
             var start_elem = StartElement(
@@ -351,9 +351,7 @@ def parse_token_list[
             )
             # Check for quantifiers after the range
             if i + 1 < len(tokens):
-                check_for_quantifiers[ImmutUntrackedOrigin](
-                    i, range_elem, tokens
-                )
+                check_for_quantifiers[ImmUntrackedOrigin](i, range_elem, tokens)
             elements.append(range_elem^)
         elif token.type == Token.DASH:
             # Dash outside brackets is a literal '-' character
@@ -363,7 +361,7 @@ def parse_token_list[
                 end_idx=token.start_pos + 1,
             )
             if i + 1 < len(tokens):
-                check_for_quantifiers[ImmutUntrackedOrigin](i, elem, tokens)
+                check_for_quantifiers[ImmUntrackedOrigin](i, elem, tokens)
             elements.append(elem^)
         elif token.type == Token.LEFTPARENTHESIS:
             # Handle nested grouping - check for non-capturing group (?:...)
@@ -467,7 +465,7 @@ def parse_token_list[
     return final_group^
 
 
-def parse(pattern: String) raises -> ASTNode[ImmutUntrackedOrigin]:
+def parse(pattern: String) raises -> ASTNode[ImmUntrackedOrigin]:
     """Parses a regular expression.
 
     Parses a regex and returns the corresponding AST.
@@ -481,8 +479,8 @@ def parse(pattern: String) raises -> ASTNode[ImmutUntrackedOrigin]:
     """
     # Create a persistent Regex object to hold the pattern and children
     # Allocate on heap to ensure it survives function return
-    var regex_ptr = alloc[Regex[ImmutUntrackedOrigin]](1)
-    regex_ptr.unsafe_write(Regex[ImmutUntrackedOrigin](pattern))
+    var regex_ptr = alloc[Regex[ImmUntrackedOrigin]](1)
+    regex_ptr.unsafe_write(Regex[ImmUntrackedOrigin](pattern))
 
     # Tokenize the pattern
     var tokens = scan(pattern)
@@ -495,14 +493,14 @@ def parse(pattern: String) raises -> ASTNode[ImmutUntrackedOrigin]:
 
     # Create a RE root node that wraps the parsed result
     # The tests expect the root to be of type RE with a GROUP child
-    var parsed_ast_immutable = rebind[ASTNode[ImmutUntrackedOrigin]](parsed_ast)
+    var parsed_ast_immutable = rebind[ASTNode[ImmUntrackedOrigin]](parsed_ast)
     var root_child_index = UInt16(
         children_len + 1
     )  # +1 because we use 1-based indexing
     regex_ptr[].append_child(parsed_ast_immutable)
 
     # Use the heap-allocated regex pointer directly
-    var re_root = ASTNode[ImmutUntrackedOrigin](
+    var re_root = ASTNode[ImmUntrackedOrigin](
         type=RE,
         regex_ptr=regex_ptr,
         start_idx=0,

--- a/src/regex/pikevm.mojo
+++ b/src/regex/pikevm.mojo
@@ -414,14 +414,14 @@ struct PikeVMEngine(Copyable, Movable):
         self.has_filter = matching_bytes < 128
 
     def match_first[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](self, text: StringSlice[O], start: Int = 0) -> Optional[Match[O]]:
         """Match pattern at the given position (like re.match)."""
         return self._run(text, start)
 
     @always_inline
     def match_next[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](self, text: StringSlice[O], start: Int = 0) -> Optional[Match[O]]:
         """Search for pattern anywhere in text (like re.search)."""
         var text_len = len(text)
@@ -446,7 +446,7 @@ struct PikeVMEngine(Copyable, Movable):
                 return result
         return None
 
-    def match_all[O: ImmutOrigin](self, text: StringSlice[O]) -> MatchList[O]:
+    def match_all[O: ImmOrigin](self, text: StringSlice[O]) -> MatchList[O]:
         """Find all non-overlapping matches (like re.findall)."""
         var text_len = len(text)
         var matches = MatchList[O](
@@ -487,7 +487,7 @@ struct PikeVMEngine(Copyable, Movable):
         return matches^
 
     def _run[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](self, text: StringSlice[O], start: Int) -> Optional[Match[O]]:
         """Run PikeVM with fixed-size SIMD state tracking.
         Zero heap allocations per step."""
@@ -738,14 +738,14 @@ struct LazyDFA(Copyable, Movable):
 
     @always_inline
     def match_first[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](mut self, text: StringSlice[O], start: Int = 0) -> Optional[Match[O]]:
         """Match at position using cached DFA transitions."""
         return self._run_lazy(text, start)
 
     @always_inline
     def match_next[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](mut self, text: StringSlice[O], start: Int = 0) -> Optional[Match[O]]:
         """Search using cached DFA with SIMD first-byte prefilter."""
         var text_len = text.byte_length()
@@ -772,9 +772,7 @@ struct LazyDFA(Copyable, Movable):
         return None
 
     @always_inline
-    def match_all[
-        O: ImmutOrigin
-    ](mut self, text: StringSlice[O]) -> MatchList[O]:
+    def match_all[O: ImmOrigin](mut self, text: StringSlice[O]) -> MatchList[O]:
         """Find all matches using cached DFA."""
         var text_len = text.byte_length()
         var matches = MatchList[O](
@@ -812,7 +810,7 @@ struct LazyDFA(Copyable, Movable):
 
     @always_inline
     def _run_lazy[
-        O: ImmutOrigin
+        O: ImmOrigin
     ](mut self, text: StringSlice[O], start: Int) -> Optional[Match[O]]:
         """Run the lazy DFA from a start position."""
         var text_ptr = text.unsafe_ptr()

--- a/src/regex/simd_ops.mojo
+++ b/src/regex/simd_ops.mojo
@@ -467,7 +467,7 @@ struct CharacterClassSIMD(
 
         def closure[
             width: Int
-        ](i: Int) {mut matches, read self, read text, read text_ptr, read pos}:
+        ](i: Int) {mut matches, imm self, imm text, imm text_ptr, imm pos}:
             if width != 1:
                 var chunk_matches = self._check_chunk_simd(
                     text.unsafe_ptr(), pos + i
@@ -551,7 +551,7 @@ struct CharacterClassSIMD(
 
         def closure[
             width: Int
-        ](i: Int) {mut count, read self, read text, read text_ptr, read pos}:
+        ](i: Int) {mut count, imm self, imm text, imm text_ptr, imm pos}:
             if width != 1:
                 var matches = self._check_chunk_simd(text.unsafe_ptr(), pos + i)
                 count += Int(matches.cast[DType.uint8]().reduce_add())
@@ -929,7 +929,7 @@ def _create_word_chars() -> CharacterClassSIMD:
 
 
 def verify_match[
-    O: ImmutOrigin
+    O: ImmOrigin
 ](pattern: Span[Byte, _], text: StringSlice[O], pos: Int) -> Bool:
     """Verify that pattern matches at given position.
 
@@ -955,7 +955,7 @@ def verify_match[
 
 
 def simd_search[
-    O: ImmutOrigin
+    O: ImmOrigin
 ](pattern: Span[Byte, _], text: StringSlice[O], start: Int = 0,) -> Int:
     """Search for pattern in text using SIMD acceleration.
 
@@ -1291,7 +1291,7 @@ def process_text_with_matcher[
 
 
 def apply_quantifier_simd_generic[
-    T: SIMDMatcher, O: ImmutOrigin
+    T: SIMDMatcher, O: ImmOrigin
 ](
     matcher: T,
     text: StringSlice[O],
@@ -1384,7 +1384,7 @@ def find_in_text_simd[
 
 
 def twoway_search[
-    O: ImmutOrigin
+    O: ImmOrigin
 ](pattern: Span[Byte, _], text: StringSlice[O], start: Int = 0,) -> Int:
     """Search for pattern in text using Two-Way algorithm with SIMD.
 

--- a/tests/test_ast.mojo
+++ b/tests/test_ast.mojo
@@ -29,13 +29,13 @@ from regex.ast import (
 
 def test_ASTNode() raises:
     var pattern = String("")
-    var regex = Regex[ImmutUntrackedOrigin](pattern)
+    var regex = Regex[ImmUntrackedOrigin](pattern)
     var regex_ptr = (
         UnsafePointer(to=regex)
         .as_immutable()
-        .unsafe_origin_cast[ImmutUntrackedOrigin]()
+        .unsafe_origin_cast[ImmUntrackedOrigin]()
     )
-    var ast_node = ASTNode[ImmutUntrackedOrigin](
+    var ast_node = ASTNode[ImmUntrackedOrigin](
         type=ELEMENT, regex_ptr=regex_ptr, start_idx=0, end_idx=0
     )
     assert_true(ast_node.__bool__())
@@ -43,7 +43,7 @@ def test_ASTNode() raises:
 
 def test_Element() raises:
     var pattern = String("a")
-    var regex = Regex[ImmutUntrackedOrigin](pattern)
+    var regex = Regex[ImmUntrackedOrigin](pattern)
     var elem = Element(regex, start_idx=0, end_idx=1)
     assert_true(elem.__bool__())
     assert_equal(elem.type, ELEMENT)
@@ -55,7 +55,7 @@ def test_Element() raises:
 
 def test_WildcardElement() raises:
     var pattern = String(".")
-    var regex = Regex[ImmutUntrackedOrigin](pattern)
+    var regex = Regex[ImmUntrackedOrigin](pattern)
     var we = WildcardElement(regex, start_idx=0, end_idx=1)
     assert_true(we.__bool__())
     assert_equal(we.type, WILDCARD)
@@ -66,7 +66,7 @@ def test_WildcardElement() raises:
 
 def test_SpaceElement() raises:
     var pattern = String("\\s")
-    var regex = Regex[ImmutUntrackedOrigin](pattern)
+    var regex = Regex[ImmUntrackedOrigin](pattern)
     var se = SpaceElement(regex, start_idx=0, end_idx=2)
     assert_true(se.__bool__())
     assert_equal(se.type, SPACE)
@@ -80,7 +80,7 @@ def test_SpaceElement() raises:
 
 def test_RangeElement_positive_logic() raises:
     var pattern = String("[abc]")
-    var regex = Regex[ImmutUntrackedOrigin](pattern)
+    var regex = Regex[ImmUntrackedOrigin](pattern)
     var re = RangeElement(regex, start_idx=1, end_idx=4, is_positive_logic=True)
     assert_true(re.__bool__())
     assert_equal(re.type, RANGE)
@@ -95,7 +95,7 @@ def test_RangeElement_positive_logic() raises:
 
 def test_RangeElement_negative_logic() raises:
     var pattern = String("[^abc]")
-    var regex = Regex[ImmutUntrackedOrigin](pattern)
+    var regex = Regex[ImmUntrackedOrigin](pattern)
     var nre = RangeElement(
         regex, start_idx=2, end_idx=5, is_positive_logic=False
     )
@@ -112,7 +112,7 @@ def test_RangeElement_negative_logic() raises:
 
 def test_StartElement() raises:
     var pattern = String("^")
-    var regex = Regex[ImmutUntrackedOrigin](pattern)
+    var regex = Regex[ImmUntrackedOrigin](pattern)
     var start = StartElement(regex, start_idx=0, end_idx=1)
     assert_true(start.__bool__())
     assert_equal(start.type, START)
@@ -122,7 +122,7 @@ def test_StartElement() raises:
 
 def test_EndElement() raises:
     var pattern = String("$")
-    var regex = Regex[ImmutUntrackedOrigin](pattern)
+    var regex = Regex[ImmUntrackedOrigin](pattern)
     var end = EndElement(regex, start_idx=0, end_idx=1)
     assert_true(end.__bool__())
     assert_equal(end.type, END)


### PR DESCRIPTION
Routine toolchain bump from `1.0.0b3.dev2026071505` to `1.0.0b3.dev2026071705`. This nightly renamed several origin identifiers; two adaptations were required.

## 1. Origin type renames (`Immut*` → `Imm*`)

| Old | New |
|---|---|
| `ImmutOrigin` | `ImmOrigin` |
| `ImmutUntrackedOrigin` | `ImmUntrackedOrigin` |

Applied with word boundaries so two similar names are **deliberately left intact** (verified: their new short forms don't exist / aren't deprecated):
- `ImmutAnyOrigin` — **not** renamed (`ImmAnyOrigin` does not exist).
- `Immutable` — the origin associated type, unrelated.

## 2. Argument-convention keyword `read` → `imm`

The `read` convention keyword is deprecated in favor of `imm`. Changed at the five explicit-annotation sites only (not the many implicit-default arguments, which never spell it): `matcher` (repl template), `onepass` (start_pcs), `parser` (tokens), and two closure capture lists in `simd_ops`.

## Verification

- **389 tests pass**, zero failures.
- **Zero compiler warnings** across `src`, `tests` and the `bench_engine` build (each rename verified against the pinned toolchain with a probe before the bulk edit).

Folds into the in-flight v0.21.0 per the mid-version rules (no version bump).