### PR TITLE
Bump mojo to 1.0.0b3.dev2026072505 + migrate to explicit unsafe pointer ops

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -32,10 +32,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026072306-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026072306-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026072306-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026072306-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026072505-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026072505-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026072505-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026072505-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
@@ -76,10 +76,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.22-h1a92334_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.1-h1b79a29_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026072306-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026072306-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026072306-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026072306-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026072505-release.conda
+      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026072505-release.conda
+      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026072505-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026072505-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
@@ -133,10 +133,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026072306-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026072306-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026072306-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026072306-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026072505-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026072505-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026072505-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026072505-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
@@ -179,10 +179,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.22-h1a92334_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.1-h1b79a29_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026072306-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026072306-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026072306-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026072306-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026072505-release.conda
+      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026072505-release.conda
+      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026072505-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026072505-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
@@ -585,10 +585,10 @@ packages:
   license_family: Other
   size: 47759
   timestamp: 1774072956767
-- conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026072306-release.conda
+- conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026072505-release.conda
   noarch: python
-  sha256: bd865b7cfd860d58166fd70fa6071a849033b8479b1e2948606f5165f4a83da1
-  md5: 5fb41c53a605dea5a6d111688c4d4f8e
+  sha256: a66e15918fe18928e4a35c08e16f0517c25d5bc10f836a2240c7cbf9788f9501
+  md5: 19378925651cd95d631a7f580cb2846d
   depends:
   - python >=3.10
   - click >=8.0.0
@@ -598,55 +598,55 @@ packages:
   - platformdirs >=2
   - tomli >=1.1.0
   license: LicenseRef-Modular-Proprietary
-  size: 135952
-  timestamp: 1784787149546
-- conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026072306-release.conda
-  sha256: f3115e6a84e659352b6bcbf4fa6cfebd32ab8ffdbaa2501f18df60bcdac78dc1
-  md5: 131a3517a02482713cf99343f146c7dd
+  size: 136731
+  timestamp: 1784959402726
+- conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026072505-release.conda
+  sha256: 9fa11e681371d1994ffbe66d0f7e1502e7b22381c5ca8d5f844b77a335c8e19b
+  md5: 6a0c4ee8b9b53aba98644702a4c2c682
   depends:
   - python >=3.10
-  - mojo-compiler ==1.0.0b3.dev2026072306
-  - mblack ==26.5.0.dev2026072306
+  - mojo-compiler ==1.0.0b3.dev2026072505
+  - mblack ==26.5.0.dev2026072505
   - jupyter_client >=8.6.2,<8.7
   license: LicenseRef-Modular-Proprietary
-  size: 114481928
-  timestamp: 1784787284605
-- conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026072306-release.conda
-  sha256: 69d7eda6b8b2c591ebf819326bc075879955fa1fb80da8d6eccbd91587026d7a
-  md5: 41723c21d61e78115129d3f5610c2bb1
+  size: 114479370
+  timestamp: 1784959545074
+- conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026072505-release.conda
+  sha256: 1c46e8cabe6b85278b054beb2123041348d7df121a95e5eebadf46de53a439de
+  md5: cb436d07d6b38b4c43c75752594f29b3
   depends:
   - python >=3.10
-  - mojo-compiler ==1.0.0b3.dev2026072306
-  - mblack ==26.5.0.dev2026072306
+  - mojo-compiler ==1.0.0b3.dev2026072505
+  - mblack ==26.5.0.dev2026072505
   - jupyter_client >=8.6.2,<8.7
   license: LicenseRef-Modular-Proprietary
-  size: 100044215
-  timestamp: 1784787408862
-- conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026072306-release.conda
-  sha256: 9495999b5a594da5f8da4887f049d399789bb32a89d566cc3f3789b012affee0
-  md5: 0617686ea407895e1d0f5a163c9dc9d9
+  size: 100037425
+  timestamp: 1784959686085
+- conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026072505-release.conda
+  sha256: 307aae574f073cf914c9efe3cfadeeb2f3992c3a426154731e934b81f7b2f725
+  md5: b9d5de41a9c940f47090818f8d9d0c18
   depends:
-  - mojo-python ==1.0.0b3.dev2026072306
+  - mojo-python ==1.0.0b3.dev2026072505
   license: LicenseRef-Modular-Proprietary
-  size: 80568439
-  timestamp: 1784787288159
-- conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026072306-release.conda
-  sha256: 60bf486f8b3db0912c3f10c45967ec308332cf0e98f20ac92a999188d03934c5
-  md5: 0462bec5462c0b3af77036b177c92a75
+  size: 80560693
+  timestamp: 1784959541118
+- conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026072505-release.conda
+  sha256: 298e96857d27d6c8cbe46843e7c564c228cf7f8d4f149a924475255ac314b204
+  md5: e841498b57e4c0b92ba3f8bce0b17d35
   depends:
-  - mojo-python ==1.0.0b3.dev2026072306
+  - mojo-python ==1.0.0b3.dev2026072505
   license: LicenseRef-Modular-Proprietary
-  size: 62030583
-  timestamp: 1784787407344
-- conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026072306-release.conda
+  size: 62029722
+  timestamp: 1784959683257
+- conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026072505-release.conda
   noarch: python
-  sha256: 31997eb3977ccd43979f8032992a66e48e84e09c00406f85ae581046189b37ad
-  md5: 40933c74ecddff04ae43165667bcb42b
+  sha256: 9d90f9d14440c864e96c331fb54e5a2be5fc724bdcdec0adf9ddd52d1dabdcb9
+  md5: f5e33c79f95b3cb3bd7e7d4bfe227eb2
   depends:
   - python >=3.10
   license: LicenseRef-Modular-Proprietary
-  size: 24123
-  timestamp: 1784787149484
+  size: 24107
+  timestamp: 1784959402688
 - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
   sha256: 6ed158e4e5dd8f6a10ad9e525631e35cee8557718f83de7a4e3966b1f772c4b1
   md5: e9c622e0d00fa24a6292279af3ab6d06

--- a/pixi.lock
+++ b/pixi.lock
@@ -32,10 +32,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026072114-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026072114-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026072114-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026072114-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026072306-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026072306-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026072306-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026072306-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
@@ -76,10 +76,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.22-h1a92334_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.1-h1b79a29_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026072114-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026072114-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026072114-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026072114-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026072306-release.conda
+      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026072306-release.conda
+      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026072306-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026072306-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
@@ -133,10 +133,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026072114-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026072114-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026072114-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026072114-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026072306-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026072306-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026072306-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026072306-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
@@ -179,10 +179,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.22-h1a92334_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.1-h1b79a29_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026072114-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026072114-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026072114-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026072114-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026072306-release.conda
+      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026072306-release.conda
+      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026072306-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026072306-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
@@ -585,10 +585,10 @@ packages:
   license_family: Other
   size: 47759
   timestamp: 1774072956767
-- conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026072114-release.conda
+- conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026072306-release.conda
   noarch: python
-  sha256: 9623e8546bc70a1fdb706a99a8bfd9d0cade52eeaec1b85a9353f783220bbe28
-  md5: 819b7632185e30e6f80782b8ebd18337
+  sha256: bd865b7cfd860d58166fd70fa6071a849033b8479b1e2948606f5165f4a83da1
+  md5: 5fb41c53a605dea5a6d111688c4d4f8e
   depends:
   - python >=3.10
   - click >=8.0.0
@@ -598,55 +598,55 @@ packages:
   - platformdirs >=2
   - tomli >=1.1.0
   license: LicenseRef-Modular-Proprietary
-  size: 135946
-  timestamp: 1784644768937
-- conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026072114-release.conda
-  sha256: f7d7f5b060418c4790ba6a527eebe844a27ebcfe08b23cf355a4e0c5ed0503dc
-  md5: 1e0a0a0620ae07c6a1a5362b8dfcff06
+  size: 135952
+  timestamp: 1784787149546
+- conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026072306-release.conda
+  sha256: f3115e6a84e659352b6bcbf4fa6cfebd32ab8ffdbaa2501f18df60bcdac78dc1
+  md5: 131a3517a02482713cf99343f146c7dd
   depends:
   - python >=3.10
-  - mojo-compiler ==1.0.0b3.dev2026072114
-  - mblack ==26.5.0.dev2026072114
+  - mojo-compiler ==1.0.0b3.dev2026072306
+  - mblack ==26.5.0.dev2026072306
   - jupyter_client >=8.6.2,<8.7
   license: LicenseRef-Modular-Proprietary
-  size: 114488894
-  timestamp: 1784644929828
-- conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026072114-release.conda
-  sha256: 8e4004e5d3ccffd9e83378fed624f823bde9d1a1f88bf73e42c6b86c6b183f41
-  md5: 0bb797cca46b22a393967e4207ecb235
+  size: 114481928
+  timestamp: 1784787284605
+- conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026072306-release.conda
+  sha256: 69d7eda6b8b2c591ebf819326bc075879955fa1fb80da8d6eccbd91587026d7a
+  md5: 41723c21d61e78115129d3f5610c2bb1
   depends:
   - python >=3.10
-  - mojo-compiler ==1.0.0b3.dev2026072114
-  - mblack ==26.5.0.dev2026072114
+  - mojo-compiler ==1.0.0b3.dev2026072306
+  - mblack ==26.5.0.dev2026072306
   - jupyter_client >=8.6.2,<8.7
   license: LicenseRef-Modular-Proprietary
-  size: 100065058
-  timestamp: 1784645066684
-- conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026072114-release.conda
-  sha256: 80bc05908275cec95c103f043b2b642f3b9fd487cbbf700e0b35da454e0880c3
-  md5: 8827196f624b2c15f212b338fa8f7810
+  size: 100044215
+  timestamp: 1784787408862
+- conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026072306-release.conda
+  sha256: 9495999b5a594da5f8da4887f049d399789bb32a89d566cc3f3789b012affee0
+  md5: 0617686ea407895e1d0f5a163c9dc9d9
   depends:
-  - mojo-python ==1.0.0b3.dev2026072114
+  - mojo-python ==1.0.0b3.dev2026072306
   license: LicenseRef-Modular-Proprietary
-  size: 81708375
-  timestamp: 1784644952964
-- conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026072114-release.conda
-  sha256: 8947d24e7fa19a32dc6c6ba108b6acb68f4482b2086701ab83a7e08f48cd73ad
-  md5: 04f979bc91b19bff89ca31ed861bb8fa
+  size: 80568439
+  timestamp: 1784787288159
+- conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026072306-release.conda
+  sha256: 60bf486f8b3db0912c3f10c45967ec308332cf0e98f20ac92a999188d03934c5
+  md5: 0462bec5462c0b3af77036b177c92a75
   depends:
-  - mojo-python ==1.0.0b3.dev2026072114
+  - mojo-python ==1.0.0b3.dev2026072306
   license: LicenseRef-Modular-Proprietary
-  size: 63173362
-  timestamp: 1784645079048
-- conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026072114-release.conda
+  size: 62030583
+  timestamp: 1784787407344
+- conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026072306-release.conda
   noarch: python
-  sha256: 59be076990ba4890612b0809c80dfb683f83aea62f8101c5ff832308d0e87d5f
-  md5: bfc27fcc113f8410c169b72fa797b48f
+  sha256: 31997eb3977ccd43979f8032992a66e48e84e09c00406f85ae581046189b37ad
+  md5: 40933c74ecddff04ae43165667bcb42b
   depends:
   - python >=3.10
   license: LicenseRef-Modular-Proprietary
-  size: 24107
-  timestamp: 1784644769177
+  size: 24123
+  timestamp: 1784787149484
 - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
   sha256: 6ed158e4e5dd8f6a10ad9e525631e35cee8557718f83de7a4e3966b1f772c4b1
   md5: e9c622e0d00fa24a6292279af3ab6d06

--- a/pixi.toml
+++ b/pixi.toml
@@ -19,7 +19,7 @@ version = "0.21.0"
 backend = { name = "pixi-build-rattler-build", version = "*" }
 
 [dependencies]
-mojo = "==1.0.0b3.dev2026072306"
+mojo = "==1.0.0b3.dev2026072505"
 
 [tasks]
 test = "bash -c 'status=0; for f in tests/test_*.mojo; do echo \"Running $f...\"; out=$(mktemp -d); mojo build -I ./src -debug-level=line-tables \"$f\" -o \"$out/exe\" && \"$out/exe\" || status=1; rm -rf \"$out\"; done; exit $status'"

--- a/pixi.toml
+++ b/pixi.toml
@@ -19,7 +19,7 @@ version = "0.21.0"
 backend = { name = "pixi-build-rattler-build", version = "*" }
 
 [dependencies]
-mojo = "==1.0.0b3.dev2026072114"
+mojo = "==1.0.0b3.dev2026072306"
 
 [tasks]
 test = "bash -c 'status=0; for f in tests/test_*.mojo; do echo \"Running $f...\"; out=$(mktemp -d); mojo build -I ./src -debug-level=line-tables \"$f\" -o \"$out/exe\" && \"$out/exe\" || status=1; rm -rf \"$out\"; done; exit $status'"

--- a/src/regex/aliases.mojo
+++ b/src/regex/aliases.mojo
@@ -51,7 +51,7 @@ def byte_in_string[O: Origin](ch_code: Int, s: StringSlice[O]) -> Bool:
     var ptr = s.unsafe_ptr()
     var target = UInt8(ch_code)
     for i in range(s.byte_length()):
-        if ptr[i] == target:
+        if ptr[unsafe_offset=i] == target:
             return True
     return False
 

--- a/src/regex/aliases.mojo
+++ b/src/regex/aliases.mojo
@@ -73,7 +73,9 @@ def imm_slice_from_ptr(
     around the 1.0.0b2 `StringSlice(unsafe_from_utf8=Span(...))`
     constructor so call sites stay compact."""
     return ImmSlice(
-        unsafe_from_utf8=Span[Byte, ImmutAnyOrigin](ptr=ptr, length=length)
+        unsafe_from_utf8=Span[Byte, ImmutAnyOrigin](
+            unsafe_ptr=ptr, length=length
+        )
     )
 
 

--- a/src/regex/ast.mojo
+++ b/src/regex/ast.mojo
@@ -546,7 +546,8 @@ struct ASTNode[regex_origin: ImmOrigin](
             return None
         return StringSlice(
             unsafe_from_utf8=Span[Byte, origin_of(self.regex_ptr[].pattern)](
-                ptr=self.regex_ptr[].pattern.unsafe_ptr() + self.start_idx,
+                unsafe_ptr=self.regex_ptr[].pattern.unsafe_ptr()
+                + self.start_idx,
                 length=self.end_idx - self.start_idx,
             )
         )

--- a/src/regex/ast.mojo
+++ b/src/regex/ast.mojo
@@ -146,7 +146,7 @@ struct Regex[origin: Origin](Copyable, Equatable, Movable, Writable):
     @always_inline
     def get_child(self, i: Int) -> ASTNode[ImmUntrackedOrigin]:
         """Get the child ASTNode at index `i`."""
-        return self.children_ptr[i]
+        return self.children_ptr[unsafe_offset=i]
 
     @always_inline
     def get_children_len(self) -> Int:
@@ -423,7 +423,7 @@ struct ASTNode[regex_origin: ImmOrigin](
                 ref val = value.value()
                 return (
                     val.byte_length() == 1
-                    and Int(val.unsafe_ptr()[0]) == ch_code
+                    and Int(val.unsafe_ptr()[unsafe_offset=0]) == ch_code
                 )
             return False
         elif self.type == WILDCARD:
@@ -484,21 +484,24 @@ struct ASTNode[regex_origin: ImmOrigin](
         """Check if a character code matches range syntax like 'a-z'."""
         var rs_ptr = range_syntax.unsafe_ptr()
         var i = 0
-        if range_syntax.byte_length() > 0 and Int(rs_ptr[0]) == CHAR_CIRCUMFLEX:
+        if (
+            range_syntax.byte_length() > 0
+            and Int(rs_ptr[unsafe_offset=0]) == CHAR_CIRCUMFLEX
+        ):
             i = 1
 
         while i < range_syntax.byte_length():
             if (
                 i + 2 < range_syntax.byte_length()
-                and Int(rs_ptr[i + 1]) == CHAR_DASH
+                and Int(rs_ptr[unsafe_offset=i + 1]) == CHAR_DASH
             ):
-                var start_code = Int(rs_ptr[i])
-                var end_code = Int(rs_ptr[i + 2])
+                var start_code = Int(rs_ptr[unsafe_offset=i])
+                var end_code = Int(rs_ptr[unsafe_offset=i + 2])
                 if start_code <= ch_code <= end_code:
                     return True
                 i += 3
             else:
-                if Int(rs_ptr[i]) == ch_code:
+                if Int(rs_ptr[unsafe_offset=i]) == ch_code:
                     return True
                 i += 1
         return False
@@ -546,8 +549,9 @@ struct ASTNode[regex_origin: ImmOrigin](
             return None
         return StringSlice(
             unsafe_from_utf8=Span[Byte, origin_of(self.regex_ptr[].pattern)](
-                unsafe_ptr=self.regex_ptr[].pattern.unsafe_ptr()
-                + self.start_idx,
+                unsafe_ptr=self.regex_ptr[]
+                .pattern.unsafe_ptr()
+                .unsafe_offset(self.start_idx),
                 length=self.end_idx - self.start_idx,
             )
         )
@@ -564,7 +568,7 @@ def Element[
     """Create an Element node with a value string."""
     var regex_ptr = (
         UnsafePointer(to=regex)
-        .as_immutable()
+        .as_imm()
         .unsafe_origin_cast[ImmUntrackedOrigin]()
     )
     return ASTNode[ImmUntrackedOrigin](
@@ -588,7 +592,7 @@ def WildcardElement[
     """Create a WildcardElement node."""
     var regex_ptr = (
         UnsafePointer(to=regex)
-        .as_immutable()
+        .as_imm()
         .unsafe_origin_cast[ImmUntrackedOrigin]()
     )
     return ASTNode[ImmUntrackedOrigin](
@@ -612,7 +616,7 @@ def SpaceElement[
     """Create a SpaceElement node."""
     var regex_ptr = (
         UnsafePointer(to=regex)
-        .as_immutable()
+        .as_imm()
         .unsafe_origin_cast[ImmUntrackedOrigin]()
     )
     return ASTNode[ImmUntrackedOrigin](
@@ -636,7 +640,7 @@ def DigitElement[
     """Create a DigitElement node."""
     var regex_ptr = (
         UnsafePointer(to=regex)
-        .as_immutable()
+        .as_imm()
         .unsafe_origin_cast[ImmUntrackedOrigin]()
     )
     return ASTNode[ImmUntrackedOrigin](
@@ -660,7 +664,7 @@ def WordElement[
     """Create a WordElement node."""
     var regex_ptr = (
         UnsafePointer(to=regex)
-        .as_immutable()
+        .as_imm()
         .unsafe_origin_cast[ImmUntrackedOrigin]()
     )
     return ASTNode[ImmUntrackedOrigin](
@@ -715,7 +719,7 @@ def RangeElement[
     """Create a RangeElement node."""
     var regex_ptr = (
         UnsafePointer(to=regex)
-        .as_immutable()
+        .as_imm()
         .unsafe_origin_cast[ImmUntrackedOrigin]()
     )
     # Classify the range pattern once at build time.
@@ -746,7 +750,7 @@ def StartElement[
     """Create a StartElement node."""
     var regex_ptr = (
         UnsafePointer(to=regex)
-        .as_immutable()
+        .as_imm()
         .unsafe_origin_cast[ImmUntrackedOrigin]()
     )
     return ASTNode[ImmUntrackedOrigin](
@@ -770,7 +774,7 @@ def EndElement[
     """Create an EndElement node."""
     var regex_ptr = (
         UnsafePointer(to=regex)
-        .as_immutable()
+        .as_imm()
         .unsafe_origin_cast[ImmUntrackedOrigin]()
     )
     return ASTNode[ImmUntrackedOrigin](
@@ -796,7 +800,7 @@ def OrNode[
     """Create an OrNode with left and right children."""
     var regex_ptr = (
         UnsafePointer(to=regex)
-        .as_immutable()
+        .as_imm()
         .unsafe_origin_cast[ImmUntrackedOrigin]()
     )
     return ASTNode[ImmUntrackedOrigin](
@@ -824,7 +828,7 @@ def NotNode[
     """Create a NotNode with a child."""
     var regex_ptr = (
         UnsafePointer(to=regex)
-        .as_immutable()
+        .as_imm()
         .unsafe_origin_cast[ImmUntrackedOrigin]()
     )
     return ASTNode[ImmUntrackedOrigin](
@@ -850,7 +854,7 @@ def GroupNode[
     """Create a GroupNode with children."""
     var regex_ptr = (
         UnsafePointer(to=regex)
-        .as_immutable()
+        .as_imm()
         .unsafe_origin_cast[ImmUntrackedOrigin]()
     )
     var node = ASTNode[ImmUntrackedOrigin](

--- a/src/regex/dfa.mojo
+++ b/src/regex/dfa.mojo
@@ -119,7 +119,7 @@ def _expand_character_range[
 
     # For simple single ranges, use slicing from pre-defined sets
     var inner_ptr = inner.unsafe_ptr()
-    if inner.byte_length() == 3 and Int(inner_ptr[1]) == ord("-"):
+    if inner.byte_length() == 3 and Int(inner_ptr[unsafe_offset=1]) == ord("-"):
         var start_char = inner[byte=0]
         var end_char = inner[byte=2]
 
@@ -147,7 +147,9 @@ def _expand_character_range[
     var result = String(capacity=estimated_capacity)
     var i = 0
     while i < inner.byte_length():
-        if i + 2 < inner.byte_length() and Int(inner_ptr[i + 1]) == ord("-"):
+        if i + 2 < inner.byte_length() and Int(
+            inner_ptr[unsafe_offset=i + 1]
+        ) == ord("-"):
             # Found a range like a-z
             var start_char = inner[byte=i]
             var end_char = inner[byte=i + 2]
@@ -291,17 +293,17 @@ struct DFAEngine(Engine):
         self._simd_scan_eligible = False
         self.literal_pattern = ""
 
-    def __init__(out self, *, deinit take: Self):
+    def __init__(out self, *, deinit move: Self):
         """Move constructor."""
-        self.states = take.states^
-        self.start_state = take.start_state
-        self.has_start_anchor = take.has_start_anchor
-        self.has_end_anchor = take.has_end_anchor
-        self.is_pure_literal = take.is_pure_literal
-        self._simd_char_matcher = take._simd_char_matcher
-        self._has_simd_matcher = take._has_simd_matcher
-        self._simd_scan_eligible = take._simd_scan_eligible
-        self.literal_pattern = take.literal_pattern^
+        self.states = move.states^
+        self.start_state = move.start_state
+        self.has_start_anchor = move.has_start_anchor
+        self.has_end_anchor = move.has_end_anchor
+        self.is_pure_literal = move.is_pure_literal
+        self._simd_char_matcher = move._simd_char_matcher
+        self._has_simd_matcher = move._has_simd_matcher
+        self._simd_scan_eligible = move._simd_scan_eligible
+        self.literal_pattern = move.literal_pattern^
 
     def compile_pattern(
         mut self,
@@ -339,7 +341,7 @@ struct DFAEngine(Engine):
         var pattern_ptr = pattern.unsafe_ptr()
         for i in range(len_pattern):
             var state = DFAState()
-            var char_code = Int(pattern_ptr[i])
+            var char_code = Int(pattern_ptr[unsafe_offset=i])
             state.add_transition(char_code, i + 1)
             self.states.append(state)
 
@@ -675,7 +677,7 @@ struct DFAEngine(Engine):
                     var prev_state = current_state_index
 
                     for ch_idx in range(branch.byte_length()):
-                        var char_code = Int(branch_ptr[ch_idx])
+                        var char_code = Int(branch_ptr[unsafe_offset=ch_idx])
                         if ch_idx == branch.byte_length() - 1:
                             # Last char in branch -> transition to shared end state
                             self.states[prev_state].add_transition(
@@ -911,7 +913,7 @@ struct DFAEngine(Engine):
             var branch_text_ptr = branch_text.unsafe_ptr()
 
             for j in range(branch_text.byte_length()):
-                var char_code = Int(branch_text_ptr[j])
+                var char_code = Int(branch_text_ptr[unsafe_offset=j])
 
                 if j == branch_text.byte_length() - 1:
                     # Last character - transition to accepting state
@@ -990,7 +992,7 @@ struct DFAEngine(Engine):
         var current_state_index = 0
         var group_text_ptr = group_text.unsafe_ptr()
         for i in range(group_text.byte_length()):
-            var char_code = Int(group_text_ptr[i])
+            var char_code = Int(group_text_ptr[unsafe_offset=i])
 
             if i == group_text.byte_length() - 1:
                 # Last character - go to accepting state
@@ -1021,7 +1023,7 @@ struct DFAEngine(Engine):
         var current_state_index = 0
         var group_text_ptr = group_text.unsafe_ptr()
         for i in range(group_text.byte_length()):
-            var char_code = Int(group_text_ptr[i])
+            var char_code = Int(group_text_ptr[unsafe_offset=i])
 
             if i == group_text.byte_length() - 1:
                 # Last character - loop back to start (for more matches) or stay accepting
@@ -1045,7 +1047,7 @@ struct DFAEngine(Engine):
         var current_state_index = 0
         var group_text_ptr = group_text.unsafe_ptr()
         for i in range(group_text.byte_length()):
-            var char_code = Int(group_text_ptr[i])
+            var char_code = Int(group_text_ptr[unsafe_offset=i])
 
             if i == group_text.byte_length() - 1:
                 # Last character - create accepting state that can loop back
@@ -1058,7 +1060,7 @@ struct DFAEngine(Engine):
 
                 # From loop state, can start pattern again or stay accepting
                 self.states[loop_index].add_transition(
-                    Int(group_text_ptr[0]),
+                    Int(group_text_ptr[unsafe_offset=0]),
                     1 if group_text.byte_length() > 1 else loop_index,
                 )
             else:
@@ -1157,7 +1159,7 @@ struct DFAEngine(Engine):
         var current_state_index = 0
         var pattern_text_ptr = pattern_text.unsafe_ptr()
         for i in range(pattern_text.byte_length()):
-            var char_code = Int(pattern_text_ptr[i])
+            var char_code = Int(pattern_text_ptr[unsafe_offset=i])
 
             if i == pattern_text.byte_length() - 1:
                 # Last character - go to accepting state
@@ -1189,7 +1191,7 @@ struct DFAEngine(Engine):
         var current_state_index = 0
         var pattern_text_ptr = pattern_text.unsafe_ptr()
         for i in range(pattern_text.byte_length()):
-            var char_code = Int(pattern_text_ptr[i])
+            var char_code = Int(pattern_text_ptr[unsafe_offset=i])
 
             if i == pattern_text.byte_length() - 1:
                 # Last character - loop back to start (for more matches) or stay accepting
@@ -1214,7 +1216,7 @@ struct DFAEngine(Engine):
         var current_state_index = 0
         var pattern_text_ptr = pattern_text.unsafe_ptr()
         for i in range(pattern_text.byte_length()):
-            var char_code = Int(pattern_text_ptr[i])
+            var char_code = Int(pattern_text_ptr[unsafe_offset=i])
 
             if i == pattern_text.byte_length() - 1:
                 # Last character - create accepting state that can loop back
@@ -1227,7 +1229,7 @@ struct DFAEngine(Engine):
 
                 # From loop state, can start pattern again or stay accepting
                 self.states[loop_index].add_transition(
-                    Int(pattern_text_ptr[0]),
+                    Int(pattern_text_ptr[unsafe_offset=0]),
                     1 if pattern_text.byte_length() > 1 else loop_index,
                 )
             else:
@@ -1428,7 +1430,7 @@ struct DFAEngine(Engine):
         var current_state = 0
         var common_prefix_ptr = common_prefix.unsafe_ptr()
         for i in range(prefix_len):
-            var char_code = Int(common_prefix_ptr[i])
+            var char_code = Int(common_prefix_ptr[unsafe_offset=i])
             var next_state_index = self._find_or_create_state(
                 current_state, char_code
             )
@@ -1446,7 +1448,7 @@ struct DFAEngine(Engine):
                 var suffix_ptr = suffix.unsafe_ptr()
 
                 for j in range(suffix.byte_length()):
-                    var char_code = Int(suffix_ptr[j])
+                    var char_code = Int(suffix_ptr[unsafe_offset=j])
 
                     if j == suffix.byte_length() - 1:
                         # Last character - create or mark accepting state
@@ -1479,12 +1481,12 @@ struct DFAEngine(Engine):
         # Find common prefix
         var first_branch_ptr = first_branch.unsafe_ptr()
         for pos in range(min_length):
-            var char_at_pos = Int(first_branch_ptr[pos])
+            var char_at_pos = Int(first_branch_ptr[unsafe_offset=pos])
             var all_match = True
 
             for i in range(1, len(branches)):
                 var branch_ptr_i = branches[i].unsafe_ptr()
-                if Int(branch_ptr_i[pos]) != char_at_pos:
+                if Int(branch_ptr_i[unsafe_offset=pos]) != char_at_pos:
                     all_match = False
                     break
 
@@ -1597,7 +1599,7 @@ struct DFAEngine(Engine):
             var branch_ptr = branch.unsafe_ptr()
 
             for j in range(branch.byte_length()):
-                var char_code = Int(branch_ptr[j])
+                var char_code = Int(branch_ptr[unsafe_offset=j])
 
                 if j == branch.byte_length() - 1:
                     # Last character - go to accepting state
@@ -1624,7 +1626,7 @@ struct DFAEngine(Engine):
             var branch_ptr = branch.unsafe_ptr()
 
             for j in range(branch.byte_length()):
-                var char_code = Int(branch_ptr[j])
+                var char_code = Int(branch_ptr[unsafe_offset=j])
 
                 if j == branch.byte_length() - 1:
                     # Last character - loop back to start for more matches
@@ -1651,7 +1653,7 @@ struct DFAEngine(Engine):
             var branch_ptr = branch.unsafe_ptr()
 
             for j in range(branch.byte_length()):
-                var char_code = Int(branch_ptr[j])
+                var char_code = Int(branch_ptr[unsafe_offset=j])
 
                 if j == branch.byte_length() - 1:
                     # Last character - go to loop state
@@ -1670,7 +1672,7 @@ struct DFAEngine(Engine):
             var branch_ptr = branch.unsafe_ptr()
 
             for j in range(branch.byte_length()):
-                var char_code = Int(branch_ptr[j])
+                var char_code = Int(branch_ptr[unsafe_offset=j])
 
                 if j == branch.byte_length() - 1:
                     # Last character - back to loop state
@@ -1785,7 +1787,7 @@ struct DFAEngine(Engine):
             else:
                 # General case - iterate through each character
                 for i in range(char_class_len):
-                    var char_code = Int(cc_ptr[i])
+                    var char_code = Int(cc_ptr[unsafe_offset=i])
                     state.add_transition(char_code, to_state)
         else:
             # Negative logic: [^abc] - add transitions for all characters
@@ -1796,7 +1798,7 @@ struct DFAEngine(Engine):
             )
             # Remove transitions for excluded characters
             for i in range(char_class_len):
-                var char_code = Int(cc_ptr[i])
+                var char_code = Int(cc_ptr[unsafe_offset=i])
                 if char_code >= 0 and char_code < DEFAULT_DFA_TRANSITIONS:
                     state.transitions[char_code] = -1
 
@@ -1833,7 +1835,7 @@ struct DFAEngine(Engine):
                 # Only match empty if start state is accepting
                 return self.states[self.start_state].is_accepting
             # Check if the character at start matches
-            var ch_code = Int(text.unsafe_ptr()[start])
+            var ch_code = Int(text.unsafe_ptr()[unsafe_offset=start])
             if self._simd_char_matcher.contains(ch_code):
                 return True
             # No match at start - only valid if start state accepts
@@ -1956,7 +1958,9 @@ struct DFAEngine(Engine):
             and len(self.states) > 0
             and (
                 self._simd_scan_eligible
-                or self.states.unsafe_ptr()[self.start_state].is_accepting
+                or self.states.unsafe_ptr()[
+                    unsafe_offset=self.start_state
+                ].is_accepting
             )
         ):
             var match_result = self._try_match_simd(text, start_pos)
@@ -1985,14 +1989,14 @@ struct DFAEngine(Engine):
         # Check if start state is accepting (for patterns like a*)
         if (
             current_state < num_states
-            and states_ptr[current_state].is_accepting
+            and states_ptr[unsafe_offset=current_state].is_accepting
         ):
             last_accepting_pos = pos
 
         while pos < text_len:
-            var next_state = states_ptr[current_state].get_transition(
-                Int(text_ptr[pos])
-            )
+            var next_state = states_ptr[
+                unsafe_offset=current_state
+            ].get_transition(Int(text_ptr[unsafe_offset=pos]))
 
             if next_state == -1:
                 break
@@ -2001,14 +2005,14 @@ struct DFAEngine(Engine):
             pos += 1
 
             # Check if current state is accepting
-            if states_ptr[current_state].is_accepting:
+            if states_ptr[unsafe_offset=current_state].is_accepting:
                 last_accepting_pos = pos
 
         # Check final state at text end
         if (
             pos == text_len
             and current_state < num_states
-            and states_ptr[current_state].is_accepting
+            and states_ptr[unsafe_offset=current_state].is_accepting
         ):
             last_accepting_pos = pos
 
@@ -2153,7 +2157,7 @@ struct DFAEngine(Engine):
         # unsafe_ptr to skip the 1.0.0b1 default List bounds check;
         # start_state is guaranteed in-range by the len check above.
         var start_accepting = self.states.unsafe_ptr()[
-            self.start_state
+            unsafe_offset=self.start_state
         ].is_accepting
 
         # Bounded quantifiers like {3} or {2,4} can't use SIMD scan because
@@ -2282,7 +2286,7 @@ struct DFAEngine(Engine):
 
         # Handle remaining characters one by one
         while pos < text_len:
-            var char_code = Int(text_ptr[pos])
+            var char_code = Int(text_ptr[unsafe_offset=pos])
             if simd_matcher.contains(char_code):
                 return pos
             pos += 1
@@ -2317,7 +2321,7 @@ struct BoyerMoore:
         # Set the last occurrence of each character in pattern
         var pattern_ptr = self.pattern.unsafe_ptr()
         for i in range(self.pattern.byte_length()):
-            var char_code = Int(pattern_ptr[i])
+            var char_code = Int(pattern_ptr[unsafe_offset=i])
             self.bad_char_table[char_code] = i
 
     def search(self, text: String, start: Int = 0) -> Int:
@@ -2340,7 +2344,9 @@ struct BoyerMoore:
             var j = m - 1
 
             # Compare pattern from right to left
-            while j >= 0 and Int(pattern_ptr[j]) == Int(text_ptr[s + j]):
+            while j >= 0 and Int(pattern_ptr[unsafe_offset=j]) == Int(
+                text_ptr[unsafe_offset=s + j]
+            ):
                 j -= 1
 
             if j < 0:
@@ -2348,7 +2354,7 @@ struct BoyerMoore:
                 return s
             else:
                 # Mismatch occurred, use bad character heuristic
-                var bad_char = Int(text_ptr[s + j])
+                var bad_char = Int(text_ptr[unsafe_offset=s + j])
                 var shift = j - self.bad_char_table[bad_char]
                 s += max(1, shift)
 
@@ -3499,12 +3505,12 @@ def _compute_common_prefix(branches: List[String]) -> String:
     # Find common prefix
     var first_branch_ptr = first_branch.unsafe_ptr()
     for pos in range(min_length):
-        var char_at_pos = Int(first_branch_ptr[pos])
+        var char_at_pos = Int(first_branch_ptr[unsafe_offset=pos])
         var all_match = True
 
         for i in range(1, len(branches)):
             var branch_ptr_i = branches[i].unsafe_ptr()
-            if Int(branch_ptr_i[pos]) != char_at_pos:
+            if Int(branch_ptr_i[unsafe_offset=pos]) != char_at_pos:
                 all_match = False
                 break
 

--- a/src/regex/literal_optimizer.mojo
+++ b/src/regex/literal_optimizer.mojo
@@ -453,7 +453,9 @@ def _longest_common_prefix(s1: String, s2: String) -> String:
     var i = 0
     var s1_ptr = s1.unsafe_ptr()
     var s2_ptr = s2.unsafe_ptr()
-    while i < min_len and Int(s1_ptr[i]) == Int(s2_ptr[i]):
+    while i < min_len and Int(s1_ptr[unsafe_offset=i]) == Int(
+        s2_ptr[unsafe_offset=i]
+    ):
         i += 1
     return String(s1[byte=:i])
 

--- a/src/regex/matcher.mojo
+++ b/src/regex/matcher.mojo
@@ -949,10 +949,10 @@ struct CompiledRegex(ImplicitlyCopyable, Movable):
     fixed-width form and `sub()` goes through the general NFA path."""
     var _fixed_sub_num_groups: Int
     """Number of capture groups in the fixed-width pattern (1..9)."""
-    var _fixed_sub_offsets: InlineArray[Int, 10]
+    var _fixed_sub_offsets: Array[Int, 10]
     """Byte offset of each capture group relative to the match start.
     Indexed by group number (1..num_groups)."""
-    var _fixed_sub_widths: InlineArray[Int, 10]
+    var _fixed_sub_widths: Array[Int, 10]
     """Byte width of each capture group. Indexed by group number."""
     var _fixed_sub_concat: Bool
     """True when the fixed-width pattern has no literal separators (pure
@@ -971,8 +971,8 @@ struct CompiledRegex(ImplicitlyCopyable, Movable):
         self.compiled_at = Int(monotonic())
         self._fixed_sub_total_width = -1
         self._fixed_sub_num_groups = 0
-        self._fixed_sub_offsets = InlineArray[Int, 10](fill=0)
-        self._fixed_sub_widths = InlineArray[Int, 10](fill=0)
+        self._fixed_sub_offsets = Array[Int, 10](fill=0)
+        self._fixed_sub_widths = Array[Int, 10](fill=0)
         self._fixed_sub_concat = False
         self._try_precompute_fixed_sub()
 
@@ -1555,8 +1555,8 @@ def _apply_template_fixed(
     repl_ptr: UnsafePointer[Byte, ImmutAnyOrigin],
     text_ptr: UnsafePointer[Byte, ImmutAnyOrigin],
     match_start: Int,
-    group_offsets: InlineArray[Int, 10],
-    group_widths: InlineArray[Int, 10],
+    group_offsets: Array[Int, 10],
+    group_widths: Array[Int, 10],
     num_groups: Int,
     output_estimate: Int,
 ) -> String:
@@ -1588,7 +1588,7 @@ def _apply_template_groups[
     template: List[_ReplSegment],
     repl_ptr: UnsafePointer[Byte, ImmutAnyOrigin],
     groups: List[Match[O]],
-    group_idx: InlineArray[Int, 10],
+    group_idx: Array[Int, 10],
 ) -> String:
     """Apply pre-parsed template using NFA-extracted group matches."""
     var out = String(capacity=32)
@@ -1757,7 +1757,7 @@ def _sub_impl_with_repl(
                     )
 
                 # Build group index for this match
-                var group_idx = InlineArray[Int, 10](fill=-1)
+                var group_idx = Array[Int, 10](fill=-1)
                 for gi in range(len(mg[1])):
                     var gid = mg[1][gi].group_id
                     if 1 <= gid <= 9:

--- a/src/regex/matcher.mojo
+++ b/src/regex/matcher.mojo
@@ -84,11 +84,11 @@ struct OptimizedLiteralInfo(Copyable, Movable):
         self.has_anchors = copy.has_anchors
         self.is_exact_match = copy.is_exact_match
 
-    def __init__(out self, *, deinit take: Self):
+    def __init__(out self, *, deinit move: Self):
         """Move constructor."""
-        self.best_literal = take.best_literal^
-        self.has_anchors = take.has_anchors
-        self.is_exact_match = take.is_exact_match
+        self.best_literal = move.best_literal^
+        self.has_anchors = move.has_anchors
+        self.is_exact_match = move.is_exact_match
 
     def get_best_required_literal(self) -> Optional[String]:
         """Get the best required literal for matching."""
@@ -158,7 +158,7 @@ def _find_rare_required_byte(
         ref s = val.value()
         if s.byte_length() != 1:
             continue
-        var byte = Int(s.unsafe_ptr()[0])
+        var byte = Int(s.unsafe_ptr()[unsafe_offset=0])
         if first_class_lookup[byte] == 0:
             return byte
     return -1
@@ -337,13 +337,13 @@ struct NFAMatcher(Copyable, Movable, RegexMatcher):
         else:
             self._onepass_ptr = None
 
-    def __init__(out self, *, deinit take: Self):
+    def __init__(out self, *, deinit move: Self):
         """Move constructor. Transfers ownership of the heap-allocated
-        engines from `take` to `self`."""
-        self.engine = take.engine^
-        self.ast = take.ast^
-        self._lazy_dfa_ptr = take._lazy_dfa_ptr
-        self._onepass_ptr = take._onepass_ptr
+        engines from `move` to `self`."""
+        self.engine = move.engine^
+        self.ast = move.ast^
+        self._lazy_dfa_ptr = move._lazy_dfa_ptr
+        self._onepass_ptr = move._onepass_ptr
 
     def __del__(deinit self):
         """Free the heap-allocated engines if we still own them."""
@@ -470,7 +470,7 @@ def _is_simple_pattern_skip_prefilter(pattern: String) -> Bool:
 
     var pattern_ptr = pattern.unsafe_ptr()
     for i in range(pattern_len):
-        var c = Int(pattern_ptr[i])
+        var c = Int(pattern_ptr[unsafe_offset=i])
         if c == ord("*") or c == ord("+") or c == ord("?"):
             has_quantifiers = True
         elif c == ord("|"):
@@ -501,7 +501,7 @@ def _is_simple_pattern_skip_prefilter(pattern: String) -> Bool:
         # Short alternation patterns like "a|b|c" yield single-char literals
         var alternation_chars = 0
         for i in range(pattern_len):
-            if Int(pattern_ptr[i]) == ord("|"):
+            if Int(pattern_ptr[unsafe_offset=i]) == ord("|"):
                 alternation_chars += 1
         # If it's mostly single chars separated by |, skip
         if (
@@ -704,18 +704,18 @@ struct HybridMatcher(Copyable, Movable, RegexMatcher):
         self._use_dfa = copy._use_dfa
         self._required_byte = copy._required_byte
 
-    def __init__(out self, *, deinit take: Self):
+    def __init__(out self, *, deinit move: Self):
         """Move constructor."""
-        self.dfa_matcher = take.dfa_matcher^
-        self.nfa_matcher = take.nfa_matcher^
-        self.complexity = take.complexity
-        self.prefilter = take.prefilter^
-        self.literal_info = take.literal_info^
-        self.is_exact_literal = take.is_exact_literal
-        self.is_wildcard_match_any = take.is_wildcard_match_any
-        self.use_pure_dfa = take.use_pure_dfa
-        self._use_dfa = take._use_dfa
-        self._required_byte = take._required_byte
+        self.dfa_matcher = move.dfa_matcher^
+        self.nfa_matcher = move.nfa_matcher^
+        self.complexity = move.complexity
+        self.prefilter = move.prefilter^
+        self.literal_info = move.literal_info^
+        self.is_exact_literal = move.is_exact_literal
+        self.is_wildcard_match_any = move.is_wildcard_match_any
+        self.use_pure_dfa = move.use_pure_dfa
+        self._use_dfa = move._use_dfa
+        self._required_byte = move._required_byte
 
     @always_inline
     def is_match(self, text: ImmSlice, start: Int = 0) -> Bool:
@@ -880,7 +880,10 @@ struct HybridMatcher(Copyable, Movable, RegexMatcher):
             # character class. That gives the earliest possible match start
             # for a pattern of shape `[class]+<needle>...`.
             var start = hit
-            while start > 0 and cc.lookup_table[Int(text_ptr[start - 1])] != 0:
+            while (
+                start > 0
+                and cc.lookup_table[Int(text_ptr[unsafe_offset=start - 1])] != 0
+            ):
                 start -= 1
             var m = self.dfa_matcher.match_first(text, start)
             if m and m.value().end_idx > hit:
@@ -984,16 +987,16 @@ struct CompiledRegex(ImplicitlyCopyable, Movable):
         self._fixed_sub_widths = copy._fixed_sub_widths
         self._fixed_sub_concat = copy._fixed_sub_concat
 
-    def __init__(out self, *, deinit take: Self):
+    def __init__(out self, *, deinit move: Self):
         """Move constructor."""
-        self.matcher = take.matcher^
-        self.pattern = take.pattern^
-        self.compiled_at = take.compiled_at
-        self._fixed_sub_total_width = take._fixed_sub_total_width
-        self._fixed_sub_num_groups = take._fixed_sub_num_groups
-        self._fixed_sub_offsets = take._fixed_sub_offsets
-        self._fixed_sub_widths = take._fixed_sub_widths
-        self._fixed_sub_concat = take._fixed_sub_concat
+        self.matcher = move.matcher^
+        self.pattern = move.pattern^
+        self.compiled_at = move.compiled_at
+        self._fixed_sub_total_width = move._fixed_sub_total_width
+        self._fixed_sub_num_groups = move._fixed_sub_num_groups
+        self._fixed_sub_offsets = move._fixed_sub_offsets
+        self._fixed_sub_widths = move._fixed_sub_widths
+        self._fixed_sub_concat = move._fixed_sub_concat
 
     def _try_precompute_fixed_sub(mut self):
         """If `pattern` is a sequence of fixed-width `(\\d{N})` capture
@@ -1406,8 +1409,8 @@ def _parse_repl_template(repl: ImmSlice) -> List[_ReplSegment]:
     var literal_start = 0
 
     while i < repl_len:
-        if Int(repl_ptr[i]) == CHAR_SLASH and i + 1 < repl_len:
-            var next_ch = Int(repl_ptr[i + 1])
+        if Int(repl_ptr[unsafe_offset=i]) == CHAR_SLASH and i + 1 < repl_len:
+            var next_ch = Int(repl_ptr[unsafe_offset=i + 1])
             if next_ch >= CHAR_ONE and next_ch <= CHAR_NINE:
                 if i > literal_start:
                     segments.append(
@@ -1432,8 +1435,8 @@ def _has_group_refs(repl: ImmSlice) -> Bool:
     var repl_ptr = repl.unsafe_ptr()
     var repl_len = repl.byte_length()
     for i in range(repl_len - 1):
-        if Int(repl_ptr[i]) == CHAR_SLASH:
-            var next_ch = Int(repl_ptr[i + 1])
+        if Int(repl_ptr[unsafe_offset=i]) == CHAR_SLASH:
+            var next_ch = Int(repl_ptr[unsafe_offset=i + 1])
             if next_ch >= CHAR_ONE and next_ch <= CHAR_NINE:
                 return True
     return False
@@ -1461,14 +1464,17 @@ def _detect_fixed_width_groups(
     var literal_run = 0  # track bytes of literal content between groups
 
     while i < plen:
-        if Int(p[i]) == CHAR_LEFT_PAREN:
+        if Int(p[unsafe_offset=i]) == CHAR_LEFT_PAREN:
             # Flush any literal run
             if literal_run > 0:
                 segments.append(-literal_run)
                 literal_run = 0
 
             # Check for non-capturing (?:...)
-            if i + 1 < plen and Int(p[i + 1]) == CHAR_QUESTION_MARK:
+            if (
+                i + 1 < plen
+                and Int(p[unsafe_offset=i + 1]) == CHAR_QUESTION_MARK
+            ):
                 return None
 
             i += 1  # skip (
@@ -1476,44 +1482,51 @@ def _detect_fixed_width_groups(
             # Expect \d or \d{N}
             if (
                 i + 1 >= plen
-                or Int(p[i]) != CHAR_SLASH
-                or Int(p[i + 1]) != CHAR_DIGIT
+                or Int(p[unsafe_offset=i]) != CHAR_SLASH
+                or Int(p[unsafe_offset=i + 1]) != CHAR_DIGIT
             ):
                 return None
             i += 2  # skip \d
 
             # Check for {N}
-            if i < plen and Int(p[i]) == CHAR_LEFT_CURLY:
+            if i < plen and Int(p[unsafe_offset=i]) == CHAR_LEFT_CURLY:
                 i += 1  # skip {
                 var num_start = i
                 while (
                     i < plen
-                    and Int(p[i]) >= CHAR_ZERO
-                    and Int(p[i]) <= CHAR_NINE
+                    and Int(p[unsafe_offset=i]) >= CHAR_ZERO
+                    and Int(p[unsafe_offset=i]) <= CHAR_NINE
                 ):
                     i += 1
-                if i == num_start or i >= plen or Int(p[i]) != CHAR_RIGHT_CURLY:
+                if (
+                    i == num_start
+                    or i >= plen
+                    or Int(p[unsafe_offset=i]) != CHAR_RIGHT_CURLY
+                ):
                     return None
                 var width = 0
                 for j in range(num_start, i):
-                    width = width * 10 + (Int(p[j]) - CHAR_ZERO)
+                    width = width * 10 + (Int(p[unsafe_offset=j]) - CHAR_ZERO)
                 i += 1  # skip }
                 segments.append(width)
-            elif i < plen and Int(p[i]) == CHAR_RIGHT_PAREN:
+            elif i < plen and Int(p[unsafe_offset=i]) == CHAR_RIGHT_PAREN:
                 # Bare \d: width 1
                 segments.append(1)
             else:
                 return None  # Variable quantifier
 
             # Expect closing )
-            if i >= plen or Int(p[i]) != CHAR_RIGHT_PAREN:
+            if i >= plen or Int(p[unsafe_offset=i]) != CHAR_RIGHT_PAREN:
                 return None
             i += 1  # skip )
-        elif Int(p[i]) == CHAR_VERTICAL_BAR or Int(p[i]) == CHAR_LEFT_BRACKET:
+        elif (
+            Int(p[unsafe_offset=i]) == CHAR_VERTICAL_BAR
+            or Int(p[unsafe_offset=i]) == CHAR_LEFT_BRACKET
+        ):
             return None
         else:
             # Literal or escape between groups
-            if Int(p[i]) == CHAR_SLASH and i + 1 < plen:
+            if Int(p[unsafe_offset=i]) == CHAR_SLASH and i + 1 < plen:
                 literal_run += (
                     1  # the escaped char takes 1 byte in matched text
                 )
@@ -1556,13 +1569,15 @@ def _apply_template_fixed(
     var tpl_len = len(template)
 
     for ti in range(tpl_len):
-        ref seg = tpl_ptr[ti]
+        ref seg = tpl_ptr[unsafe_offset=ti]
         if seg.group_ref > 0 and seg.group_ref <= num_groups:
             var gs = match_start + group_offsets[seg.group_ref]
             var gw = group_widths[seg.group_ref]
-            out += imm_slice_from_ptr(text_ptr + gs, gw)
+            out += imm_slice_from_ptr(text_ptr.unsafe_offset(gs), gw)
         else:
-            out += imm_slice_from_ptr(repl_ptr + seg.start, seg.length)
+            out += imm_slice_from_ptr(
+                repl_ptr.unsafe_offset(seg.start), seg.length
+            )
     return out
 
 
@@ -1581,13 +1596,15 @@ def _apply_template_groups[
     var tpl_len = len(template)
 
     for ti in range(tpl_len):
-        ref seg = tpl_ptr[ti]
+        ref seg = tpl_ptr[unsafe_offset=ti]
         if seg.group_ref > 0:
             var idx = group_idx[seg.group_ref]
             if idx >= 0:
                 out += groups[idx].get_match_text()
         else:
-            out += imm_slice_from_ptr(repl_ptr + seg.start, seg.length)
+            out += imm_slice_from_ptr(
+                repl_ptr.unsafe_offset(seg.start), seg.length
+            )
     return out
 
 
@@ -1669,7 +1686,7 @@ def _sub_impl_with_repl(
             if compiled._fixed_sub_concat and text_len == total_width:
                 var all_digits = True
                 for i in range(total_width):
-                    var b = Int(text_ptr[i])
+                    var b = Int(text_ptr[unsafe_offset=i])
                     if b < CHAR_ZERO or b > CHAR_NINE:
                         all_digits = False
                         break
@@ -1696,7 +1713,7 @@ def _sub_impl_with_repl(
 
                 if match_start > pos:
                     result += imm_slice_from_ptr(
-                        text_ptr + pos, match_start - pos
+                        text_ptr.unsafe_offset(pos), match_start - pos
                     )
 
                 result += _apply_template_fixed(
@@ -1713,7 +1730,9 @@ def _sub_impl_with_repl(
 
                 if match_end == match_start:
                     if pos < text_len:
-                        result += imm_slice_from_ptr(text_ptr + pos, 1)
+                        result += imm_slice_from_ptr(
+                            text_ptr.unsafe_offset(pos), 1
+                        )
                     pos = match_end + 1
                 else:
                     pos = match_end
@@ -1734,7 +1753,7 @@ def _sub_impl_with_repl(
 
                 if m.start_idx > pos:
                     result += imm_slice_from_ptr(
-                        text_ptr + pos, m.start_idx - pos
+                        text_ptr.unsafe_offset(pos), m.start_idx - pos
                     )
 
                 # Build group index for this match
@@ -1751,7 +1770,9 @@ def _sub_impl_with_repl(
 
                 if m.end_idx == m.start_idx:
                     if pos < text_len:
-                        result += imm_slice_from_ptr(text_ptr + pos, 1)
+                        result += imm_slice_from_ptr(
+                            text_ptr.unsafe_offset(pos), 1
+                        )
                     pos = m.end_idx + 1
                 else:
                     pos = m.end_idx
@@ -1768,14 +1789,16 @@ def _sub_impl_with_repl(
             var match_end = m.value().end_idx
 
             if match_start > pos:
-                result += imm_slice_from_ptr(text_ptr + pos, match_start - pos)
+                result += imm_slice_from_ptr(
+                    text_ptr.unsafe_offset(pos), match_start - pos
+                )
 
             result += repl
             replacements += 1
 
             if match_end == match_start:
                 if pos < text_len:
-                    result += imm_slice_from_ptr(text_ptr + pos, 1)
+                    result += imm_slice_from_ptr(text_ptr.unsafe_offset(pos), 1)
                 pos = match_end + 1
             else:
                 pos = match_end
@@ -1784,7 +1807,9 @@ def _sub_impl_with_repl(
                 break
 
     if pos < text_len:
-        result += imm_slice_from_ptr(text_ptr + pos, text_len - pos)
+        result += imm_slice_from_ptr(
+            text_ptr.unsafe_offset(pos), text_len - pos
+        )
 
     return result
 

--- a/src/regex/matching.mojo
+++ b/src/regex/matching.mojo
@@ -39,7 +39,7 @@ struct Match[origin: ImmOrigin](Copyable, Movable, TrivialRegisterPassable):
         """Returns the text that was matched."""
         return StringSlice[Self.origin](
             unsafe_from_utf8=Span[Byte, Self.origin](
-                ptr=self.text_ptr + self.start_idx,
+                unsafe_ptr=self.text_ptr + self.start_idx,
                 length=self.end_idx - self.start_idx,
             )
         )

--- a/src/regex/nfa.mojo
+++ b/src/regex/nfa.mojo
@@ -767,10 +767,11 @@ struct NFAEngine(Copyable, Engine):
             return (False, str_i)
 
         var str_ptr = str.unsafe_ptr()
-        var ch_code = Int(str_ptr[str_i])
+        var ch_code = Int(str_ptr[unsafe_offset=str_i])
         if (
             ast.get_value()
-            and Int(ast.get_value().value().unsafe_ptr()[0]) == ch_code
+            and Int(ast.get_value().value().unsafe_ptr()[unsafe_offset=0])
+            == ch_code
         ):
             return self._apply_quantifier(
                 ast, str, str_i, 1, match_first_mode, required_start_pos
@@ -794,7 +795,7 @@ struct NFAEngine(Copyable, Engine):
             return (False, str_i)
 
         var str_ptr = str.unsafe_ptr()
-        var ch_code = Int(str_ptr[str_i])
+        var ch_code = Int(str_ptr[unsafe_offset=str_i])
         if ch_code != CHAR_NEWLINE:  # Exclude newline
             return self._apply_quantifier(
                 ast, str, str_i, 1, match_first_mode, required_start_pos
@@ -820,7 +821,7 @@ struct NFAEngine(Copyable, Engine):
         # Inline range check avoids a per-character Dict lookup through
         # `get_whitespace_matcher()` (see ast.is_match_char for reference).
         var str_ptr = str.unsafe_ptr()
-        var ch_code = Int(str_ptr[str_i])
+        var ch_code = Int(str_ptr[unsafe_offset=str_i])
         if (
             ch_code == CHAR_SPACE
             or ch_code == CHAR_TAB_CHAR
@@ -860,7 +861,7 @@ struct NFAEngine(Copyable, Engine):
         # Inline range check avoids a per-character Dict lookup through
         # `get_digit_matcher()` (see ast.is_match_char for reference).
         var str_ptr = str.unsafe_ptr()
-        var ch_code = Int(str_ptr[str_i])
+        var ch_code = Int(str_ptr[unsafe_offset=str_i])
         if CHAR_ZERO <= ch_code <= CHAR_NINE:
             return self._apply_quantifier(
                 ast, str, str_i, 1, match_first_mode, required_start_pos
@@ -902,7 +903,7 @@ struct NFAEngine(Copyable, Engine):
         # Inline range check avoids a per-character Dict lookup through
         # `get_word_matcher()` (see ast.is_match_char for reference).
         var str_ptr = str.unsafe_ptr()
-        var ch_code = Int(str_ptr[str_i])
+        var ch_code = Int(str_ptr[unsafe_offset=str_i])
         if (
             (CHAR_A <= ch_code <= CHAR_Z)
             or (CHAR_A_UPPER <= ch_code <= CHAR_Z_UPPER)
@@ -939,7 +940,7 @@ struct NFAEngine(Copyable, Engine):
             return (False, str_i)
 
         var str_ptr = str.unsafe_ptr()
-        var ch_code = Int(str_ptr[str_i])
+        var ch_code = Int(str_ptr[unsafe_offset=str_i])
         var ch_found = False
 
         var kind = ast.range_kind
@@ -1332,7 +1333,7 @@ struct NFAEngine(Copyable, Engine):
             ):
                 return -1  # Moved too far from required start position
 
-            if ast.is_match_char(Int(str_ptr[pos]), pos, str_len):
+            if ast.is_match_char(Int(str_ptr[unsafe_offset=pos]), pos, str_len):
                 matched += 1
                 pos += 1
             else:
@@ -1422,7 +1423,7 @@ struct NFAEngine(Copyable, Engine):
                     break
 
             if ast.is_match_char(
-                Int(str_ptr[current_pos]), current_pos, str_len
+                Int(str_ptr[unsafe_offset=current_pos]), current_pos, str_len
             ):
                 matches_count += 1
                 current_pos += 1
@@ -1562,7 +1563,7 @@ struct NFAEngine(Copyable, Engine):
                     actual_max = str.byte_length() - str_i
 
                 while pos < str.byte_length() and match_count < actual_max:
-                    var ch_code = Int(str_ptr[pos])
+                    var ch_code = Int(str_ptr[unsafe_offset=pos])
                     var is_match: Bool
                     if (
                         (CHAR_A <= ch_code <= CHAR_Z)
@@ -1603,7 +1604,7 @@ struct NFAEngine(Copyable, Engine):
                         while (
                             pos < str.byte_length() and match_count < actual_max
                         ):
-                            var ch_code = Int(str_ptr[pos])
+                            var ch_code = Int(str_ptr[unsafe_offset=pos])
                             if not matcher.contains(ch_code):
                                 match_count += 1
                                 pos += 1
@@ -1622,7 +1623,7 @@ struct NFAEngine(Copyable, Engine):
                     actual_max = str.byte_length() - str_i
 
                 while pos < str.byte_length() and match_count < actual_max:
-                    var ch_code = Int(str_ptr[pos])
+                    var ch_code = Int(str_ptr[unsafe_offset=pos])
                     var is_match = self._match_char_in_range(
                         range_pattern, ch_code
                     )
@@ -1650,8 +1651,8 @@ struct NFAEngine(Copyable, Engine):
             # Handle simple ranges like [c-n]
             if inner.byte_length() == 3 and inner[byte=1] == "-":
                 var inner_ptr = inner.unsafe_ptr()
-                var start_char = Int(inner_ptr[0])
-                var end_char = Int(inner_ptr[2])
+                var start_char = Int(inner_ptr[unsafe_offset=0])
+                var end_char = Int(inner_ptr[unsafe_offset=2])
                 return ch_code >= start_char and ch_code <= end_char
 
             # Direct byte scan instead of chr() + string `in`
@@ -1678,7 +1679,7 @@ struct NFAEngine(Copyable, Engine):
         if actual_max == -1:
             actual_max = str.byte_length() - str_i
         while pos < str.byte_length() and match_count < actual_max:
-            var ch_code = Int(str_ptr[pos])
+            var ch_code = Int(str_ptr[unsafe_offset=pos])
             if not matcher.contains(ch_code):
                 match_count += 1
                 pos += 1
@@ -1709,7 +1710,7 @@ struct NFAEngine(Copyable, Engine):
         if actual_max == -1:
             actual_max = str.byte_length() - str_i
         while pos < str.byte_length() and match_count < actual_max:
-            var ch_code = Int(str_ptr[pos])
+            var ch_code = Int(str_ptr[unsafe_offset=pos])
             var is_match = range_start <= ch_code <= range_end
             if is_match == positive_logic:
                 match_count += 1

--- a/src/regex/onepass.mojo
+++ b/src/regex/onepass.mojo
@@ -61,7 +61,7 @@ blow-ups. ONEPASS_MAX_STATES is comfortably within Int16 range."""
 
 def _epsilon_close(
     program: Program,
-    imm start_pcs: InlineArray[Int, MAX_STATES],
+    imm start_pcs: Array[Int, MAX_STATES],
     start_count: Int,
     at_start: Bool,
     at_end: Bool = False,
@@ -74,7 +74,7 @@ def _epsilon_close(
     retained in the set.
     """
     var result = SIMD[DType.uint8, MAX_STATES](0)
-    var stack = InlineArray[Int, MAX_STATES](uninitialized=True)
+    var stack = Array[Int, MAX_STATES](uninitialized=True)
     var stack_len = start_count
     for i in range(start_count):
         stack[i] = start_pcs[i]
@@ -127,7 +127,7 @@ def _closure_reaches_match_with_end_anchor(
     """True iff the epsilon closure of `nfa_set` with `OP_END_ANCHOR`
     fired reaches OP_MATCH. Used at compile time to precompute the
     per-state answer; at match time the cached Bool is a single load."""
-    var start_pcs = InlineArray[Int, MAX_STATES](uninitialized=True)
+    var start_pcs = Array[Int, MAX_STATES](uninitialized=True)
     var count = 0
     for pc in range(len(program)):
         if nfa_set[pc] != 0:
@@ -204,7 +204,7 @@ def compile_onepass(
             has_end_anchor = True
 
     # Seed the worklist with the start state.
-    var start_pcs = InlineArray[Int, MAX_STATES](uninitialized=True)
+    var start_pcs = Array[Int, MAX_STATES](uninitialized=True)
     start_pcs[0] = 0
     var start_set = _epsilon_close(program, start_pcs, 1, at_start=True)
     var states = List[OnePassState](capacity=32)
@@ -218,21 +218,21 @@ def compile_onepass(
     worklist.append(0)
 
     # Temporary buffers reused per state.
-    var next_pcs = InlineArray[Int, MAX_STATES](uninitialized=True)
-    var first_pcs = InlineArray[Int, MAX_STATES](uninitialized=True)
-    var other_pcs = InlineArray[Int, MAX_STATES](uninitialized=True)
+    var next_pcs = Array[Int, MAX_STATES](uninitialized=True)
+    var first_pcs = Array[Int, MAX_STATES](uninitialized=True)
+    var other_pcs = Array[Int, MAX_STATES](uninitialized=True)
 
     # Per-state scratch: list of "active" PCs (those marked in nfa_set
     # with a byte-consuming op). Filtering once per state is O(prog_len);
     # the inner byte loop then only touches the (typically small) active
     # set instead of probing all PCs for every byte.
-    var active_pcs = InlineArray[Int, MAX_STATES](uninitialized=True)
+    var active_pcs = Array[Int, MAX_STATES](uninitialized=True)
 
     while len(worklist) > 0:
         var state_id = worklist[len(worklist) - 1]
         _ = worklist.pop()
         var cur_set = states[state_id].nfa_set
-        var transitions = InlineArray[Int, 256](fill=ONEPASS_DEAD_INT)
+        var transitions = Array[Int, 256](fill=ONEPASS_DEAD_INT)
 
         # Collect byte-consuming PCs once per state.
         var active_count = 0
@@ -325,11 +325,11 @@ def compile_onepass(
     # cold `nfa_set` is dropped from runtime so the per-byte hot loop
     # touches only ~512B per state instead of ~2576B.
     var num_states = len(states)
-    var runtime_transitions = List[InlineArray[Int16, 256]](capacity=num_states)
+    var runtime_transitions = List[Array[Int16, 256]](capacity=num_states)
     var is_match_flags = List[Bool](capacity=num_states)
     var is_end_match_flags = List[Bool](capacity=num_states)
     for i in range(num_states):
-        var compact = InlineArray[Int16, 256](fill=ONEPASS_DEAD)
+        var compact = Array[Int16, 256](fill=ONEPASS_DEAD)
         ref src = states[i].transitions
         for b in range(256):
             compact[b] = Int16(src[b])
@@ -411,7 +411,7 @@ struct OnePassState(Copyable, Movable):
     state reaches OP_MATCH. Precomputed at compile_onepass time so the
     per-call `match_first` end-of-text fixup is a single field load
     instead of a state-set DFS walk."""
-    var transitions: InlineArray[Int, 256]
+    var transitions: Array[Int, 256]
     """Byte -> next OnePass state id. `ONEPASS_DEAD` for bytes that
     have no valid successor."""
 
@@ -423,7 +423,7 @@ struct OnePassState(Copyable, Movable):
         self.nfa_set = nfa_set
         self.is_match = is_match
         self.is_end_match = False
-        self.transitions = InlineArray[Int, 256](fill=ONEPASS_DEAD_INT)
+        self.transitions = Array[Int, 256](fill=ONEPASS_DEAD_INT)
 
 
 struct OnePassNFA(Copyable, Movable):
@@ -434,7 +434,7 @@ struct OnePassNFA(Copyable, Movable):
     `nfa_set` from compilation is dropped; `is_match` / `is_end_match`
     live in their own dense `List[Bool]` arrays."""
 
-    var transitions: List[InlineArray[Int16, 256]]
+    var transitions: List[Array[Int16, 256]]
     """Per-state byte -> next-state-id table. Int16 since
     `ONEPASS_MAX_STATES = 512` and `ONEPASS_DEAD = -1` both fit. Each
     entry is 512B vs the compile-time 2KB table — 4x denser, 4x more
@@ -452,7 +452,7 @@ struct OnePassNFA(Copyable, Movable):
 
     def __init__(
         out self,
-        var transitions: List[InlineArray[Int16, 256]],
+        var transitions: List[Array[Int16, 256]],
         var is_match_flags: List[Bool],
         var is_end_match_flags: List[Bool],
         has_start_anchor: Bool,

--- a/src/regex/onepass.mojo
+++ b/src/regex/onepass.mojo
@@ -485,21 +485,25 @@ struct OnePassNFA(Copyable, Movable):
         var match_end = -1
         var trans_ptr = self.transitions.unsafe_ptr()
         var match_ptr = self.is_match_flags.unsafe_ptr()
-        if match_ptr[0]:
+        if match_ptr[unsafe_offset=0]:
             match_end = start
         var pos = start
         while pos < text_len:
-            var next_id = Int(trans_ptr[state_id][Int(text_ptr[pos])])
+            var next_id = Int(
+                trans_ptr[unsafe_offset=state_id][
+                    Int(text_ptr[unsafe_offset=pos])
+                ]
+            )
             if next_id == Int(ONEPASS_DEAD):
                 break
             state_id = next_id
             pos += 1
-            if match_ptr[state_id]:
+            if match_ptr[unsafe_offset=state_id]:
                 match_end = pos
         # End-of-text fixup for `$` anchors: cached per-state at compile
         # time, so no per-call state-set DFS walk.
         if self.has_end_anchor and pos == text_len:
-            if self.is_end_match_flags.unsafe_ptr()[state_id]:
+            if self.is_end_match_flags.unsafe_ptr()[unsafe_offset=state_id]:
                 match_end = pos
         if match_end >= 0:
             return Match(0, start, match_end, text)

--- a/src/regex/optimizer.mojo
+++ b/src/regex/optimizer.mojo
@@ -693,12 +693,12 @@ struct PatternAnalyzer:
         # Find common prefix
         var fb_ptr = first_branch.unsafe_ptr()
         for pos in range(min_length):
-            var char_at_pos = Int(fb_ptr[pos])
+            var char_at_pos = Int(fb_ptr[unsafe_offset=pos])
             var all_match = True
 
             for i in range(1, len(branches)):
                 var br_ptr = branches[i].unsafe_ptr()
-                if Int(br_ptr[pos]) != char_at_pos:
+                if Int(br_ptr[unsafe_offset=pos]) != char_at_pos:
                     all_match = False
                     break
 

--- a/src/regex/pikevm.mojo
+++ b/src/regex/pikevm.mojo
@@ -260,7 +260,7 @@ def _compile_element(node: ASTNode, mut program: Program):
     if val:
         var ch = val.value()
         if ch.byte_length() > 0:
-            _ = program.emit(OP_BYTE, Int(ch.unsafe_ptr()[0]))
+            _ = program.emit(OP_BYTE, Int(ch.unsafe_ptr()[unsafe_offset=0]))
 
 
 def _compile_wildcard(node: ASTNode, mut program: Program):
@@ -288,8 +288,10 @@ def _compile_char_class_node(node: ASTNode, mut program: Program):
         var inner_ptr = inner.unsafe_ptr()
         var j = 0
         while j < inner.byte_length():
-            if j + 1 < inner.byte_length() and Int(inner_ptr[j]) == ord("\\"):
-                var next_ch = Int(inner_ptr[j + 1])
+            if j + 1 < inner.byte_length() and Int(
+                inner_ptr[unsafe_offset=j]
+            ) == ord("\\"):
+                var next_ch = Int(inner_ptr[unsafe_offset=j + 1])
                 if next_ch == ord("s"):
                     table[ord(" ")] = 1
                     table[ord("\t")] = 1
@@ -310,16 +312,16 @@ def _compile_char_class_node(node: ASTNode, mut program: Program):
                 else:
                     table[next_ch] = 1
                 j += 2
-            elif j + 2 < inner.byte_length() and Int(inner_ptr[j + 1]) == ord(
-                "-"
-            ):
-                var lo = Int(inner_ptr[j])
-                var hi = Int(inner_ptr[j + 2])
+            elif j + 2 < inner.byte_length() and Int(
+                inner_ptr[unsafe_offset=j + 1]
+            ) == ord("-"):
+                var lo = Int(inner_ptr[unsafe_offset=j])
+                var hi = Int(inner_ptr[unsafe_offset=j + 2])
                 for c in range(lo, hi + 1):
                     table[c] = 1
                 j += 3
             else:
-                table[Int(inner_ptr[j])] = 1
+                table[Int(inner_ptr[unsafe_offset=j])] = 1
                 j += 1
 
     # Handle negated classes
@@ -430,7 +432,10 @@ struct PikeVMEngine(Copyable, Movable):
             var pos = start
             while pos < text_len:
                 # Skip positions where first byte can't match
-                if self.first_byte_filter[Int(text_ptr[pos])] == 0:
+                if (
+                    self.first_byte_filter[Int(text_ptr[unsafe_offset=pos])]
+                    == 0
+                ):
                     pos += 1
                     continue
                 var result = self._run(text, pos)
@@ -457,7 +462,10 @@ struct PikeVMEngine(Copyable, Movable):
         if self.has_filter:
             var text_ptr = text.unsafe_ptr()
             while pos < text_len:
-                if self.first_byte_filter[Int(text_ptr[pos])] == 0:
+                if (
+                    self.first_byte_filter[Int(text_ptr[unsafe_offset=pos])]
+                    == 0
+                ):
                     pos += 1
                     continue
                 var result = self._run(text, pos)
@@ -528,7 +536,7 @@ struct PikeVMEngine(Copyable, Movable):
             if pos == text_len:
                 break
 
-            var ch = Int(text_ptr[pos])
+            var ch = Int(text_ptr[unsafe_offset=pos])
 
             # Process all current states
             for i in range(cur_count):
@@ -827,13 +835,13 @@ struct LazyDFA(Copyable, Movable):
         var pos = start
         while pos < text_len:
             # Check if current state is a match
-            if states_ptr[state_id].is_match:
+            if states_ptr[unsafe_offset=state_id].is_match:
                 match_end = pos
 
-            var ch = Int(text_ptr[pos])
+            var ch = Int(text_ptr[unsafe_offset=pos])
 
             # Look up cached transition
-            var next_id = states_ptr[state_id].transitions[ch]
+            var next_id = states_ptr[unsafe_offset=state_id].transitions[ch]
 
             if next_id == LAZY_DFA_UNKNOWN:
                 # Cache miss: compute via PikeVM one-step simulation
@@ -842,7 +850,7 @@ struct LazyDFA(Copyable, Movable):
                 )
                 # Re-fetch pointer in case _compute_transition grew the list
                 states_ptr = self.states.unsafe_ptr()
-                states_ptr[state_id].transitions[ch] = next_id
+                states_ptr[unsafe_offset=state_id].transitions[ch] = next_id
 
             if next_id == LAZY_DFA_DEAD:
                 break
@@ -851,7 +859,7 @@ struct LazyDFA(Copyable, Movable):
             pos += 1
 
         # Check final state at text_len (handles $ anchor)
-        if states_ptr[state_id].is_match:
+        if states_ptr[unsafe_offset=state_id].is_match:
             match_end = pos
 
         if match_end >= 0:

--- a/src/regex/pikevm.mojo
+++ b/src/regex/pikevm.mojo
@@ -507,8 +507,8 @@ struct PikeVMEngine(Copyable, Movable):
             return None
 
         # Fixed-size state arrays on stack - zero allocation per step
-        var cur_pcs = InlineArray[Int, MAX_STATES](fill=0)
-        var nxt_pcs = InlineArray[Int, MAX_STATES](fill=0)
+        var cur_pcs = Array[Int, MAX_STATES](fill=0)
+        var nxt_pcs = Array[Int, MAX_STATES](fill=0)
         var cur_count = 0
         var nxt_count = 0
 
@@ -603,7 +603,7 @@ struct PikeVMEngine(Copyable, Movable):
 
     def _add_state(
         self,
-        mut pcs: InlineArray[Int, MAX_STATES],
+        mut pcs: Array[Int, MAX_STATES],
         mut count: Int,
         mut seen: SIMD[DType.uint8, MAX_STATES],
         pc: Int,
@@ -668,7 +668,7 @@ struct CachedState(Copyable, Movable):
     """Which NFA PCs are active (byte per PC, 0/1)."""
     var is_match: Bool
     """Whether this state set contains the MATCH instruction."""
-    var transitions: InlineArray[Int, 256]
+    var transitions: Array[Int, 256]
     """Next DFA state ID per input byte. LAZY_DFA_UNKNOWN = not cached."""
 
     def __init__(
@@ -676,7 +676,7 @@ struct CachedState(Copyable, Movable):
     ):
         self.nfa_set = nfa_set
         self.is_match = is_match
-        self.transitions = InlineArray[Int, 256](fill=LAZY_DFA_UNKNOWN)
+        self.transitions = Array[Int, 256](fill=LAZY_DFA_UNKNOWN)
 
 
 struct LazyDFA(Copyable, Movable):
@@ -881,7 +881,7 @@ struct LazyDFA(Copyable, Movable):
         var prog_len = len(self.pikevm.program)
 
         # Collect active PCs from the NFA set
-        var nxt_pcs = InlineArray[Int, MAX_STATES](fill=0)
+        var nxt_pcs = Array[Int, MAX_STATES](fill=0)
         var nxt_count = 0
         var nxt_seen = SIMD[DType.uint8, MAX_STATES](0)
 
@@ -944,7 +944,7 @@ struct LazyDFA(Copyable, Movable):
     @always_inline
     def _get_or_create_state_for_pos(mut self, pc: Int, pos: Int) -> Int:
         """Create a DFA state from the epsilon closure of a given PC."""
-        var pcs = InlineArray[Int, MAX_STATES](fill=0)
+        var pcs = Array[Int, MAX_STATES](fill=0)
         var count = 0
         var seen = SIMD[DType.uint8, MAX_STATES](0)
         # Dummy text_ptr for epsilon closure (no bytes consumed). 1.0.0b1

--- a/src/regex/prefilter.mojo
+++ b/src/regex/prefilter.mojo
@@ -45,13 +45,13 @@ struct LiteralInfo(Copyable, Movable):
         self.is_exact_match = copy.is_exact_match
         self.has_anchors = copy.has_anchors
 
-    def __init__(out self, *, deinit take: Self):
+    def __init__(out self, *, deinit move: Self):
         """Move constructor."""
-        self.required_literals = take.required_literals^
-        self.literal_prefixes = take.literal_prefixes^
-        self.literal_suffixes = take.literal_suffixes^
-        self.is_exact_match = take.is_exact_match
-        self.has_anchors = take.has_anchors
+        self.required_literals = move.required_literals^
+        self.literal_prefixes = move.literal_prefixes^
+        self.literal_suffixes = move.literal_suffixes^
+        self.is_exact_match = move.is_exact_match
+        self.has_anchors = move.has_anchors
 
     def has_prefilter_candidates(self) -> Bool:
         """Check if this pattern has candidates suitable for prefiltering."""
@@ -278,12 +278,12 @@ struct LiteralExtractor:
         # Find common prefix
         var fb_ptr = first_branch.unsafe_ptr()
         for pos in range(min_length):
-            var char_at_pos = Int(fb_ptr[pos])
+            var char_at_pos = Int(fb_ptr[unsafe_offset=pos])
             var all_match = True
 
             for i in range(1, len(branches)):
                 var br_ptr = branches[i].unsafe_ptr()
-                if Int(br_ptr[pos]) != char_at_pos:
+                if Int(br_ptr[unsafe_offset=pos]) != char_at_pos:
                     all_match = False
                     break
 
@@ -314,13 +314,13 @@ struct LiteralExtractor:
         # Find common suffix (work backwards)
         var fb_ptr = first_branch.unsafe_ptr()
         for pos in range(1, min_length + 1):
-            var char_at_pos = Int(fb_ptr[len(first_branch) - pos])
+            var char_at_pos = Int(fb_ptr[unsafe_offset=len(first_branch) - pos])
             var all_match = True
 
             for i in range(1, len(branches)):
                 var branch = branches[i]
                 var br_ptr = branch.unsafe_ptr()
-                if Int(br_ptr[len(branch) - pos]) != char_at_pos:
+                if Int(br_ptr[unsafe_offset=len(branch) - pos]) != char_at_pos:
                     all_match = False
                     break
 
@@ -398,10 +398,10 @@ struct MemchrPrefilter(Copyable, Movable, PrefilterMatcher):
         self.literal = copy.literal
         self.is_prefix = copy.is_prefix
 
-    def __init__(out self, *, deinit take: Self):
+    def __init__(out self, *, deinit move: Self):
         """Move constructor."""
-        self.literal = take.literal^
-        self.is_prefix = take.is_prefix
+        self.literal = move.literal^
+        self.is_prefix = move.is_prefix
 
     def find_candidates(self, text: StringSlice) -> List[Int]:
         """Find all candidate positions of the literal in text."""

--- a/src/regex/simd_matchers.mojo
+++ b/src/regex/simd_matchers.mojo
@@ -371,7 +371,9 @@ def analyze_character_class_pattern(pattern: String) -> String:
         # Check if it's a simple range
         if pattern.startswith("[") and pattern.endswith("]") and "-" in pattern:
             var inner = pattern[byte=1:-1]
-            if len(inner) == 3 and Int(inner.unsafe_ptr()[1]) == ord("-"):
+            if len(inner) == 3 and Int(
+                inner.unsafe_ptr()[unsafe_offset=1]
+            ) == ord("-"):
                 return "range"
         return "lookup"
 

--- a/src/regex/simd_ops.mojo
+++ b/src/regex/simd_ops.mojo
@@ -365,8 +365,8 @@ struct CharacterClassSIMD(
         """Detect up to 3 contiguous sub-ranges in the lookup table.
         For patterns like [a-zA-Z0-9], this finds ranges a-z, A-Z, 0-9
         enabling multi-range SIMD scan. Uses stack-local variables only."""
-        var starts = InlineArray[Int, 4](fill=-1)
-        var ends = InlineArray[Int, 4](fill=-1)
+        var starts = Array[Int, 4](fill=-1)
+        var ends = Array[Int, 4](fill=-1)
         var count = 0
         var in_range = False
         for c in range(256):

--- a/src/regex/simd_ops.mojo
+++ b/src/regex/simd_ops.mojo
@@ -115,7 +115,7 @@ def find_first_in_nibble_tables(
     var mask_0f = SIMD[DType.uint8, SIMD_WIDTH](0x0F)
 
     while pos + SIMD_WIDTH <= text_len:
-        var chunk = text_ptr.load[width=SIMD_WIDTH](pos)
+        var chunk = text_ptr.unsafe_load[width=SIMD_WIDTH](pos)
         var lo_res = lo_nibble._dynamic_shuffle(chunk & mask_0f)
         var hi_res = hi_nibble._dynamic_shuffle((chunk >> 4) & mask_0f)
         var matches = (lo_res & hi_res).ne(0)
@@ -127,7 +127,7 @@ def find_first_in_nibble_tables(
 
     # Scalar tail
     while pos < text_len:
-        if filter[Int(text_ptr[pos])] != 0:
+        if filter[Int(text_ptr[unsafe_offset=pos])] != 0:
             return pos
         pos += 1
 
@@ -220,7 +220,7 @@ def simd_find_byte(
     text_len: Int,
     needle: UInt8,
 ) -> Int:
-    """Return the first position of `needle` in `text_ptr[start:text_len]`,
+    """Return the first position of `needle` in `text_ptr[unsafe_offset=start:text_len]`,
     or -1 if not found.
 
     memchr-style SIMD scan. Used as a prefilter when a rare required byte
@@ -229,13 +229,13 @@ def simd_find_byte(
     var pos = start
     var splat = SIMD[DType.uint8, SIMD_WIDTH](needle)
     while pos + SIMD_WIDTH <= text_len:
-        var chunk = text_ptr.load[width=SIMD_WIDTH](pos)
+        var chunk = text_ptr.unsafe_load[width=SIMD_WIDTH](pos)
         var matches = chunk.eq(splat)
         if matches.reduce_or():
             return pos + _first_true(matches)
         pos += SIMD_WIDTH
     while pos < text_len:
-        if text_ptr[pos] == needle:
+        if text_ptr[unsafe_offset=pos] == needle:
             return pos
         pos += 1
     return -1
@@ -445,7 +445,7 @@ struct CharacterClassSIMD(
         # Handle remaining characters
         var text_ptr = text.unsafe_ptr()
         while pos < text_len:
-            if self.contains(Int(text_ptr[pos])):
+            if self.contains(Int(text_ptr[unsafe_offset=pos])):
                 return pos
             pos += 1
 
@@ -475,7 +475,7 @@ struct CharacterClassSIMD(
                 for j in range(width):
                     if chunk_matches[j]:
                         matches.append(pos + i + j)
-            elif self.contains(Int(text_ptr[pos + i])):
+            elif self.contains(Int(text_ptr[unsafe_offset=pos + i])):
                 matches.append(pos + i)
 
         vectorize[SIMD_WIDTH](text_len - pos, closure)
@@ -555,7 +555,7 @@ struct CharacterClassSIMD(
             if width != 1:
                 var matches = self._check_chunk_simd(text.unsafe_ptr(), pos + i)
                 count += Int(matches.cast[DType.uint8]().reduce_add())
-            elif self.contains(Int(text_ptr[pos + i])):
+            elif self.contains(Int(text_ptr[unsafe_offset=pos + i])):
                 count += 1
 
         vectorize[SIMD_WIDTH](actual_end - pos, closure)
@@ -588,7 +588,7 @@ struct CharacterClassSIMD(
                 UInt8(self.range_end - self.range_start)
             )
             while pos + SIMD_WIDTH <= text_len:
-                var chunk = text_ptr.load[width=SIMD_WIDTH](pos)
+                var chunk = text_ptr.unsafe_load[width=SIMD_WIDTH](pos)
                 var in_range = _in_range_1(chunk, lo, span)
                 if in_range.reduce_or():
                     return pos + _first_true(in_range)
@@ -603,7 +603,7 @@ struct CharacterClassSIMD(
                 UInt8(self.range2_end - self.range2_start)
             )
             while pos + SIMD_WIDTH <= text_len:
-                var chunk = text_ptr.load[width=SIMD_WIDTH](pos)
+                var chunk = text_ptr.unsafe_load[width=SIMD_WIDTH](pos)
                 var in_range = _in_range_2(chunk, lo1, span1, lo2, span2)
                 if in_range.reduce_or():
                     return pos + _first_true(in_range)
@@ -622,7 +622,7 @@ struct CharacterClassSIMD(
                 UInt8(self.range3_end - self.range3_start)
             )
             while pos + SIMD_WIDTH <= text_len:
-                var chunk = text_ptr.load[width=SIMD_WIDTH](pos)
+                var chunk = text_ptr.unsafe_load[width=SIMD_WIDTH](pos)
                 var in_range = _in_range_3(
                     chunk, lo1, span1, lo2, span2, lo3, span3
                 )
@@ -642,7 +642,7 @@ struct CharacterClassSIMD(
         # Scalar tail (reached for range paths only; the nibble fallback
         # handles its own tail internally).
         while pos < text_len:
-            if self.lookup_table[Int(text_ptr[pos])] != 0:
+            if self.lookup_table[Int(text_ptr[unsafe_offset=pos])] != 0:
                 return pos
             pos += 1
         return -1
@@ -680,8 +680,10 @@ struct CharacterClassSIMD(
                 UInt8(self.range_end - self.range_start)
             )
             while pos + 2 * SIMD_WIDTH <= text_len:
-                var c1 = text_ptr.load[width=SIMD_WIDTH](pos)
-                var c2 = text_ptr.load[width=SIMD_WIDTH](pos + SIMD_WIDTH)
+                var c1 = text_ptr.unsafe_load[width=SIMD_WIDTH](pos)
+                var c2 = text_ptr.unsafe_load[width=SIMD_WIDTH](
+                    pos + SIMD_WIDTH
+                )
                 var r1 = _in_range_1(c1, lo, span)
                 var r2 = _in_range_1(c2, lo, span)
                 if (r1 & r2).reduce_and():
@@ -689,7 +691,7 @@ struct CharacterClassSIMD(
                     continue
                 return pos + _first_false_in_two(r1, r2) - start
             while pos + SIMD_WIDTH <= text_len:
-                var chunk = text_ptr.load[width=SIMD_WIDTH](pos)
+                var chunk = text_ptr.unsafe_load[width=SIMD_WIDTH](pos)
                 var in_range = _in_range_1(chunk, lo, span)
                 if in_range.reduce_and():
                     pos += SIMD_WIDTH
@@ -707,8 +709,10 @@ struct CharacterClassSIMD(
                 UInt8(self.range2_end - self.range2_start)
             )
             while pos + 2 * SIMD_WIDTH <= text_len:
-                var c1 = text_ptr.load[width=SIMD_WIDTH](pos)
-                var c2 = text_ptr.load[width=SIMD_WIDTH](pos + SIMD_WIDTH)
+                var c1 = text_ptr.unsafe_load[width=SIMD_WIDTH](pos)
+                var c2 = text_ptr.unsafe_load[width=SIMD_WIDTH](
+                    pos + SIMD_WIDTH
+                )
                 var r1 = _in_range_2(c1, lo1, span1, lo2, span2)
                 var r2 = _in_range_2(c2, lo1, span1, lo2, span2)
                 if (r1 & r2).reduce_and():
@@ -716,7 +720,7 @@ struct CharacterClassSIMD(
                     continue
                 return pos + _first_false_in_two(r1, r2) - start
             while pos + SIMD_WIDTH <= text_len:
-                var chunk = text_ptr.load[width=SIMD_WIDTH](pos)
+                var chunk = text_ptr.unsafe_load[width=SIMD_WIDTH](pos)
                 var in_range = _in_range_2(chunk, lo1, span1, lo2, span2)
                 if in_range.reduce_and():
                     pos += SIMD_WIDTH
@@ -738,8 +742,10 @@ struct CharacterClassSIMD(
                 UInt8(self.range3_end - self.range3_start)
             )
             while pos + 2 * SIMD_WIDTH <= text_len:
-                var c1 = text_ptr.load[width=SIMD_WIDTH](pos)
-                var c2 = text_ptr.load[width=SIMD_WIDTH](pos + SIMD_WIDTH)
+                var c1 = text_ptr.unsafe_load[width=SIMD_WIDTH](pos)
+                var c2 = text_ptr.unsafe_load[width=SIMD_WIDTH](
+                    pos + SIMD_WIDTH
+                )
                 var r1 = _in_range_3(c1, lo1, span1, lo2, span2, lo3, span3)
                 var r2 = _in_range_3(c2, lo1, span1, lo2, span2, lo3, span3)
                 if (r1 & r2).reduce_and():
@@ -747,7 +753,7 @@ struct CharacterClassSIMD(
                     continue
                 return pos + _first_false_in_two(r1, r2) - start
             while pos + SIMD_WIDTH <= text_len:
-                var chunk = text_ptr.load[width=SIMD_WIDTH](pos)
+                var chunk = text_ptr.unsafe_load[width=SIMD_WIDTH](pos)
                 var in_range = _in_range_3(
                     chunk, lo1, span1, lo2, span2, lo3, span3
                 )
@@ -758,22 +764,22 @@ struct CharacterClassSIMD(
         else:
             # Scalar 4-way unroll for non-contiguous character classes
             while pos + 4 <= text_len:
-                if self.lookup_table[Int(text_ptr[pos])] == 0:
+                if self.lookup_table[Int(text_ptr[unsafe_offset=pos])] == 0:
                     break
-                if self.lookup_table[Int(text_ptr[pos + 1])] == 0:
+                if self.lookup_table[Int(text_ptr[unsafe_offset=pos + 1])] == 0:
                     pos += 1
                     break
-                if self.lookup_table[Int(text_ptr[pos + 2])] == 0:
+                if self.lookup_table[Int(text_ptr[unsafe_offset=pos + 2])] == 0:
                     pos += 2
                     break
-                if self.lookup_table[Int(text_ptr[pos + 3])] == 0:
+                if self.lookup_table[Int(text_ptr[unsafe_offset=pos + 3])] == 0:
                     pos += 3
                     break
                 pos += 4
 
         # Scalar tail
         while pos < text_len:
-            if self.lookup_table[Int(text_ptr[pos])] == 0:
+            if self.lookup_table[Int(text_ptr[unsafe_offset=pos])] == 0:
                 break
             pos += 1
 
@@ -792,7 +798,7 @@ struct CharacterClassSIMD(
             SIMD vector of booleans indicating matches
         """
         # Load chunk of characters
-        var chunk = text_ptr.load[width=SIMD_WIDTH](pos)
+        var chunk = text_ptr.unsafe_load[width=SIMD_WIDTH](pos)
 
         # Use hybrid approach based on pattern characteristics
         if self.use_shuffle:
@@ -948,7 +954,7 @@ def verify_match[
     var text_ptr = text.unsafe_ptr()
     var pattern_ptr = pattern.unsafe_ptr()
     for i in range(pattern_len):
-        if text_ptr[pos + i] != pattern_ptr[i]:
+        if text_ptr[unsafe_offset=pos + i] != pattern_ptr[unsafe_offset=i]:
             return False
 
     return True
@@ -985,19 +991,21 @@ def simd_search[
 
     # Single-byte literal: pure memchr-style SIMD scan.
     if pattern_len == 1:
-        return simd_find_byte(text_ptr, start, text_len, pattern_ptr[0])
+        return simd_find_byte(
+            text_ptr, start, text_len, pattern_ptr[unsafe_offset=0]
+        )
 
     # Two-byte anchored SIMD scan for pattern_len >= 2.
-    var first_byte = pattern_ptr[0]
+    var first_byte = pattern_ptr[unsafe_offset=0]
     var last_offset = pattern_len - 1
-    var last_byte = pattern_ptr[last_offset]
+    var last_byte = pattern_ptr[unsafe_offset=last_offset]
     var first_splat = SIMD[DType.uint8, SIMD_WIDTH](first_byte)
     var last_splat = SIMD[DType.uint8, SIMD_WIDTH](last_byte)
     var pos = start
 
     while pos + SIMD_WIDTH + last_offset <= text_len:
-        var chunk_a = text_ptr.load[width=SIMD_WIDTH](pos)
-        var chunk_b = text_ptr.load[width=SIMD_WIDTH](pos + last_offset)
+        var chunk_a = text_ptr.unsafe_load[width=SIMD_WIDTH](pos)
+        var chunk_b = text_ptr.unsafe_load[width=SIMD_WIDTH](pos + last_offset)
         var both = chunk_a.eq(first_splat) & chunk_b.eq(last_splat)
         if both.reduce_or():
             for i in range(SIMD_WIDTH):
@@ -1043,8 +1051,12 @@ def simd_memcmp(
 
     # Compare chunks using SIMD
     while pos + SIMD_WIDTH <= length:
-        var chunk1 = s1.unsafe_ptr().load[width=SIMD_WIDTH](s1_offset + pos)
-        var chunk2 = s2.unsafe_ptr().load[width=SIMD_WIDTH](s2_offset + pos)
+        var chunk1 = s1.unsafe_ptr().unsafe_load[width=SIMD_WIDTH](
+            s1_offset + pos
+        )
+        var chunk2 = s2.unsafe_ptr().unsafe_load[width=SIMD_WIDTH](
+            s2_offset + pos
+        )
 
         if chunk1 != chunk2:
             return False
@@ -1055,7 +1067,10 @@ def simd_memcmp(
     var s1_ptr = s1.unsafe_ptr()
     var s2_ptr = s2.unsafe_ptr()
     while pos < length:
-        if s1_ptr[s1_offset + pos] != s2_ptr[s2_offset + pos]:
+        if (
+            s1_ptr[unsafe_offset=s1_offset + pos]
+            != s2_ptr[unsafe_offset=s2_offset + pos]
+        ):
             return False
         pos += 1
 
@@ -1083,7 +1098,7 @@ def simd_count_char(text: String, target_char: StringSlice) -> Int:
 
     # Process chunks using SIMD
     while pos + SIMD_WIDTH <= text_len:
-        var chunk = text.unsafe_ptr().load[width=SIMD_WIDTH](pos)
+        var chunk = text.unsafe_ptr().unsafe_load[width=SIMD_WIDTH](pos)
         var matches = chunk.eq(target_simd)
         count += Int(matches.cast[DType.uint8]().reduce_add())
         pos += SIMD_WIDTH
@@ -1091,7 +1106,7 @@ def simd_count_char(text: String, target_char: StringSlice) -> Int:
     # Handle remaining characters
     var text_ptr = text.unsafe_ptr()
     while pos < text_len:
-        if Int(text_ptr[pos]) == target_code:
+        if Int(text_ptr[unsafe_offset=pos]) == target_code:
             count += 1
         pos += 1
 
@@ -1271,7 +1286,7 @@ def process_text_with_matcher[
     var text_len = len(text)
 
     while pos + 16 <= text_len:
-        var chunk = text.unsafe_ptr().load[width=16](pos)
+        var chunk = text.unsafe_ptr().unsafe_load[width=16](pos)
         var chunk_matches = matcher.match_chunk(chunk)
 
         for i in range(16):
@@ -1283,7 +1298,7 @@ def process_text_with_matcher[
     # Handle remaining characters
     var text_ptr = text.unsafe_ptr()
     while pos < text_len:
-        if matcher.contains(Int(text_ptr[pos])):
+        if matcher.contains(Int(text_ptr[unsafe_offset=pos])):
             matches.append(pos)
         pos += 1
 
@@ -1326,7 +1341,7 @@ def apply_quantifier_simd_generic[
     # Count consecutive matching characters
     var text_ptr = text.unsafe_ptr()
     while pos < text_len and match_count < actual_max:
-        if matcher.contains(Int(text_ptr[pos])):
+        if matcher.contains(Int(text_ptr[unsafe_offset=pos])):
             match_count += 1
             pos += 1
         else:
@@ -1362,7 +1377,7 @@ def find_in_text_simd[
 
     # Process in SIMD chunks for speed
     while pos + 16 <= actual_end:
-        var chunk = text_ptr.load[width=16](pos)
+        var chunk = text_ptr.unsafe_load[width=16](pos)
         var matches = matcher.match_chunk(chunk)
 
         # Check if any match in chunk
@@ -1376,7 +1391,7 @@ def find_in_text_simd[
 
     # Handle remaining characters
     while pos < actual_end:
-        if matcher.contains(Int(text_ptr[pos])):
+        if matcher.contains(Int(text_ptr[unsafe_offset=pos])):
             return pos
         pos += 1
 
@@ -1421,7 +1436,10 @@ def twoway_search[
         while pos <= m - n:
             var matched = True
             for i in range(n):
-                if text_ptr[pos + i] != pattern_ptr[i]:
+                if (
+                    text_ptr[unsafe_offset=pos + i]
+                    != pattern_ptr[unsafe_offset=i]
+                ):
                     matched = False
                     break
             if matched:
@@ -1444,7 +1462,7 @@ def twoway_search[
     for i in range(1, n):
         var is_period = True
         for j in range(n - i):
-            if pattern_ptr[j] != pattern_ptr[j + i]:
+            if pattern_ptr[unsafe_offset=j] != pattern_ptr[unsafe_offset=j + i]:
                 is_period = False
                 break
         if is_period:
@@ -1455,7 +1473,7 @@ def twoway_search[
         # Simple forward comparison
         var matched = True
         for i in range(n):
-            if text_ptr[pos + i] != pattern_ptr[i]:
+            if text_ptr[unsafe_offset=pos + i] != pattern_ptr[unsafe_offset=i]:
                 matched = False
                 break
 
@@ -1500,7 +1518,7 @@ struct MultiLiteralSearcher(Copyable, Movable):
         for i in range(self.literal_count):
             var lit = literals[i]
             if lit.byte_length() > 0:
-                self.first_bytes[i] = lit.unsafe_ptr()[0]
+                self.first_bytes[i] = lit.unsafe_ptr()[unsafe_offset=0]
                 self.max_len = max(self.max_len, lit.byte_length())
                 self.min_len = min(self.min_len, lit.byte_length())
         self.literals = literals^
@@ -1524,7 +1542,7 @@ struct MultiLiteralSearcher(Copyable, Movable):
 
         # Process text in SIMD chunks
         while pos + SIMD_WIDTH <= text_len - self.min_len + 1:
-            var chunk = text_ptr.load[width=SIMD_WIDTH](pos)
+            var chunk = text_ptr.unsafe_load[width=SIMD_WIDTH](pos)
 
             # Check if any first bytes match
             var any_match = SIMD[DType.bool, SIMD_WIDTH](fill=False)
@@ -1544,7 +1562,7 @@ struct MultiLiteralSearcher(Copyable, Movable):
                         for lit_idx in range(self.literal_count):
                             var lit = self.literals[lit_idx]
                             if lit.byte_length() > 0 and Int(
-                                text_ptr[text_pos]
+                                text_ptr[unsafe_offset=text_pos]
                             ) == Int(self.first_bytes[lit_idx]):
                                 # Verify full literal
                                 if self._verify_literal(text, text_pos, lit):
@@ -1585,6 +1603,6 @@ struct MultiLiteralSearcher(Copyable, Movable):
         var text_ptr = text.unsafe_ptr()
         var lit_ptr = literal.unsafe_ptr()
         for i in range(lit_len):
-            if text_ptr[pos + i] != lit_ptr[i]:
+            if text_ptr[unsafe_offset=pos + i] != lit_ptr[unsafe_offset=i]:
                 return False
         return True

--- a/tests/test_ast.mojo
+++ b/tests/test_ast.mojo
@@ -32,7 +32,7 @@ def test_ASTNode() raises:
     var regex = Regex[ImmUntrackedOrigin](pattern)
     var regex_ptr = (
         UnsafePointer(to=regex)
-        .as_immutable()
+        .as_imm()
         .unsafe_origin_cast[ImmUntrackedOrigin]()
     )
     var ast_node = ASTNode[ImmUntrackedOrigin](

--- a/tests/test_literal_optimization.mojo
+++ b/tests/test_literal_optimization.mojo
@@ -120,7 +120,7 @@ def test_two_way_searcher() raises:
     # Test simple pattern
     var pattern1 = "fox"
     var pattern1_span = Span[Byte](
-        ptr=pattern1.unsafe_ptr(), length=pattern1.byte_length()
+        unsafe_ptr=pattern1.unsafe_ptr(), length=pattern1.byte_length()
     )
     var pos1 = twoway_search(pattern1_span, text)
     assert_equal(pos1, 16, "Should find 'fox' at position 16")
@@ -132,7 +132,7 @@ def test_two_way_searcher() raises:
     # Test pattern not found
     var pattern2 = "cat"
     var pattern2_span = Span[Byte](
-        ptr=pattern2.unsafe_ptr(), length=pattern2.byte_length()
+        unsafe_ptr=pattern2.unsafe_ptr(), length=pattern2.byte_length()
     )
     var pos3 = twoway_search(pattern2_span, text)
     assert_equal(pos3, -1, "Should return -1 when pattern not found")
@@ -140,7 +140,7 @@ def test_two_way_searcher() raises:
     # Test longer pattern
     var pattern3 = "quick brown"
     var pattern3_span = Span[Byte](
-        ptr=pattern3.unsafe_ptr(), length=pattern3.byte_length()
+        unsafe_ptr=pattern3.unsafe_ptr(), length=pattern3.byte_length()
     )
     var pos4 = twoway_search(pattern3_span, text)
     assert_equal(pos4, 4, "Should find 'quick brown' at position 4")
@@ -148,7 +148,7 @@ def test_two_way_searcher() raises:
     # Test pattern at end - use "quick" instead of "quick." to avoid regex metachar
     var pattern4 = "quick"
     var pattern4_span = Span[Byte](
-        ptr=pattern4.unsafe_ptr(), length=pattern4.byte_length()
+        unsafe_ptr=pattern4.unsafe_ptr(), length=pattern4.byte_length()
     )
     var pos5 = twoway_search(
         pattern4_span, text, 50

--- a/tests/test_simd.mojo
+++ b/tests/test_simd.mojo
@@ -154,7 +154,7 @@ def test_simd_string_search() raises:
     """Test SIMD-accelerated string search."""
     var pattern = "hello"
     var pattern_span = Span[Byte](
-        ptr=pattern.unsafe_ptr(), length=pattern.byte_length()
+        unsafe_ptr=pattern.unsafe_ptr(), length=pattern.byte_length()
     )
 
     # Test basic search
@@ -170,7 +170,7 @@ def test_simd_string_search_all() raises:
     """Test finding all occurrences with SIMD string search."""
     var pattern = "ll"
     var pattern_span = Span[Byte](
-        ptr=pattern.unsafe_ptr(), length=pattern.byte_length()
+        unsafe_ptr=pattern.unsafe_ptr(), length=pattern.byte_length()
     )
     var text = "hello world, all well"
 
@@ -196,7 +196,7 @@ def test_simd_string_search_empty() raises:
     """Test SIMD string search with empty pattern."""
     var pattern = ""
     var pattern_span = Span[Byte](
-        ptr=pattern.unsafe_ptr(), length=pattern.byte_length()
+        unsafe_ptr=pattern.unsafe_ptr(), length=pattern.byte_length()
     )
 
     # Empty pattern should match at any position
@@ -208,7 +208,7 @@ def test_simd_string_search_single_char() raises:
     """Test SIMD string search with single character."""
     var pattern = "a"
     var pattern_span = Span[Byte](
-        ptr=pattern.unsafe_ptr(), length=pattern.byte_length()
+        unsafe_ptr=pattern.unsafe_ptr(), length=pattern.byte_length()
     )
 
     assert_equal(simd_search(pattern_span, "banana"), 1)


### PR DESCRIPTION
Updates to the latest nightly `1.0.0b3.dev2026072505`, which lands the stdlib **"safe Pointer" overhaul**. This is a large but purely mechanical migration.

Supersedes #175: this branch is built on top of it, so it contains the `Span` `ptr=` → `unsafe_ptr=` keyword rename **plus** the full pointer migration, on the newest nightly. Close #175 in favor of this.

## What changed upstream

Operations that are individually unsafe (unchecked-offset access, raw load/store, pointer arithmetic) are now gated so they must be spelled explicitly at the call site, rather than relying on the whole pointer being an unsafe type. The unprefixed forms only remain available on genuinely-unsafe (`_safe=False`) pointers, so every access through a safe-origin pointer had to migrate to an explicit `unsafe_*` form.

## Migrations applied (all mechanical, no behavior change)

| Before | After |
|---|---|
| `ptr[i]` (positional offset) | `ptr[unsafe_offset=i]` |
| `ptr[]` (no-arg deref) | unchanged |
| `ptr.load[width=w](off)` | `ptr.unsafe_load[width=w](off)` |
| `ptr + off` (feeding a slice/pointer) | `ptr.unsafe_offset(off)` |
| `as_immutable` | `as_imm` |
| `__init__(*, deinit take: Self)` | `__init__(*, deinit move: Self)` |

The subscript rename touches every offset-access in the hot paths: SIMD scans, the DFA/NFA/pikevm/onepass inner loops, literal search, and replacement templating. `unsafe_offset=` / `unsafe_load` / `unsafe_offset()` all work on **both** safe and unsafe pointers, so the conversions are uniform and origin-agnostic.

## Method

The subscript sites were migrated compiler-driven (each `no matching method in call to '__getitem__'` error gives the exact `[` column), then swept comprehensively for the remaining `*_ptr[...]` / `.unsafe_ptr()[...]` offset accesses. Pointer *derefs* (`ptr[]`) and dict subscripts on a deref (`ptr[][key]`) were deliberately left untouched. `ptr + off` sites were converted only where the pointer is safe-origin; the `_safe=False` `alloc` pointers (e.g. the AST children arena) keep bare `+`.

## Verification

- **389 tests pass**, zero failures.
- **Zero compiler warnings** across `src`, `tests` and the `bench_engine` build.
- No benchmark timing taken (a mechanical API migration with no logic change); the full engine suite exercising every migrated hot path is the correctness gate.

Folds into the in-flight v0.21.0 per the mid-version rules (no version bump).

## Also: adopt the `InlineArray` -> `Array` rename

The same nightly renamed `InlineArray` to `Array` (modular #93254), keeping a *temporary* comptime alias for adoption. Our 32 `InlineArray` uses therefore still compiled with zero warnings, but the alias will be removed, so a second commit renames them all to `Array` now (prelude type, no import change).