### PR TITLE
Bump mojo to 1.0.0b3.dev2026080106 nightly

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -32,10 +32,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026072606-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026072606-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026072606-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026072606-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026080106-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026080106-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026080106-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026080106-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
@@ -76,10 +76,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.22-h1a92334_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.1-h1b79a29_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026072606-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026072606-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026072606-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026072606-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026080106-release.conda
+      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026080106-release.conda
+      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026080106-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026080106-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
@@ -133,10 +133,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026072606-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026072606-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026072606-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026072606-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026080106-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026080106-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026080106-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026080106-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
@@ -179,10 +179,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.22-h1a92334_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.1-h1b79a29_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026072606-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026072606-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026072606-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026072606-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026080106-release.conda
+      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026080106-release.conda
+      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026080106-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026080106-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
@@ -585,10 +585,10 @@ packages:
   license_family: Other
   size: 47759
   timestamp: 1774072956767
-- conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026072606-release.conda
+- conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026080106-release.conda
   noarch: python
-  sha256: e73194b69149a166d216d94d410c3b7e69e90b2199ec1d3b5c9f25f28e4240f3
-  md5: 4c9bb35603c29121e920521c1346b739
+  sha256: 244b169714d59c0029600a847bd72ccfb8538160fbb7b22c6b8ee606f7e13cef
+  md5: e8962fe5b4656ad8d1d3854293be2c42
   depends:
   - python >=3.10
   - click >=8.0.0
@@ -598,55 +598,55 @@ packages:
   - platformdirs >=2
   - tomli >=1.1.0
   license: LicenseRef-Modular-Proprietary
-  size: 136742
-  timestamp: 1785046411624
-- conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026072606-release.conda
-  sha256: 720101de4d010fa83de06977bca24c3bb0894dcb12d80555697ab94917c5b545
-  md5: 2c859679957787dd2a8484f424b92284
+  size: 137260
+  timestamp: 1785564577721
+- conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026080106-release.conda
+  sha256: b615c878490f839855ac54d4c7371ad0d39ea8654ef412eddd8cb9e80a2f64aa
+  md5: 5781854d7c9c4cd3081c4aa281e48d5a
   depends:
   - python >=3.10
-  - mojo-compiler ==1.0.0b3.dev2026072606
-  - mblack ==26.5.0.dev2026072606
+  - mojo-compiler ==1.0.0b3.dev2026080106
+  - mblack ==26.5.0.dev2026080106
   - jupyter_client >=8.6.2,<8.7
   license: LicenseRef-Modular-Proprietary
-  size: 114475554
-  timestamp: 1785046552670
-- conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026072606-release.conda
-  sha256: c9d97366023b56b916a7e06e46948922ab0ae55f5201cc197721b57b749e61be
-  md5: 8b84b46d22d8ea592b2ffec08324dc48
+  size: 114652144
+  timestamp: 1785564716242
+- conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026080106-release.conda
+  sha256: 4ba53c65ec88243c5bde208da42f717d4b4decdf7559d687cd0c0d6e07065a69
+  md5: 8581572fa3eaf03773a6633e05908bc1
   depends:
   - python >=3.10
-  - mojo-compiler ==1.0.0b3.dev2026072606
-  - mblack ==26.5.0.dev2026072606
+  - mojo-compiler ==1.0.0b3.dev2026080106
+  - mblack ==26.5.0.dev2026080106
   - jupyter_client >=8.6.2,<8.7
   license: LicenseRef-Modular-Proprietary
-  size: 100042505
-  timestamp: 1785046705826
-- conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026072606-release.conda
-  sha256: 2be3e62c4987616d6cb75d722590b1d402fe464321b59fa6537a8adebd663389
-  md5: 414b987f696ac2c330cf869e53b40caa
+  size: 100237436
+  timestamp: 1785565980231
+- conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026080106-release.conda
+  sha256: 690f11ed178d0118b3a904f5bb0923fab6979b332db99de20c6ffa759927b373
+  md5: f7fda55ea617388ea2bbcbb624ce7b94
   depends:
-  - mojo-python ==1.0.0b3.dev2026072606
+  - mojo-python ==1.0.0b3.dev2026080106
   license: LicenseRef-Modular-Proprietary
-  size: 80576947
-  timestamp: 1785046554858
-- conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026072606-release.conda
-  sha256: 2dd0d3895db5d860e545cdb09da0ca3f107fa045807e7bd6e8e8d4e6302a4bfd
-  md5: 9fb4bacb5365ba9eae18b4cbf2c8a9da
+  size: 80184983
+  timestamp: 1785564717230
+- conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026080106-release.conda
+  sha256: 0eaa71dd603efbfc81c3b47310534648a46c9aa8e5cf41b2ec7f1cf7de96cf41
+  md5: 78b42fd9e195c6001ac7716adf6a7b85
   depends:
-  - mojo-python ==1.0.0b3.dev2026072606
+  - mojo-python ==1.0.0b3.dev2026080106
   license: LicenseRef-Modular-Proprietary
-  size: 62028894
-  timestamp: 1785046705871
-- conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026072606-release.conda
+  size: 61661096
+  timestamp: 1785565979112
+- conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026080106-release.conda
   noarch: python
-  sha256: 01800e46b1b9a9322d8bf21f4ee1b50648ad09b7ee77efd656df9de3752d0ecd
-  md5: 3293ef13c519d39909f75919928c4105
+  sha256: fd1bcf6bd06db13a0106a4cc067042e9f76c9994866ef23cf5927a4c248321c9
+  md5: e9407eceac1a300db9e4ee00dd23bf5f
   depends:
   - python >=3.10
   license: LicenseRef-Modular-Proprietary
-  size: 24099
-  timestamp: 1785046412138
+  size: 24127
+  timestamp: 1785564577182
 - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
   sha256: 6ed158e4e5dd8f6a10ad9e525631e35cee8557718f83de7a4e3966b1f772c4b1
   md5: e9c622e0d00fa24a6292279af3ab6d06

--- a/pixi.toml
+++ b/pixi.toml
@@ -19,7 +19,7 @@ version = "0.21.0"
 backend = { name = "pixi-build-rattler-build", version = "*" }
 
 [dependencies]
-mojo = "==1.0.0b3.dev2026072606"
+mojo = "==1.0.0b3.dev2026080106"
 
 [tasks]
 test = "bash -c 'status=0; for f in tests/test_*.mojo; do echo \"Running $f...\"; out=$(mktemp -d); mojo build -I ./src -debug-level=line-tables \"$f\" -o \"$out/exe\" && \"$out/exe\" || status=1; rm -rf \"$out\"; done; exit $status'"

--- a/src/regex/ast.mojo
+++ b/src/regex/ast.mojo
@@ -162,7 +162,7 @@ struct Regex[origin: Origin](Copyable, Equatable, Movable, Writable):
         #     ": ",
         #     child,
         # )
-        (self.children_ptr + self.children_len).unsafe_write(child^)
+        self.children_ptr.unsafe_offset(self.children_len).unsafe_write(child^)
         self.children_len += 1
 
 

--- a/src/regex/matcher.mojo
+++ b/src/regex/matcher.mojo
@@ -345,16 +345,16 @@ struct NFAMatcher(Copyable, Movable, RegexMatcher):
         self._lazy_dfa_ptr = move._lazy_dfa_ptr
         self._onepass_ptr = move._onepass_ptr
 
-    def __del__(deinit self):
+    def __deinit__(deinit self):
         """Free the heap-allocated engines if we still own them."""
         if self._lazy_dfa_ptr:
             var ptr = self._lazy_dfa_ptr.value()
             ptr.unsafe_deinit_pointee()
-            ptr.free()
+            ptr.unsafe_free()
         if self._onepass_ptr:
             var ptr = self._onepass_ptr.value()
             ptr.unsafe_deinit_pointee()
-            ptr.free()
+            ptr.unsafe_free()
 
     @always_inline
     def match_first[
@@ -983,8 +983,8 @@ struct CompiledRegex(ImplicitlyCopyable, Movable):
         self.compiled_at = copy.compiled_at
         self._fixed_sub_total_width = copy._fixed_sub_total_width
         self._fixed_sub_num_groups = copy._fixed_sub_num_groups
-        self._fixed_sub_offsets = copy._fixed_sub_offsets
-        self._fixed_sub_widths = copy._fixed_sub_widths
+        self._fixed_sub_offsets = copy._fixed_sub_offsets.copy()
+        self._fixed_sub_widths = copy._fixed_sub_widths.copy()
         self._fixed_sub_concat = copy._fixed_sub_concat
 
     def __init__(out self, *, deinit move: Self):
@@ -994,8 +994,8 @@ struct CompiledRegex(ImplicitlyCopyable, Movable):
         self.compiled_at = move.compiled_at
         self._fixed_sub_total_width = move._fixed_sub_total_width
         self._fixed_sub_num_groups = move._fixed_sub_num_groups
-        self._fixed_sub_offsets = move._fixed_sub_offsets
-        self._fixed_sub_widths = move._fixed_sub_widths
+        self._fixed_sub_offsets = move._fixed_sub_offsets^
+        self._fixed_sub_widths = move._fixed_sub_widths^
         self._fixed_sub_concat = move._fixed_sub_concat
 
     def _try_precompute_fixed_sub(mut self):

--- a/src/regex/matching.mojo
+++ b/src/regex/matching.mojo
@@ -39,7 +39,7 @@ struct Match[origin: ImmOrigin](Copyable, Movable, TrivialRegisterPassable):
         """Returns the text that was matched."""
         return StringSlice[Self.origin](
             unsafe_from_utf8=Span[Byte, Self.origin](
-                unsafe_ptr=self.text_ptr + self.start_idx,
+                unsafe_ptr=self.text_ptr.unsafe_offset(self.start_idx),
                 length=self.end_idx - self.start_idx,
             )
         )
@@ -100,10 +100,10 @@ struct MatchList[origin: ImmOrigin](Copyable, Movable, Sized):
         # var call_location = __call_location()
         # print("Copying MatchList", call_location)
 
-    def __del__(deinit self):
+    def __deinit__(deinit self):
         """Destructor to free allocated memory."""
         if self._capacity > 0:
-            self._data.free()
+            self._data.unsafe_free()
 
     @always_inline
     def __len__(self) -> Int:
@@ -124,7 +124,7 @@ struct MatchList[origin: ImmOrigin](Copyable, Movable, Sized):
         Returns:
             A reference to the match at the given index.
         """
-        return self._data[idx]
+        return self._data[unsafe_offset=idx]
 
     @no_inline
     def _realloc(mut self, new_capacity: Int):
@@ -132,7 +132,7 @@ struct MatchList[origin: ImmOrigin](Copyable, Movable, Sized):
 
         if self._capacity > 0:
             unsafe_memcpy(dest=new_data, src=self._data, count=len(self))
-            self._data.free()
+            self._data.unsafe_free()
         self._data = new_data
         self._capacity = new_capacity
 
@@ -146,7 +146,7 @@ struct MatchList[origin: ImmOrigin](Copyable, Movable, Sized):
                 self._capacity * 2, self.DEFAULT_RESERVE_SIZE
             )
             self._realloc(new_capacity)
-        self._data[self._len] = m
+        self._data[unsafe_offset=self._len] = m
         self._len += 1
 
     def clear(

--- a/src/regex/onepass.mojo
+++ b/src/regex/onepass.mojo
@@ -309,7 +309,7 @@ def compile_onepass(
                 worklist.append(idx)
             transitions[byte] = idx
 
-        states[state_id].transitions = transitions
+        states[state_id].transitions = transitions^
 
     # Precompute the `$` end-of-text answer for each state so match_first
     # can resolve the end-anchor fixup with a single field load.

--- a/tests/test_onepass.mojo
+++ b/tests/test_onepass.mojo
@@ -25,7 +25,7 @@ def test_onepass_compiles_simple_literal() raises:
     if opt_ptr:
         var ptr = opt_ptr.value()
         ptr.unsafe_deinit_pointee()
-        ptr.free()
+        ptr.unsafe_free()
 
 
 def test_onepass_compiles_phone_validation() raises:
@@ -38,7 +38,7 @@ def test_onepass_compiles_phone_validation() raises:
     if opt_ptr:
         var ptr = opt_ptr.value()
         ptr.unsafe_deinit_pointee()
-        ptr.free()
+        ptr.unsafe_free()
 
 
 def test_onepass_literal_matches() raises:
@@ -56,7 +56,7 @@ def test_onepass_literal_matches() raises:
         assert_equal(m_good.value().start_idx, 0)
         assert_equal(m_good.value().end_idx, 3)
     ptr.unsafe_deinit_pointee()
-    ptr.free()
+    ptr.unsafe_free()
 
 
 def test_onepass_end_anchor() raises:
@@ -74,7 +74,7 @@ def test_onepass_end_anchor() raises:
     if m_hit:
         assert_equal(m_hit.value().end_idx, 4)
     ptr.unsafe_deinit_pointee()
-    ptr.free()
+    ptr.unsafe_free()
 
 
 def main() raises:


### PR DESCRIPTION
Updates to the latest nightly `1.0.0b3.dev2026080106`, which tightens several stdlib rules further. Two categories of change were required.

## 1. `Array` is no longer unconditionally `ImplicitlyCopyable`

`Array` (the type formerly `InlineArray`) now requires an explicit copy/transfer. Our `Array`-holding fields had to spell it out:

- **`CompiledRegex` copy ctor**: `copy._fixed_sub_offsets` / `_widths` → `.copy()`.
- **`CompiledRegex` move ctor**: `move._fixed_sub_offsets` / `_widths` → `^` (transfer, since the source is being consumed).
- **onepass DFA builder**: `states[state_id].transitions = transitions` → `transitions^`. The source is a fresh per-iteration `Array[Int, 256]`, so a transfer is both correct and avoids a 2 KB copy per state.

## 2. Deprecations, now flagged even on `_safe=False` pointers

The previous unsafe-pointer migration (#176) deliberately left the genuinely-unsafe (`_safe=False`) pointer sites untouched because they compiled without warning. This nightly deprecates them too, plus renames two lifecycle methods:

| Before | After |
|---|---|
| `ptr + off` | `ptr.unsafe_offset(off)` |
| `ptr[i]` | `ptr[unsafe_offset=i]` |
| `ptr.free()` | `ptr.unsafe_free()` |
| `def __del__(deinit self)` | `def __deinit__(deinit self)` |

Sites: the AST children-arena write (`ast.mojo`), the `Match` text-slice constructor and `MatchList._data` access/free (`matching.mojo`), the `CompiledRegex` engine-pointer free + destructor (`matcher.mojo`), and the manual pointer frees in `test_onepass.mojo`.

## Verification

- **389 tests pass**, zero failures.
- **Zero compiler warnings** across `src`, `tests` and the `bench_engine` build.

Folds into the in-flight v0.21.0 per the mid-version rules (no version bump).
