### PR TITLE
Use index-free iteration in a few places (NFC)

### DIFF
--- a/src/regex/ast.mojo
+++ b/src/regex/ast.mojo
@@ -74,8 +74,8 @@ comptime ChildrenIndexes = List[UInt16]
 def _make_children_indexes(*values: UInt16) -> ChildrenIndexes:
     """Helper to create a ChildrenIndexes list from variadic UInt16 values."""
     var result = ChildrenIndexes(capacity=len(values))
-    for i in range(len(values)):
-        result.append(values[i])
+    for value in values:
+        result.append(value)
     return result^
 
 

--- a/src/regex/dfa.mojo
+++ b/src/regex/dfa.mojo
@@ -670,8 +670,7 @@ struct DFAEngine(Engine):
                 var end_state_index = len(self.states) - 1
 
                 # Build chain of states for each branch
-                for branch_idx in range(len(element.alternation_branches)):
-                    ref branch = element.alternation_branches[branch_idx]
+                for branch in element.alternation_branches:
                     var branch_ptr = branch.unsafe_ptr()
                     var prev_state = current_state_index
 
@@ -903,8 +902,7 @@ struct DFAEngine(Engine):
         ref all_branches = _collect_all_alternation_branches(or_node)
 
         # Build trie-like DFA structure to handle shared prefixes
-        for i in range(len(all_branches)):
-            ref branch_text = all_branches[i]
+        for branch_text in all_branches:
             if branch_text.byte_length() == 0:
                 continue
 
@@ -1120,8 +1118,8 @@ struct DFAEngine(Engine):
 
         # Build the pattern string
         var pattern_text = String("")
-        for i in range(len(pattern_parts)):
-            pattern_text += pattern_parts[i]
+        for part in pattern_parts:
+            pattern_text += part
 
         if pattern_text.byte_length() == 0:
             raise Error("Empty quantifier pattern")
@@ -1437,8 +1435,7 @@ struct DFAEngine(Engine):
             current_state = next_state_index
 
         # Process each branch after common prefix
-        for i in range(len(branches)):
-            ref branch = branches[i]
+        for branch in branches:
             if branch.byte_length() == prefix_len:
                 # Branch ends at common prefix - make current state accepting
                 self.states[current_state].is_accepting = True
@@ -1595,8 +1592,7 @@ struct DFAEngine(Engine):
         var accepting_index = len(self.states) - 1
 
         # Add paths for each branch
-        for i in range(len(branches)):
-            ref branch = branches[i]
+        for branch in branches:
             var current_state = 0
             var branch_ptr = branch.unsafe_ptr()
 
@@ -1623,8 +1619,7 @@ struct DFAEngine(Engine):
         self.states[0].is_accepting = True
 
         # For each branch, create path that loops back to start
-        for i in range(len(branches)):
-            ref branch = branches[i]
+        for branch in branches:
             var current_state = 0
             var branch_ptr = branch.unsafe_ptr()
 
@@ -1651,8 +1646,7 @@ struct DFAEngine(Engine):
         var loop_index = len(self.states) - 1
 
         # For each branch, create path to loop state
-        for i in range(len(branches)):
-            ref branch = branches[i]
+        for branch in branches:
             var current_state = 0
             var branch_ptr = branch.unsafe_ptr()
 
@@ -1671,8 +1665,7 @@ struct DFAEngine(Engine):
                     )
 
         # From loop state, can match any branch again (loop back through each branch)
-        for i in range(len(branches)):
-            ref branch = branches[i]
+        for branch in branches:
             var current_state = loop_index
             var branch_ptr = branch.unsafe_ptr()
 
@@ -3278,8 +3271,8 @@ def _collect_all_alternation_branches(
         if branch.type == OR:
             # Nested OR - recursively collect its branches
             ref nested_branches = _collect_all_alternation_branches(branch)
-            for j in range(len(nested_branches)):
-                branches.append(nested_branches[j])
+            for nested_branch in nested_branches:
+                branches.append(nested_branch)
         elif branch.type == GROUP:
             # Unwrap nested GROUPs to find OR or literal content
             var inner = branch
@@ -3287,8 +3280,8 @@ def _collect_all_alternation_branches(
                 inner = inner.get_child(0)
             if inner.type == OR:
                 ref nested = _collect_all_alternation_branches(inner)
-                for j in range(len(nested)):
-                    branches.append(nested[j])
+                for nested_item in nested:
+                    branches.append(nested_item)
             else:
                 ref branch_text = _extract_branch_text(branch)
                 if branch_text.byte_length() > 0:

--- a/src/regex/matcher.mojo
+++ b/src/regex/matcher.mojo
@@ -1012,8 +1012,7 @@ struct CompiledRegex(ImplicitlyCopyable, Movable):
         var num_groups = 0
         var total_width = 0
         var has_literals = False
-        for si in range(len(segs)):
-            var s = segs[si]
+        for s in segs:
             if s > 0:
                 num_groups += 1
                 if num_groups > 9:
@@ -1525,8 +1524,8 @@ def _detect_fixed_width_groups(
 
     # Check we found at least one group
     var has_group = False
-    for si in range(len(segments)):
-        if segments[si] > 0:
+    for seg in segments:
+        if seg > 0:
             has_group = True
             break
     if not has_group:
@@ -1657,8 +1656,7 @@ def _sub_impl_with_repl(
 
             # Estimate output size from template.
             var output_est = 0
-            for ti in range(len(template)):
-                ref tseg = template[ti]
+            for tseg in template:
                 if tseg.group_ref > 0 and tseg.group_ref <= num_groups:
                     output_est += group_widths[tseg.group_ref]
                 else:

--- a/src/regex/onepass.mojo
+++ b/src/regex/onepass.mojo
@@ -314,9 +314,9 @@ def compile_onepass(
     # Precompute the `$` end-of-text answer for each state so match_first
     # can resolve the end-anchor fixup with a single field load.
     if has_end_anchor:
-        for i in range(len(states)):
-            states[i].is_end_match = _closure_reaches_match_with_end_anchor(
-                program, states[i].nfa_set
+        for ref state in states:
+            state.is_end_match = _closure_reaches_match_with_end_anchor(
+                program, state.nfa_set
             )
 
     # Project the compile-time states (which carry the bulky ~512B
@@ -374,8 +374,7 @@ def _find_or_add_state(
     try:
         if key in index:
             ref bucket = index[key]
-            for i in range(len(bucket)):
-                var sid = bucket[i]
+            for sid in bucket:
                 if states[sid].nfa_set.eq(nfa_set).reduce_and():
                     return sid
     except:

--- a/src/regex/parser.mojo
+++ b/src/regex/parser.mojo
@@ -216,8 +216,7 @@ def parse_token_list[
     # Validate tokens for unescaped closing brackets and parentheses
     var bracket_depth = 0
     var paren_depth_validation = 0
-    for validation_i in range(len(tokens)):
-        ref validation_token = tokens[validation_i]
+    for validation_token in tokens:
         if validation_token.type == Token.LEFTBRACKET:
             bracket_depth += 1
         elif validation_token.type == Token.RIGHTBRACKET:

--- a/src/regex/pikevm.mojo
+++ b/src/regex/pikevm.mojo
@@ -210,8 +210,8 @@ def _compile_quantified(node: ASTNode, mut program: Program):
             _compile_node(node, program)
         # Patch all splits to jump past the optional parts
         var after = len(program)
-        for i in range(len(splits)):
-            program.patch(splits[i], arg0=splits[i] + 1, arg1=after)
+        for split in splits:
+            program.patch(split, arg0=split + 1, arg1=after)
         return
 
     # {n,} = unbounded repetition (min then greedy loop)

--- a/src/regex/prefilter.mojo
+++ b/src/regex/prefilter.mojo
@@ -228,15 +228,15 @@ struct LiteralExtractor:
 
         # Check if all branches are literals
         var all_literal = True
-        for i in range(len(branches)):
-            if len(branches[i]) == 0:
+        for branch in branches:
+            if len(branch) == 0:
                 all_literal = False
                 break
 
         if all_literal:
             # All branches are literals, add them as required literals
-            for i in range(len(branches)):
-                info.required_literals.append(branches[i])
+            for branch in branches:
+                info.required_literals.append(branch)
 
             # Check for common prefix among all branches
             var common_prefix = self._compute_common_prefix(branches)
@@ -448,8 +448,7 @@ struct ExactLiteralMatcher(PrefilterMatcher):
         """Find all positions where any of the literals match exactly."""
         var candidates = List[Int]()
 
-        for i in range(len(self.literals)):
-            var literal = self.literals[i]
+        for literal in self.literals:
             var start = 0
 
             while start <= len(text) - len(literal):
@@ -468,8 +467,7 @@ struct ExactLiteralMatcher(PrefilterMatcher):
         """Find the first exact literal match at or after start."""
         var best_pos: Optional[Int] = None
 
-        for i in range(len(self.literals)):
-            var literal = self.literals[i]
+        for literal in self.literals:
             if start + len(literal) > len(text):
                 continue
 


### PR DESCRIPTION
Switches by-index loops to by-element iteration for readability.

## What

Switches by-index loops of the form

```mojo
for i in range(len(xs)):
    ... xs[i] ...
```

to by-element

```mojo
for x in xs:
    ... x ...
```

wherever the loop index is used **only** to subscript the ranged collection. Redundant `ref x = xs[i]` / `var x = xs[i]` binding lines that immediately followed such loops are dropped too.

**22 loops** across `ast`, `dfa`, `matcher`, `onepass`, `parser`, `pikevm` and `prefilter`. Net **-13 lines**.

## Careful bits

- The one loop that *mutates* elements (the onepass end-anchor precompute, `states[i].is_end_match = ...`) uses `for ref state in states` to keep write access.
- **Deliberately left ~13 loops** where the index is genuinely load-bearing: parallel-array copies (e.g. `self.children_indexes[i] = children_indexes[i]`), index arithmetic, or indexing a *second* collection with the loop index. A mechanical substring match flags several of these as false positives; each was read and rejected.

## Verification

Readability only, no behavior change. **389 tests pass, zero compiler warnings** across `src`, `tests` and the `bench_engine` build. `range(len(...))` loop count drops 35 → 13.

Folds into the in-flight v0.21.0 per the mid-version rules (no version bump).