### PR TITLE
Upgrade to stable Mojo 1.0.0 (max channel)

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -3,209 +3,213 @@ environments:
   default:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
-    - url: https://conda.modular.com/max-nightly/
+    - url: https://conda.modular.com/max/
     options:
       pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.5-py314hd8ed1ab_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.6-py314hd8ed1ab_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-ha1258a1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h373387f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h3435931_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.1.0-ha9f2e26_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.1.0-he0feb66_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.22-h280c20c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.1-h0c1763c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026080206-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026080206-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026080206-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026080206-release.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-hf4e2dac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+      - conda: https://conda.modular.com/max/noarch/mblack-26.5.0-release.conda
+      - conda: https://conda.modular.com/max/linux-64/mojo-1.0.0-release.conda
+      - conda: https://conda.modular.com/max/linux-64/mojo-compiler-1.0.0-release.conda
+      - conda: https://conda.modular.com/max/noarch/mojo-python-1.0.0-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.3-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.10.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.5-habeac84_100_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.11.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.6-h242f9ac_102_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.14.5-h4df99d1_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.14.6-h4df99d1_102.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.6-py314h5bd0f2a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.8-py314h5bd0f2a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.16.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h09e67af_11.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
       osx-arm64:
-      - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.5-py314hd8ed1ab_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h4e30115_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.6-py314hd8ed1ab_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-py310h579977c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-h385eeb1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.6-h55c6f16_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321hafb1f1b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-hfd3d5f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.8-h55c6f16_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321h26f1114_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-hcf2aa1b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.22-h1a92334_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.1-h1b79a29_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026080206-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026080206-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026080206-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026080206-release.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.4-h1ae2325_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_3.conda
+      - conda: https://conda.modular.com/max/noarch/mblack-26.5.0-release.conda
+      - conda: https://conda.modular.com/max/osx-arm64/mojo-1.0.0-release.conda
+      - conda: https://conda.modular.com/max/osx-arm64/mojo-compiler-1.0.0-release.conda
+      - conda: https://conda.modular.com/max/noarch/mojo-python-1.0.0-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-he64c551_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.3-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.10.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.5-h4c637c5_100_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.11.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.6-hf4d206d_102_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.14.5-h4df99d1_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.14.6-h4df99d1_102.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py312h022ad19_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hd3d0363_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.6-py314h6c2aa35_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.8-py314h6c2aa35_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.16.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h10816f8_11.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hf451053_7.conda
   mojopkg:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
-    - url: https://conda.modular.com/max-nightly/
+    - url: https://conda.modular.com/max/
     options:
       pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.5-py314hd8ed1ab_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.6-py314hd8ed1ab_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-ha1258a1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h373387f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h3435931_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.1.0-ha9f2e26_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.1.0-he0feb66_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.22-h280c20c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.1-h0c1763c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026080206-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026080206-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026080206-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026080206-release.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-hf4e2dac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+      - conda: https://conda.modular.com/max/noarch/mblack-26.5.0-release.conda
+      - conda: https://conda.modular.com/max/linux-64/mojo-1.0.0-release.conda
+      - conda: https://conda.modular.com/max/linux-64/mojo-compiler-1.0.0-release.conda
+      - conda: https://conda.modular.com/max/noarch/mojo-python-1.0.0-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.3-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.10.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.5-habeac84_100_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.11.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.6-h242f9ac_102_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.14.5-h4df99d1_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.14.6-h4df99d1_102.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py314h67df5f8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.6-py314h5bd0f2a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.8-py314h5bd0f2a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.16.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h09e67af_11.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
       osx-arm64:
-      - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.5-py314hd8ed1ab_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h4e30115_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.6-py314hd8ed1ab_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-py310h579977c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-h385eeb1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.6-h55c6f16_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321hafb1f1b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-hfd3d5f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.8-h55c6f16_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321h26f1114_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-hcf2aa1b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.22-h1a92334_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.1-h1b79a29_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026080206-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026080206-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026080206-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026080206-release.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.4-h1ae2325_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_3.conda
+      - conda: https://conda.modular.com/max/noarch/mblack-26.5.0-release.conda
+      - conda: https://conda.modular.com/max/osx-arm64/mojo-1.0.0-release.conda
+      - conda: https://conda.modular.com/max/osx-arm64/mojo-compiler-1.0.0-release.conda
+      - conda: https://conda.modular.com/max/noarch/mojo-python-1.0.0-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-he64c551_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.3-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.10.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.5-h4c637c5_100_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.11.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.6-hf4d206d_102_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.14.5-h4df99d1_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.14.6-h4df99d1_102.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py314h6e9b3f0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py312h022ad19_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hd3d0363_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.6-py314h6c2aa35_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.8-py314h6c2aa35_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.16.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h10816f8_11.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hf451053_7.conda
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   build_number: 20
@@ -220,64 +224,84 @@ packages:
   license_family: BSD
   size: 28948
   timestamp: 1770939786096
-- conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
-  sha256: a3967b937b9abf0f2a99f3173fa4630293979bd1644709d89580e7c62a544661
-  md5: aaa2a381ccc56eac91d63b6c1240312f
+- conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
+  sha256: 2a7204314663eeda5dec482a956f0e2eaf289bd5b9953eaaaad0e81aa64638f2
+  md5: 3845f3d75991bae0fb90884662f4327c
   depends:
   - cpython
   - python-gil
   license: MIT
   license_family: MIT
-  size: 8191
-  timestamp: 1744137672556
-- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
-  sha256: 0b75d45f0bba3e95dc693336fa51f40ea28c980131fec438afb7ce6118ed05f6
-  md5: d2ffd7602c02f2b316fd921d39876885
+  size: 8144
+  timestamp: 1784221492234
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+  sha256: 1a0d382c515ebf55f8ee1f38c8b81bc95af5c2acc42ad53b66bc5df932032f96
+  md5: e675fabcf81499adc7edf58124fb1e01
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   license: bzip2-1.0.6
   license_family: BSD
-  size: 260182
-  timestamp: 1771350215188
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
-  sha256: 540fe54be35fac0c17feefbdc3e29725cce05d7367ffedfaaa1bdda234b019df
-  md5: 620b85a3f45526a8bc4d23fd78fc22f0
+  size: 257808
+  timestamp: 1785906269155
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h4e30115_10.conda
+  sha256: 8ec22f0ba25cbfc2e64d70cf29459eccd7ffdf6436f6a6ff15bbfef799f7d4f6
+  md5: b50612e7d190b8061ab4e7dc119cf4d5
   depends:
   - __osx >=11.0
   license: bzip2-1.0.6
   license_family: BSD
-  size: 124834
-  timestamp: 1771350416561
-- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
-  sha256: 9812a303a1395e1dafbd92e5bc8a1ff6013bcbba0a09c7f03a8d23e43560aa9b
-  md5: 489b8e97e666c93f68fdb35c3c9b957f
+  size: 124965
+  timestamp: 1785906749812
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+  sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+  md5: 0f51e2391ade309db462a55611263e9c
   depends:
   - __unix
   license: ISC
-  size: 129868
-  timestamp: 1779289852439
-- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
-  sha256: c253a41cdf898b651a0786cbb76c6d5fc101d0dbbe719f93a124bc4fde5cdd6a
-  md5: 554304a07e581a85891b15e39ea9f268
+  size: 131780
+  timestamp: 1784754889428
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
+  sha256: ccc4787f511964f9a1f2d2d2859c91c5d571fb60f7f09d4c4e092c9b7a94e671
+  md5: 2c4bd6aeb90bb157456841c3270a0d92
   depends:
   - __unix
   - python
   - python >=3.10
   license: BSD-3-Clause
   license_family: BSD
-  size: 104999
-  timestamp: 1779900548735
-- conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.5-py314hd8ed1ab_100.conda
+  size: 107155
+  timestamp: 1783085363526
+- conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.6-py314hd8ed1ab_102.conda
   noarch: generic
-  sha256: 777882d2685f368417f31bbe1b28f73687fc6c8f6a5768bda20ffeefa6b07f5b
-  md5: a749029ce5d0632a913db19d17f944ab
+  sha256: 4d97fdae803c1ed7c704289d1f856d60e5502f24e93e92f9d45fbea37fd9e9a7
+  md5: 6b344ff499096c0b873d202fea1e2fcd
   depends:
   - python >=3.14,<3.15.0a0
   - python_abi * *_cp314
   license: Python-2.0
-  size: 50212
-  timestamp: 1779236682725
+  size: 49916
+  timestamp: 1786444134021
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
+  sha256: 9f07834f0c546ab14d885ce0366285f61f44e326c0edd1fc63b8294e113ae432
+  md5: 72a381cbad04f24b1c2a43ef707f45b4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  size: 14459115
+  timestamp: 1786545741408
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-py310h579977c_2.conda
+  sha256: 6cdb5dee54c72e56ab189fb3ad33cb28533553d42590e7e831160248f4416a43
+  md5: a5efc0b42bb8b42e97d0a29ae3e3c187
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 14070242
+  timestamp: 1786545847761
 - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
   sha256: 43e2a5497cad1598ff88a3e69f69bc88b7b8f141fa63c60eab5db296317318b8
   md5: ffc17e785d64e12fc311af9184221839
@@ -329,9 +353,9 @@ packages:
   license: LGPL-2.1-or-later
   size: 134088
   timestamp: 1754905959823
-- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-ha1258a1_0.conda
-  sha256: 3e307628ca3527448dd1cb14ad7bb9d04d1d28c7d4c5f97ba196ae984571dd25
-  md5: fb53fb07ce46a575c5d004bbc96032c2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
+  sha256: 9b07046870772f28740e3f6149f09ff222843733087a33c5540b169c6289652d
+  md5: 54157a1c8c0bb70f62dd0b17fba7e7f2
   depends:
   - __glibc >=2.17,<3.0.a0
   - keyutils >=1.6.3,<2.0a0
@@ -339,71 +363,71 @@ packages:
   - libedit >=3.1.20250104,<4.0a0
   - libgcc >=14
   - libstdcxx >=14
-  - openssl >=3.5.5,<4.0a0
+  - openssl >=3.5.7,<4.0a0
   license: MIT
   license_family: MIT
-  size: 1386730
-  timestamp: 1769769569681
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-h385eeb1_0.conda
-  sha256: c0a0bf028fe7f3defcdcaa464e536cf1b202d07451e18ad83fdd169d15bef6ed
-  md5: e446e1822f4da8e5080a9de93474184d
+  size: 1388990
+  timestamp: 1781859420533
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-hfd3d5f3_1.conda
+  sha256: c740e4a2e7247776a9883158fdab50ae0732c8f67f96d8f1db8ad9da5e0b5222
+  md5: 8780f41b013d19219faef9c82260744b
   depends:
   - __osx >=11.0
   - libcxx >=19
   - libedit >=3.1.20250104,<3.2.0a0
   - libedit >=3.1.20250104,<4.0a0
-  - openssl >=3.5.5,<4.0a0
+  - openssl >=3.5.7,<4.0a0
   license: MIT
   license_family: MIT
-  size: 1160828
-  timestamp: 1769770119811
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
-  sha256: 3d584956604909ff5df353767f3a2a2f60e07d070b328d109f30ac40cd62df6c
-  md5: 18335a698559cdbcd86150a48bf54ba6
+  size: 1159780
+  timestamp: 1781859501654
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+  sha256: 27d83f1188cd19bcb7754a078b3fa7f4cfb8527f8eb2fde54dd01fc529d1adec
+  md5: 449500f2c089da11c40f5c21312e3e07
   depends:
   - __glibc >=2.17,<3.0.a0
   - zstd >=1.5.7,<1.6.0a0
   constrains:
-  - binutils_impl_linux-64 2.45.1
+  - binutils_impl_linux-64 2.46.1
   license: GPL-3.0-only
   license_family: GPL
-  size: 728002
-  timestamp: 1774197446916
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.6-h55c6f16_0.conda
-  sha256: 3e2f8ad32ddab88c5114b9aa2160f8c129f515df0e551d0d86ef5744446afdbd
-  md5: 589cc6f6222fdc0eaf8e90bc38fcce7b
+  size: 745303
+  timestamp: 1784214507189
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.8-h55c6f16_0.conda
+  sha256: a2e7abab5add9750fab064c024394de48e49f97631c605ad5db5c8ac3fc769ef
+  md5: 89f76a2a21a3ec3ec983b5eb237c4113
   depends:
   - __osx >=11.0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 570038
-  timestamp: 1779253025527
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
-  sha256: d789471216e7aba3c184cd054ed61ce3f6dac6f87a50ec69291b9297f8c18724
-  md5: c277e0a4d549b03ac1e9d6cbbe3d017b
+  size: 569349
+  timestamp: 1781670209146
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h373387f_1.conda
+  sha256: 6473eb8caf2aae830f37caa93db9b26dddf7ac84b63229e8bf7fc0e5c3ab95b0
+  md5: 50708d3b951d0f8e2d7f2df5b5edc040
   depends:
   - ncurses
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - ncurses >=6.5,<7.0a0
+  - ncurses >=6.6,<7.0a0
   license: BSD-2-Clause
   license_family: BSD
-  size: 134676
-  timestamp: 1738479519902
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321hafb1f1b_0.conda
-  sha256: 66aa216a403de0bb0c1340a88d1a06adaff66bae2cfd196731aa24db9859d631
-  md5: 44083d2d2c2025afca315c7a172eab2b
+  size: 135098
+  timestamp: 1786616658086
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321h26f1114_1.conda
+  sha256: 257c926f19e32bdb981fc674c76966049b6fc73f706bae58e9fed8757ad1da70
+  md5: 843ef89082f368cb889305084d3b483c
   depends:
   - ncurses
   - __osx >=11.0
-  - ncurses >=6.5,<7.0a0
+  - ncurses >=6.6,<7.0a0
   license: BSD-2-Clause
   license_family: BSD
-  size: 107691
-  timestamp: 1738479560845
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_0.conda
-  sha256: 363018b25fdb5534c79783d912bd4b685a3547f4fc5996357ad548899b0ee8e7
-  md5: 93764a5ca80616e9c10106cdaec92f74
+  size: 107742
+  timestamp: 1786616721640
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+  sha256: 16feffd9ddbbe5b718515d38ee376c685ba95491cd901244e24671d20b952a77
+  md5: b24d3c612f71e7aa74158d92106318b2
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
@@ -411,81 +435,81 @@ packages:
   - expat 2.8.1.*
   license: MIT
   license_family: MIT
-  size: 77294
-  timestamp: 1779278686680
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_0.conda
-  sha256: 3133fb6bfa871288b92c8b8752696686a841bf4ffe035aa3038033c9e15b738e
-  md5: ef22e9ab1dc7c2f334252f565f90b3b8
+  size: 77856
+  timestamp: 1781203599810
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+  sha256: 5af74261101e3c777399c6294b2b5d290e508153268eb2e9ff99c4d69834612f
+  md5: a915151d5d3c5bf039f5ccc8402a436f
   depends:
   - __osx >=11.0
   constrains:
   - expat 2.8.1.*
   license: MIT
   license_family: MIT
-  size: 69110
-  timestamp: 1779278728511
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
-  sha256: 31f19b6a88ce40ebc0d5a992c131f57d919f73c0b92cd1617a5bec83f6e961e6
-  md5: a360c33a5abe61c07959e449fa1453eb
+  size: 69362
+  timestamp: 1781203631990
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h3435931_0.conda
+  sha256: ac38603008bf1e99b8ed379b1a656a67a70e2841f2b6a069c630cdf6316012d2
+  md5: 0abe40a9880086ca4d2e5daf09dceff9
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   license: MIT
   license_family: MIT
-  size: 58592
-  timestamp: 1769456073053
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
-  sha256: 6686a26466a527585e6a75cc2a242bf4a3d97d6d6c86424a441677917f28bec7
-  md5: 43c04d9cb46ef176bb2a4c77e324d599
+  size: 67576
+  timestamp: 1783520858222
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-hcf2aa1b_0.conda
+  sha256: 2c6ac9a6cd65af89b2bd448518bb1e13b44a2e48c0d469398e37bcfc0092e832
+  md5: 92e8690d170d46d768c32553458c0105
   depends:
   - __osx >=11.0
   license: MIT
   license_family: MIT
-  size: 40979
-  timestamp: 1769456747661
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
-  sha256: 8e0a3b5e41272e5678499b5dfc4cddb673f9e935de01eb0767ce857001229f46
-  md5: 57736f29cc2b0ec0b6c2952d3f101b6a
+  size: 43734
+  timestamp: 1783521647536
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.1.0-ha9f2e26_1.conda
+  sha256: d5cb8475131c31680f8fd30512c418f373064e272e452063276a8fb14c9fa42f
+  md5: 5a7d954665c707c93311657cd779c705
   depends:
   - __glibc >=2.17,<3.0.a0
   - _openmp_mutex >=4.5
   constrains:
-  - libgcc-ng ==15.2.0=*_19
-  - libgomp 15.2.0 he0feb66_19
+  - libgomp 16.1.0 he0feb66_1
+  - libgcc-ng ==16.1.0=*_1
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 1041084
-  timestamp: 1778269013026
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
-  sha256: 5abe4ab9d93f6c9757d654f1969ae2267d4505315c1f2f8fe705fd60af084f1b
-  md5: faac990cb7aedc7f3a2224f2c9b0c26c
+  size: 1057877
+  timestamp: 1785375436766
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.1.0-he0feb66_1.conda
+  sha256: 62cb599ad0539d99386515326d9d5e8f51f75a60c69c2131b21df76edf35bd89
+  md5: 88f2d91cb1533194c323534253094d23
   depends:
   - __glibc >=2.17,<3.0.a0
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 603817
-  timestamp: 1778268942614
-- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
-  sha256: ec30e52a3c1bf7d0425380a189d209a52baa03f22fb66dd3eb587acaa765bd6d
-  md5: b88d90cad08e6bc8ad540cb310a761fb
+  size: 640415
+  timestamp: 1785375373755
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
+  sha256: 9787df8c22a59c9a70d3e5a10db9ad663485e75e9ccc3f09bd092cb7b95e0dab
+  md5: 1390b7c5ac0b1d8e447bc5efa6d3c8c2
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   constrains:
   - xz 5.8.3.*
   license: 0BSD
-  size: 113478
-  timestamp: 1775825492909
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
-  sha256: 34878d87275c298f1a732c6806349125cebbf340d24c6c23727268184bba051e
-  md5: b1fd823b5ae54fbec272cea0811bd8a9
+  size: 112995
+  timestamp: 1786348617826
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_1.conda
+  sha256: 23d0630046a3e8b164d8f80f2b74ed2605af2e7050ab9913018056402fae4311
+  md5: 8ab10323068b107661a4b9a4af84f3b5
   depends:
   - __osx >=11.0
   constrains:
   - xz 5.8.3.*
   license: 0BSD
-  size: 92472
-  timestamp: 1775825802659
+  size: 91720
+  timestamp: 1786348695846
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
   sha256: fe171ed5cf5959993d43ff72de7596e8ac2853e9021dec0344e583734f1e0843
   md5: 2c21e66f50753a083cbe6b80f38268fa
@@ -522,73 +546,75 @@ packages:
   license: ISC
   size: 247352
   timestamp: 1779164136206
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.1-h0c1763c_0.conda
-  sha256: 54cdcd3214313b62c2a8ee277e6f42150d9b748264c1b70d958bf735e420ef8d
-  md5: 7dc38adcbf71e6b38748e919e16e0dce
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-hf4e2dac_0.conda
+  sha256: 72023efc207fe681e26b65fc9d668062cf0b4f0eacf3431e6eb099b95c1f2efd
+  md5: df088a279cd5e6fd2790b4c196434da1
   depends:
   - __glibc >=2.17,<3.0.a0
+  - icu >=78.3,<79.0a0
   - libgcc >=14
   - libzlib >=1.3.2,<2.0a0
   license: blessing
-  size: 954962
-  timestamp: 1777986471789
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.1-h1b79a29_0.conda
-  sha256: 49daec7c83e70d4efc17b813547824bc2bcf2f7256d84061d24fbfe537da9f74
-  md5: 6681822ea9d362953206352371b6a904
+  size: 964200
+  timestamp: 1785016112246
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.4-h1ae2325_0.conda
+  sha256: 745662565e103f290e9dc4263bbd88285082f8cf699854fe2d5f1e35a4a0d326
+  md5: 0e3477c0c3e718dcf2eb74ccc8f68570
   depends:
   - __osx >=11.0
+  - icu >=78.3,<79.0a0
   - libzlib >=1.3.2,<2.0a0
   license: blessing
-  size: 920047
-  timestamp: 1777987051643
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
-  sha256: dff1058c76ec6b8759e41cefa2508162d00e4a5e6721aa68ec3fd10094e702dc
-  md5: 5794b3bdc38177caf969dabd3af08549
+  size: 929203
+  timestamp: 1785016131414
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_1.conda
+  sha256: 79721dd08aeb0ab9e773f1f9ef41cf4e6c17477e3d72319147619045bce05a09
+  md5: aed6cf89adc1e9b846e4367ac538e434
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc 15.2.0 he0feb66_19
+  - libgcc 16.1.0 ha9f2e26_1
   constrains:
-  - libstdcxx-ng ==15.2.0=*_19
+  - libstdcxx-ng ==16.1.0=*_1
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 5852044
-  timestamp: 1778269036376
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
-  sha256: 3f0edf1280e2f6684a986f821eaa3e123d2694a00b31b96ca0d4a4c12c129231
-  md5: 7d0a66598195ef00b6efc55aefc7453b
+  size: 6631744
+  timestamp: 1785375462643
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+  sha256: 9b1bdce27a7e31f7d241aeecff67a1f3101d52a2b1e33ccc2cdf2613072bf81f
+  md5: 01bb81d12c957de066ea7362007df642
   depends:
-  - __glibc >=2.17,<3.0.a0
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 40163
-  timestamp: 1779118517630
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
-  sha256: 55044c403570f0dc26e6364de4dc5368e5f3fc7ff103e867c487e2b5ab2bcda9
-  md5: d87ff7921124eccd67248aa483c23fec
+  size: 40017
+  timestamp: 1781625522462
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+  sha256: eb8a0db0aa570124f7d2a93d7c7f596e3390df5e047818d873baad32985fc736
+  md5: 0de0122d9570a8ab637c6b73db268389
   depends:
   - __glibc >=2.17,<3.0.a0
   constrains:
-  - zlib 1.3.2 *_2
+  - zlib 1.3.2 *_3
   license: Zlib
   license_family: Other
-  size: 63629
-  timestamp: 1774072609062
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
-  sha256: 361415a698514b19a852f5d1123c5da746d4642139904156ddfca7c922d23a05
-  md5: bc5a5721b6439f2f62a84f2548136082
+  size: 63713
+  timestamp: 1785362952714
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_3.conda
+  sha256: a18fa5d5bac452401459f966cf0d872224e8080c4ff93c77e168d43ab42ef9d7
+  md5: f39288f0ea63ae962e1a2e4f355a0d75
   depends:
   - __osx >=11.0
   constrains:
-  - zlib 1.3.2 *_2
+  - zlib 1.3.2 *_3
   license: Zlib
   license_family: Other
-  size: 47759
-  timestamp: 1774072956767
-- conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026080206-release.conda
+  size: 47822
+  timestamp: 1785277049190
+- conda: https://conda.modular.com/max/noarch/mblack-26.5.0-release.conda
   noarch: python
-  sha256: c2f636a260ddf0bcd54520cd8bb0ff47c278e9bef892a611da327d56ccd681c4
-  md5: 90f9010ea97d98fa9084a38264fe4548
+  sha256: 49102b55366eab56b04620533302b8693b4fa4a6c5972b3cc978b3f3bad83ebe
+  md5: 0cbfc119215c063cd279f0a6beb04285
   depends:
   - python >=3.10
   - click >=8.0.0
@@ -598,55 +624,55 @@ packages:
   - platformdirs >=2
   - tomli >=1.1.0
   license: LicenseRef-Modular-Proprietary
-  size: 137259
-  timestamp: 1785651187650
-- conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026080206-release.conda
-  sha256: 62106f16dbcc5cb12952f7aae108bc8ad322929a70f1a41757d285f5d6aec00a
-  md5: a59dc0987f4d516ed98473f759e75e0a
+  size: 137187
+  timestamp: 1786151006088
+- conda: https://conda.modular.com/max/linux-64/mojo-1.0.0-release.conda
+  sha256: 5778f999b69cf77bd6f07ccaf32d0bafc258fe75206afc8e88919269cebb6e75
+  md5: afeb126acb57602a5f9b8153e75e1c3c
   depends:
   - python >=3.10
-  - mojo-compiler ==1.0.0b3.dev2026080206
-  - mblack ==26.5.0.dev2026080206
+  - mojo-compiler ==1.0.0
+  - mblack ==26.5.0
   - jupyter_client >=8.6.2,<8.7
   license: LicenseRef-Modular-Proprietary
-  size: 114652994
-  timestamp: 1785651331165
-- conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-1.0.0b3.dev2026080206-release.conda
-  sha256: ba23f47465ebf4aa32bf17a92f051e1321f57c2cbe7ea3e82d40bcf50911e5a9
-  md5: 47d57f603d02171fab600b2aec02778d
+  size: 115641078
+  timestamp: 1786292404342
+- conda: https://conda.modular.com/max/osx-arm64/mojo-1.0.0-release.conda
+  sha256: 200bd9ace6e06ad2a9b4f4cce9afa3e5f3c00b3d87a6d57206249df2a5568e38
+  md5: 954433eb905b424cc3d4325c9c2242de
   depends:
   - python >=3.10
-  - mojo-compiler ==1.0.0b3.dev2026080206
-  - mblack ==26.5.0.dev2026080206
+  - mojo-compiler ==1.0.0
+  - mblack ==26.5.0
   - jupyter_client >=8.6.2,<8.7
   license: LicenseRef-Modular-Proprietary
-  size: 100230126
-  timestamp: 1785651464491
-- conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026080206-release.conda
-  sha256: a0c6520fe5484edb60fdb3ae79e794e540caa8aa6ef952993e8b4b7e719abaed
-  md5: 889b1e777df751d6f819af51cf378638
+  size: 101155040
+  timestamp: 1786294689438
+- conda: https://conda.modular.com/max/linux-64/mojo-compiler-1.0.0-release.conda
+  sha256: 4394c6146d47ec7794a9a3ed5775ae158f59f83f8e1aed59408b17c4909821b3
+  md5: 75d2e2ca9d87fdc76513d7939202e7dc
   depends:
-  - mojo-python ==1.0.0b3.dev2026080206
+  - mojo-python ==1.0.0
   license: LicenseRef-Modular-Proprietary
-  size: 80195047
-  timestamp: 1785651334650
-- conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-1.0.0b3.dev2026080206-release.conda
-  sha256: 2dcceb79b707897ca8d449373bfde89fe147efdeab3bd2814650041bf854f7da
-  md5: ea26404327ab9e11c4ba2a085597eb08
+  size: 68511359
+  timestamp: 1786292410712
+- conda: https://conda.modular.com/max/osx-arm64/mojo-compiler-1.0.0-release.conda
+  sha256: c52054bc444d851e5c38cc33e790fb011a1080470244aaa59351ac5056d08c59
+  md5: b5103c9d9978173a1e97c5e5eed1aeba
   depends:
-  - mojo-python ==1.0.0b3.dev2026080206
+  - mojo-python ==1.0.0
   license: LicenseRef-Modular-Proprietary
-  size: 61668970
-  timestamp: 1785651460986
-- conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b3.dev2026080206-release.conda
+  size: 61221085
+  timestamp: 1786294690001
+- conda: https://conda.modular.com/max/noarch/mojo-python-1.0.0-release.conda
   noarch: python
-  sha256: 68820463504d6c4c1a71b13997622b5f70563305e5df19e2d982136605d601a7
-  md5: 46d3a83fa170aa007623755da2cba031
+  sha256: fc449a47c7707ed96a794768e29d5d2b0bf7afab373e2a9751f281ed7c4f822c
+  md5: 4a27e1596a5c2d27330a2377090b12c5
   depends:
   - python >=3.10
   license: LicenseRef-Modular-Proprietary
-  size: 24129
-  timestamp: 1785651187428
+  size: 24040
+  timestamp: 1785891558838
 - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
   sha256: 6ed158e4e5dd8f6a10ad9e525631e35cee8557718f83de7a4e3966b1f772c4b1
   md5: e9c622e0d00fa24a6292279af3ab6d06
@@ -656,54 +682,54 @@ packages:
   license_family: MIT
   size: 11766
   timestamp: 1745776666688
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
-  sha256: fc89f74bbe362fb29fa3c037697a89bec140b346a2469a90f7936d1d7ea4d8a3
-  md5: fc21868a1a5aacc937e7a18747acb8a5
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+  sha256: 5d46557214ed184381dafe835b7c94a474a1c3b307a08a250b1ea4779b44ffb3
+  md5: ee6c0cd80a60961a1f48aa3e0b91f986
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   license: X11 AND BSD-3-Clause
-  size: 918956
-  timestamp: 1777422145199
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
-  sha256: 4ea6c620b87bd1d42bb2ccc2c87cd2483fa2d7f9e905b14c223f11ff3f4c455d
-  md5: 343d10ed5b44030a2f67193905aea159
+  size: 911196
+  timestamp: 1786355078102
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-he64c551_1.conda
+  sha256: 7024a48c8c0d0114ed4ab53c76bf9275d50e91ba7cea367a9aead638d3c29c68
+  md5: 3dfa0d0316dc246cd44937a557de4501
   depends:
   - __osx >=11.0
   license: X11 AND BSD-3-Clause
-  size: 805509
-  timestamp: 1777423252320
-- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
-  sha256: c0ef482280e38c71a08ad6d71448194b719630345b0c9c60744a2010e8a8e0cb
-  md5: da1b85b6a87e141f5140bb9924cecab0
+  size: 804298
+  timestamp: 1786355189145
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_1.conda
+  sha256: 012096056b97abf1f68c46b7146bd2cbd68c1be762340b4f5dad4fbbe99177bc
+  md5: c5955c27917ff2234def47f075e71e02
   depends:
   - __glibc >=2.17,<3.0.a0
   - ca-certificates
   - libgcc >=14
   license: Apache-2.0
   license_family: Apache
-  size: 3167099
-  timestamp: 1775587756857
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
-  sha256: c91bf510c130a1ea1b6ff023e28bac0ccaef869446acd805e2016f69ebdc49ea
-  md5: 25dcccd4f80f1638428613e0d7c9b4e1
+  size: 3182423
+  timestamp: 1785913583650
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_1.conda
+  sha256: 66be2283b5b37dcda1332b5e74c1782a8cb14fd2e62e0d38017c2d35bf73c119
+  md5: 65d1906712b85d1679263c518d011b5b
   depends:
   - __osx >=11.0
   - ca-certificates
   license: Apache-2.0
   license_family: Apache
-  size: 3106008
-  timestamp: 1775587972483
-- conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
-  sha256: 3906abfb6511a3bb309e39b9b1b7bc38f50a723971de2395489fd1f379255890
-  md5: 4c06a92e74452cfa53623a81592e8934
+  size: 3109132
+  timestamp: 1785913735357
+- conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.3-pyhc364b38_0.conda
+  sha256: c432626b16768b8dab228bfb706f7060c2d462a21c516d240f68f2f902b5a044
+  md5: 936687ed80f295a1f5dbcf8bd34c252c
   depends:
-  - python >=3.8
+  - python >=3.9
   - python
   license: Apache-2.0
   license_family: APACHE
-  size: 91574
-  timestamp: 1777103621679
+  size: 116363
+  timestamp: 1785888127370
 - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
   sha256: 6eaee417d33f298db79bc7185ab1208604c0e6cf51dade34cd513c6f9db9c6f3
   md5: 11adc78451c998c0fd162584abfa3559
@@ -713,66 +739,66 @@ packages:
   license_family: MOZILLA
   size: 56559
   timestamp: 1777271601895
-- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.10.0-pyhcf101f3_0.conda
-  sha256: 9e5e1fd3506ccfc4d444fc4d2d39b0ed097d5d0e3bd3d4bdf6bcc81aaf66860d
-  md5: 2c5ef45db85d34799771629bd5860fd7
+- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.11.2-pyhcf101f3_0.conda
+  sha256: eea7ead8bcdc3b307241cbc8d038f8b95db9e351e52f2bf3c12ad55eb4d9a8d1
+  md5: 15f2020d6b2ede94d80b2c884a1a6f3e
   depends:
   - python >=3.10
   - python
   license: MIT
   license_family: MIT
-  size: 26308
-  timestamp: 1779972894916
-- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.5-habeac84_100_cp314.conda
-  build_number: 100
-  sha256: 55eed9bf2a3f6e90311276f0834737fe7c2d9ec3e5e2e557507858df4c7521e6
-  md5: da92e59ff92f2d5ede4f612af20f583f
+  size: 26869
+  timestamp: 1786390868223
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.6-h242f9ac_102_cp314.conda
+  build_number: 102
+  sha256: f5ff5c1fac471dfed4fc4288856a63eb9d771e6042d9f70420d75b9f488400d8
+  md5: 9b6c336ef7195fbee1c10c09bfcf901b
   depends:
   - __glibc >=2.17,<3.0.a0
   - bzip2 >=1.0.8,<2.0a0
   - ld_impl_linux-64 >=2.36.1
-  - libexpat >=2.8.0,<3.0a0
-  - libffi >=3.5.2,<3.6.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libffi >=3.7.0,<3.8.0a0
   - libgcc >=14
   - liblzma >=5.8.3,<6.0a0
   - libmpdec >=4.0.0,<5.0a0
-  - libsqlite >=3.53.1,<4.0a0
-  - libuuid >=2.42.1,<3.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - libuuid >=2.42.2,<3.0a0
   - libzlib >=1.3.2,<2.0a0
   - ncurses >=6.6,<7.0a0
-  - openssl >=3.5.6,<4.0a0
+  - openssl >=3.5.7,<4.0a0
   - python_abi 3.14.* *_cp314
   - readline >=8.3,<9.0a0
   - tk >=8.6.13,<8.7.0a0
   - tzdata
   - zstd >=1.5.7,<1.6.0a0
   license: Python-2.0
-  size: 36745188
-  timestamp: 1779236923603
+  size: 36866750
+  timestamp: 1786444737142
   python_site_packages_path: lib/python3.14/site-packages
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.5-h4c637c5_100_cp314.conda
-  build_number: 100
-  sha256: 06dec0e2f50e2f7e6a8808fcb4aff23729a3f23bcb1fca4fcbc3a341d9e38a83
-  md5: f7331c9deaf21c79e5675e72b21d570b
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.6-hf4d206d_102_cp314.conda
+  build_number: 102
+  sha256: 9767b5eee5cef50716708787bb3b4225d2a974bcd50653e856f9db5910a4b17e
+  md5: 8da4ea285021110e2617f7538c386afc
   depends:
   - __osx >=11.0
   - bzip2 >=1.0.8,<2.0a0
-  - libexpat >=2.8.0,<3.0a0
-  - libffi >=3.5.2,<3.6.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libffi >=3.7.0,<3.8.0a0
   - liblzma >=5.8.3,<6.0a0
   - libmpdec >=4.0.0,<5.0a0
-  - libsqlite >=3.53.1,<4.0a0
+  - libsqlite >=3.53.4,<4.0a0
   - libzlib >=1.3.2,<2.0a0
   - ncurses >=6.6,<7.0a0
-  - openssl >=3.5.6,<4.0a0
+  - openssl >=3.5.7,<4.0a0
   - python_abi 3.14.* *_cp314
   - readline >=8.3,<9.0a0
   - tk >=8.6.13,<8.7.0a0
   - tzdata
   - zstd >=1.5.7,<1.6.0a0
   license: Python-2.0
-  size: 13560854
-  timestamp: 1779238292621
+  size: 13960847
+  timestamp: 1786444540722
   python_site_packages_path: lib/python3.14/site-packages
 - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
   sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664
@@ -785,15 +811,15 @@ packages:
   license_family: APACHE
   size: 233310
   timestamp: 1751104122689
-- conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.14.5-h4df99d1_100.conda
-  sha256: 41dd7da285d71d519257fa7dacb1cae060d5ebfaa5f92cba5994899d2978e943
-  md5: 41954747ba952ec4b01e16c2c9e8d8ff
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.14.6-h4df99d1_102.conda
+  sha256: b15fb3e5daae788ca78844ee4ee9f1a1b07911cd4e83c484d8c1ce2794c6c93b
+  md5: 364ec4bb854ab4ca9ca4e626a55ea8da
   depends:
-  - cpython 3.14.5.*
+  - cpython 3.14.6.*
   - python_abi * *_cp314
   license: Python-2.0
-  size: 50212
-  timestamp: 1779236703009
+  size: 49897
+  timestamp: 1786444152084
 - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
   build_number: 8
   sha256: ad6d2e9ac39751cc0529dd1566a26751a0bf2542adb0c232533d32e176e21db5
@@ -892,29 +918,28 @@ packages:
   license_family: MIT
   size: 18455
   timestamp: 1753199211006
-- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
-  sha256: cafeec44494f842ffeca27e9c8b0c27ed714f93ac77ddadc6aaf726b5554ebac
-  md5: cffd3bdd58090148f4cfcd831f4b26ab
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
+  build_number: 103
+  sha256: 43624eab22f5f29df7d6ffe914cf442f28fd559b55b290906255492826e636e8
+  md5: 48a1049e710857572fc2a832aa394d9f
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - libzlib >=1.3.1,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
   constrains:
-  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libx11 >=1.8.13,<2.0a0
   license: TCL
-  license_family: BSD
-  size: 3301196
-  timestamp: 1769460227866
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
-  sha256: 799cab4b6cde62f91f750149995d149bc9db525ec12595e8a1d91b9317f038b3
-  md5: a9d86bc62f39b94c4661716624eb21b0
+  size: 3550916
+  timestamp: 1784229071544
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hd3d0363_3.conda
+  sha256: 47186bc7ab8d7e8bee86bbd1a917196f8c21cf63f081fc33cd6d1221af087580
+  md5: 8e3cf0e455e6b54519f0b1c72c61780a
   depends:
   - __osx >=11.0
-  - libzlib >=1.3.1,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
   license: TCL
-  license_family: BSD
-  size: 3127137
-  timestamp: 1769460817696
+  size: 3338712
+  timestamp: 1784229090530
 - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
   sha256: 91cafdb64268e43e0e10d30bd1bef5af392e69f00edd34dfaf909f69ab2da6bd
   md5: b5325cf06a000c5b14970462ff5e4d58
@@ -925,9 +950,9 @@ packages:
   license_family: MIT
   size: 21561
   timestamp: 1774492402955
-- conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.6-py314h5bd0f2a_0.conda
-  sha256: 6971e79b5ce220cd845195e0e2a00b4c10ed6b63710316a6e3dbc6a2cb78f484
-  md5: fdb4d8fea83ebcc004fa4b29cbbc801b
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.8-py314h5bd0f2a_0.conda
+  sha256: ebec0d90f99fa7bbe91eabab41ee77d3f36dbd58ec2f08aa4220fdd713610b6d
+  md5: faea84d2f2ccadf70cf9e55381d75b3e
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
@@ -935,11 +960,11 @@ packages:
   - python_abi 3.14.* *_cp314
   license: Apache-2.0
   license_family: Apache
-  size: 914451
-  timestamp: 1779915938568
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.6-py314h6c2aa35_0.conda
-  sha256: 45df7cdb5f104866bb520cb27f8a775088726ae5a5691a53c0ffed49a099838a
-  md5: 9c61bebaff48c4f060ca35f38479ad01
+  size: 923237
+  timestamp: 1786226770518
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.8-py314h6c2aa35_0.conda
+  sha256: 4af8e4394d249619b4f1641c82fd6c0a8b97d51991ca2986095bed400c2e5eb9
+  md5: ab1bd70ec9c95d199f8ce456823004ab
   depends:
   - __osx >=11.0
   - python >=3.14,<3.15.0a0
@@ -947,24 +972,24 @@ packages:
   - python_abi 3.14.* *_cp314
   license: Apache-2.0
   license_family: Apache
-  size: 916141
-  timestamp: 1779916422402
-- conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.0-pyhcf101f3_0.conda
-  sha256: dfb681579be59c2e790c95f7f49b7529a9b0511d6385ad276e3c8988cbd54d2c
-  md5: 4bada6a6d908a27262af8ebddf4f7492
+  size: 922067
+  timestamp: 1786227125229
+- conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.16.1-pyhcf101f3_0.conda
+  sha256: 03dba5917f944c6684ab44c81daacac1624cd148e4b2cae215dcec594a210c48
+  md5: a79bf97561232a31447b6246c2153ab5
   depends:
   - python >=3.10
   - python
   license: BSD-3-Clause
   license_family: BSD
-  size: 115165
-  timestamp: 1778074251714
-- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-  sha256: 1d30098909076af33a35017eed6f2953af1c769e273a0626a04722ac4acaba3c
-  md5: ad659d0a2b3e47e38d829aa8cad2d610
+  size: 116935
+  timestamp: 1785761789772
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+  sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+  md5: fcb489df604d100968b737f2cb6076c6
   license: LicenseRef-Public-Domain
-  size: 119135
-  timestamp: 1767016325805
+  size: 118849
+  timestamp: 1784250406640
 - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
   sha256: 6d9ea2f731e284e9316d95fa61869fe7bbba33df7929f82693c121022810f4ad
   md5: a77f85f77be52ff59391544bfe73390a
@@ -1019,23 +1044,23 @@ packages:
   license_family: MIT
   size: 24190
   timestamp: 1779159948016
-- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
-  sha256: 68f0206ca6e98fea941e5717cec780ed2873ffabc0e1ed34428c061e2c6268c7
-  md5: 4a13eeac0b5c8e5b8ab496e6c4ddd829
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
+  sha256: 47d682b9f6d6ec9eb1a6e6c3e75ea6273e899e78fb7fc59f81d39745009fbc60
+  md5: aa459086047c0e5e27023ab19f8cb86a
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libzlib >=1.3.1,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 601375
-  timestamp: 1764777111296
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
-  sha256: 9485ba49e8f47d2b597dd399e88f4802e100851b27c21d7525625b0b4025a5d9
-  md5: ab136e4c34e97f34fb621d2592a393d8
+  size: 601301
+  timestamp: 1786599621503
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hf451053_7.conda
+  sha256: da867f5092eb0cb746d353694f0098031fd9817a4ce7d5743121209ae0f406ca
+  md5: 4ec2684c73812cc2c3d78379384a39cc
   depends:
   - __osx >=11.0
-  - libzlib >=1.3.1,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 433413
-  timestamp: 1764777166076
+  size: 433687
+  timestamp: 1786599629846

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 authors = ["Manuel Saelices <msaelices@gmail.com>"]
-channels = ["conda-forge", "https://conda.modular.com/max-nightly"]
+channels = ["conda-forge", "https://conda.modular.com/max"]
 description = "Library for dealing with regular expressions in Mojo"
 homepage = "https://github.com/msaelices/mojo-regex"
 repository = "https://github.com/msaelices/mojo-regex"
@@ -19,7 +19,7 @@ version = "0.21.0"
 backend = { name = "pixi-build-rattler-build", version = "*" }
 
 [dependencies]
-mojo = "==1.0.0b3.dev2026080206"
+mojo = "==1.0.0"
 
 [tasks]
 test = "bash -c 'status=0; for f in tests/test_*.mojo; do echo \"Running $f...\"; out=$(mktemp -d); mojo build -I ./src -debug-level=line-tables \"$f\" -o \"$out/exe\" && \"$out/exe\" || status=1; rm -rf \"$out\"; done; exit $status'"

--- a/src/regex/aliases.mojo
+++ b/src/regex/aliases.mojo
@@ -67,7 +67,7 @@ without allocating a `String`."""
 
 @always_inline
 def imm_slice_from_ptr(
-    ptr: UnsafePointer[Byte, ImmutAnyOrigin], length: Int
+    ptr: Pointer[Byte, ImmutAnyOrigin], length: Int
 ) -> ImmSlice:
     """Construct an `ImmSlice` over `[ptr, ptr+length)`. Thin wrapper
     around the 1.0.0b2 `StringSlice(unsafe_from_utf8=Span(...))`

--- a/src/regex/ast.mojo
+++ b/src/regex/ast.mojo
@@ -1,4 +1,5 @@
-from std.memory import Pointer, UnsafePointer, unsafe_memcpy, alloc
+from std.memory import Pointer, unsafe_memcpy
+from std.memory.alloc import unsafe_alloc
 from std.os import abort
 
 from regex.aliases import (
@@ -83,9 +84,7 @@ struct Regex[origin: Origin](Copyable, Equatable, Movable, Writable):
     comptime ImmOrigin = ImmOrigin(Self.origin)
     comptime Immutable = Regex[origin=Self.ImmOrigin]
     var pattern: String
-    var children_ptr: UnsafePointer[
-        ASTNode[ImmUntrackedOrigin], MutUntrackedOrigin
-    ]
+    var children_ptr: Pointer[ASTNode[ImmUntrackedOrigin], MutUntrackedOrigin]
     var children_len: Int
     """Regex struct for representing a regular expression pattern."""
 
@@ -93,7 +92,7 @@ struct Regex[origin: Origin](Copyable, Equatable, Movable, Writable):
         """Initialize a Regex with a pattern."""
         self.pattern = pattern
         self.children_len = 0
-        self.children_ptr = alloc[ASTNode[ImmUntrackedOrigin]](
+        self.children_ptr = unsafe_alloc[ASTNode[ImmUntrackedOrigin]](
             pattern.byte_length() * 2
         )  # Allocate enough space for children
 
@@ -181,7 +180,7 @@ struct ASTNode[regex_origin: ImmOrigin](
 
     var type: Int
     """The type of AST node (e.g., ELEMENT, GROUP, RANGE, etc.)."""
-    var regex_ptr: UnsafePointer[Regex[ImmUntrackedOrigin], ImmUntrackedOrigin]
+    var regex_ptr: Pointer[Regex[ImmUntrackedOrigin], ImmUntrackedOrigin]
     """Pointer to the parent regex object containing the pattern string."""
     var start_idx: Int
     """Starting position of this node in the original pattern string."""
@@ -209,7 +208,7 @@ struct ASTNode[regex_origin: ImmOrigin](
     def __init__(
         out self,
         type: Int,
-        regex_ptr: UnsafePointer[Regex[ImmUntrackedOrigin], ImmUntrackedOrigin],
+        regex_ptr: Pointer[Regex[ImmUntrackedOrigin], ImmUntrackedOrigin],
         start_idx: Int,
         end_idx: Int,
         capturing_group: Bool = False,
@@ -236,7 +235,7 @@ struct ASTNode[regex_origin: ImmOrigin](
 
     def __init__(
         out self,
-        regex_ptr: UnsafePointer[Regex[ImmUntrackedOrigin], ImmUntrackedOrigin],
+        regex_ptr: Pointer[Regex[ImmUntrackedOrigin], ImmUntrackedOrigin],
         type: Int,
         child_index: UInt16,
         start_idx: Int,
@@ -264,7 +263,7 @@ struct ASTNode[regex_origin: ImmOrigin](
 
     def __init__(
         out self,
-        regex_ptr: UnsafePointer[Regex[ImmUntrackedOrigin], ImmUntrackedOrigin],
+        regex_ptr: Pointer[Regex[ImmUntrackedOrigin], ImmUntrackedOrigin],
         type: Int,
         children_indexes: ChildrenIndexes,
         start_idx: Int,
@@ -470,7 +469,9 @@ struct ASTNode[regex_origin: ImmOrigin](
         """Check if a character code is in a range pattern. Zero-allocation
         version of _is_char_in_range."""
         if range_pattern.startswith("["):
-            var inner_pattern = range_pattern[byte=1:-1]
+            var inner_pattern = range_pattern[
+                byte = 1 : range_pattern.byte_length() - 1
+            ]
             return self._char_code_matches_range(ch_code, inner_pattern)
         else:
             # Expanded string, check if char is in it
@@ -567,9 +568,7 @@ def Element[
 ) -> ASTNode[ImmUntrackedOrigin]:
     """Create an Element node with a value string."""
     var regex_ptr = (
-        UnsafePointer(to=regex)
-        .as_imm()
-        .unsafe_origin_cast[ImmUntrackedOrigin]()
+        Pointer(to=regex).as_imm().unsafe_origin_cast[ImmUntrackedOrigin]()
     )
     return ASTNode[ImmUntrackedOrigin](
         type=ELEMENT,
@@ -591,9 +590,7 @@ def WildcardElement[
 ) -> ASTNode[ImmUntrackedOrigin]:
     """Create a WildcardElement node."""
     var regex_ptr = (
-        UnsafePointer(to=regex)
-        .as_imm()
-        .unsafe_origin_cast[ImmUntrackedOrigin]()
+        Pointer(to=regex).as_imm().unsafe_origin_cast[ImmUntrackedOrigin]()
     )
     return ASTNode[ImmUntrackedOrigin](
         type=WILDCARD,
@@ -615,9 +612,7 @@ def SpaceElement[
 ) -> ASTNode[ImmUntrackedOrigin]:
     """Create a SpaceElement node."""
     var regex_ptr = (
-        UnsafePointer(to=regex)
-        .as_imm()
-        .unsafe_origin_cast[ImmUntrackedOrigin]()
+        Pointer(to=regex).as_imm().unsafe_origin_cast[ImmUntrackedOrigin]()
     )
     return ASTNode[ImmUntrackedOrigin](
         type=SPACE,
@@ -639,9 +634,7 @@ def DigitElement[
 ) -> ASTNode[ImmUntrackedOrigin]:
     """Create a DigitElement node."""
     var regex_ptr = (
-        UnsafePointer(to=regex)
-        .as_imm()
-        .unsafe_origin_cast[ImmUntrackedOrigin]()
+        Pointer(to=regex).as_imm().unsafe_origin_cast[ImmUntrackedOrigin]()
     )
     return ASTNode[ImmUntrackedOrigin](
         type=DIGIT,
@@ -663,9 +656,7 @@ def WordElement[
 ) -> ASTNode[ImmUntrackedOrigin]:
     """Create a WordElement node."""
     var regex_ptr = (
-        UnsafePointer(to=regex)
-        .as_imm()
-        .unsafe_origin_cast[ImmUntrackedOrigin]()
+        Pointer(to=regex).as_imm().unsafe_origin_cast[ImmUntrackedOrigin]()
     )
     return ASTNode[ImmUntrackedOrigin](
         type=WORD,
@@ -675,6 +666,30 @@ def WordElement[
         min=1,
         max=1,
     )
+
+
+@always_inline
+def _has_range_seq(pattern: StringSlice, lo: Int, hi: Int) -> Bool:
+    """Scalar scan for a `lo-hi` byte triple (e.g. 'a','-','z') inside `pattern`.
+
+    Deliberately avoids `StringSlice.__contains__` / slicing: those lower
+    to a SIMD substring search that over-reads a 16-byte chunk past the
+    end of a short class, which the 1.0.0 comptime interpreter rejects
+    as an out-of-bounds access. A plain byte loop through `unsafe_ptr`
+    stays interpretable at comptime and keeps `classify_range_kind`
+    usable from the comptime-regex path for explicit classes.
+    """
+    var ptr = pattern.unsafe_ptr()
+    var n = pattern.byte_length()
+    var dash = ord("-")
+    for i in range(n - 2):
+        if (
+            Int(ptr[unsafe_offset=i]) == lo
+            and Int(ptr[unsafe_offset=i + 1]) == dash
+            and Int(ptr[unsafe_offset=i + 2]) == hi
+        ):
+            return True
+    return False
 
 
 @always_inline
@@ -694,14 +709,17 @@ def classify_range_kind(pattern: StringSlice) -> Int:
         return RANGE_KIND_ALNUM
     if pattern == "[a-zA-Z]":
         return RANGE_KIND_ALPHA
-    # Check for complex alphanumeric patterns like [a-zA-Z0-9._%+-]
+    # Check for complex alphanumeric patterns like [a-zA-Z0-9._%+-].
+    # The length gate (inner length = pattern length minus the two
+    # brackets) short-circuits short explicit classes before the byte
+    # scans. Both the gate and the scans stay scalar so this remains
+    # comptime-evaluable (see `_has_range_seq`).
     if pattern.startswith("[") and pattern.endswith("]"):
-        var inner = pattern[byte=1:-1]
         if (
-            "a-z" in inner
-            and "A-Z" in inner
-            and "0-9" in inner
-            and inner.byte_length() > COMPLEX_CHAR_CLASS_THRESHOLD
+            pattern.byte_length() - 2 > COMPLEX_CHAR_CLASS_THRESHOLD
+            and _has_range_seq(pattern, ord("a"), ord("z"))
+            and _has_range_seq(pattern, ord("A"), ord("Z"))
+            and _has_range_seq(pattern, ord("0"), ord("9"))
         ):
             return RANGE_KIND_COMPLEX_ALNUM
     return RANGE_KIND_OTHER
@@ -718,9 +736,7 @@ def RangeElement[
 ) -> ASTNode[ImmUntrackedOrigin]:
     """Create a RangeElement node."""
     var regex_ptr = (
-        UnsafePointer(to=regex)
-        .as_imm()
-        .unsafe_origin_cast[ImmUntrackedOrigin]()
+        Pointer(to=regex).as_imm().unsafe_origin_cast[ImmUntrackedOrigin]()
     )
     # Classify the range pattern once at build time.
     var kind = RANGE_KIND_OTHER
@@ -749,9 +765,7 @@ def StartElement[
 ) -> ASTNode[ImmUntrackedOrigin]:
     """Create a StartElement node."""
     var regex_ptr = (
-        UnsafePointer(to=regex)
-        .as_imm()
-        .unsafe_origin_cast[ImmUntrackedOrigin]()
+        Pointer(to=regex).as_imm().unsafe_origin_cast[ImmUntrackedOrigin]()
     )
     return ASTNode[ImmUntrackedOrigin](
         type=START,
@@ -773,9 +787,7 @@ def EndElement[
 ) -> ASTNode[ImmUntrackedOrigin]:
     """Create an EndElement node."""
     var regex_ptr = (
-        UnsafePointer(to=regex)
-        .as_imm()
-        .unsafe_origin_cast[ImmUntrackedOrigin]()
+        Pointer(to=regex).as_imm().unsafe_origin_cast[ImmUntrackedOrigin]()
     )
     return ASTNode[ImmUntrackedOrigin](
         type=END,
@@ -799,9 +811,7 @@ def OrNode[
 ) -> ASTNode[ImmUntrackedOrigin]:
     """Create an OrNode with left and right children."""
     var regex_ptr = (
-        UnsafePointer(to=regex)
-        .as_imm()
-        .unsafe_origin_cast[ImmUntrackedOrigin]()
+        Pointer(to=regex).as_imm().unsafe_origin_cast[ImmUntrackedOrigin]()
     )
     return ASTNode[ImmUntrackedOrigin](
         type=OR,
@@ -827,9 +837,7 @@ def NotNode[
 ) -> ASTNode[ImmUntrackedOrigin]:
     """Create a NotNode with a child."""
     var regex_ptr = (
-        UnsafePointer(to=regex)
-        .as_imm()
-        .unsafe_origin_cast[ImmUntrackedOrigin]()
+        Pointer(to=regex).as_imm().unsafe_origin_cast[ImmUntrackedOrigin]()
     )
     return ASTNode[ImmUntrackedOrigin](
         type=NOT,
@@ -853,9 +861,7 @@ def GroupNode[
 ) -> ASTNode[ImmUntrackedOrigin]:
     """Create a GroupNode with children."""
     var regex_ptr = (
-        UnsafePointer(to=regex)
-        .as_imm()
-        .unsafe_origin_cast[ImmUntrackedOrigin]()
+        Pointer(to=regex).as_imm().unsafe_origin_cast[ImmUntrackedOrigin]()
     )
     var node = ASTNode[ImmUntrackedOrigin](
         type=GROUP,

--- a/src/regex/comptime_regex.mojo
+++ b/src/regex/comptime_regex.mojo
@@ -28,7 +28,6 @@ call goes through the returned pointer. See the proposal's
 """
 
 from std.ffi import _Global
-from std.collections.string.string_slice import get_static_string
 from std.os import abort
 
 from regex.aliases import ImmSlice, imm_slice_from_ptr
@@ -121,15 +120,20 @@ def _init_ct_engine[pattern: StaticString]() -> DFAEngine:
 
 def _get_ct_engine[
     pattern: StaticString
-]() -> UnsafePointer[DFAEngine, MutUntrackedOrigin]:
+]() -> Pointer[DFAEngine, MutUntrackedOrigin]:
     """Return the process-global engine for `pattern`.
 
     The `_Global` slot is keyed by the pattern itself under the
     `__ctregex__:` namespace so it cannot collide with the runtime
     cache globals ("RegexCache", "LastSubCache", "SIMDMatchers").
     """
+    # Build the per-pattern slot name as a comptime `StaticString`.
+    # (`get_static_string` was removed from the public stdlib API in
+    # 1.0.0; a type-annotated comptime concatenation interns the same
+    # static string.)
+    comptime slot_name: StaticString = "__ctregex__:" + pattern
     comptime ENGINE_GLOBAL = _Global[
-        get_static_string["__ctregex__:", pattern](),
+        slot_name,
         _init_ct_engine[pattern],
     ]
     try:

--- a/src/regex/dfa.mojo
+++ b/src/regex/dfa.mojo
@@ -110,7 +110,7 @@ def _expand_character_range[
         return WORD_CHARS
 
     # Extract the inner part: [a-z] -> a-z
-    var inner = range_str[byte=1:-1]
+    var inner = range_str[byte = 1 : range_str.byte_length() - 1]
 
     # Handle negated ranges like [^a-z]
     var negated = inner.startswith("^")
@@ -2433,17 +2433,17 @@ def compile_dfa_pattern[
         dfa.has_end_anchor = has_end
     elif _is_multi_character_class_sequence(ast):
         # Handle multi-character class sequences like [a-z]+[0-9]+, \d+\w+
-        sequence_info = _extract_multi_class_sequence_info(ast)
+        var sequence_info = _extract_multi_class_sequence_info(ast)
         dfa.compile_multi_character_class_sequence[use_matcher_cache](
             sequence_info^
         )
     elif _is_sequential_character_class_pattern(ast):
         # Handle sequential character class patterns like [+]*\d+[-]*\d+
-        sequence_info = _extract_sequential_pattern_info(ast)
+        var sequence_info = _extract_sequential_pattern_info(ast)
         dfa.compile_sequential_pattern(sequence_info^)
     elif _is_mixed_sequential_pattern(ast):
         # Handle mixed patterns like [0-9]+\.?[0-9]* (numbers with optional decimal)
-        sequence_info = _extract_mixed_sequential_pattern_info(ast)
+        var sequence_info = _extract_mixed_sequential_pattern_info(ast)
         dfa.compile_multi_character_class_sequence[use_matcher_cache](
             sequence_info^
         )

--- a/src/regex/literal_optimizer.mojo
+++ b/src/regex/literal_optimizer.mojo
@@ -27,7 +27,7 @@ struct LiteralInfo[node_origin: ImmOrigin](ImplicitlyCopyable, Movable):
     Built only during regex compilation (pattern analysis), never on the
     per-match hot path, so it does not need to stay `TrivialRegisterPassable`;
     that lets `node_ptr` be a safe `Optional[Pointer[...]]` borrow instead of
-    a raw `UnsafePointer`."""
+    a raw `Pointer`."""
 
     var node_ptr: Optional[
         Pointer[ASTNode[ImmUntrackedOrigin], Self.node_origin]

--- a/src/regex/matcher.mojo
+++ b/src/regex/matcher.mojo
@@ -6,7 +6,8 @@ and implements the hybrid routing system that selects the optimal engine based
 on pattern complexity.
 """
 from std.hashlib import hash
-from std.memory import UnsafePointer, alloc
+from std.memory import Pointer
+from std.memory.alloc import unsafe_alloc
 from std.os import abort
 from std.ffi import _Global
 from std.time import monotonic
@@ -211,10 +212,10 @@ trait RegexMatcher:
 struct DFAMatcher(Boolable, Copyable, Movable, RegexMatcher):
     """High-performance DFA-based matcher for simple patterns."""
 
-    var engine_ptr: Optional[UnsafePointer[DFAEngine, MutUntrackedOrigin]]
+    var engine_ptr: Optional[Pointer[DFAEngine, MutUntrackedOrigin]]
     """The underlying DFA engine for pattern matching. None when the
     matcher was default-constructed and no AST has been compiled into
-    it (1.0.0b1 forbids null UnsafePointer, so absence goes through
+    it (1.0.0b1 forbids null Pointer, so absence goes through
     Optional's None niche)."""
 
     def __init__(out self):
@@ -230,8 +231,8 @@ struct DFAMatcher(Boolable, Copyable, Movable, RegexMatcher):
             ast: AST representing the regex pattern.
             pattern: The original regex pattern string.
         """
-        engine = compile_dfa_pattern(ast)
-        var ptr = alloc[DFAEngine](1)
+        var engine = compile_dfa_pattern(ast)
+        var ptr = unsafe_alloc[DFAEngine](1)
         ptr.unsafe_write(engine^)
         self.engine_ptr = ptr
 
@@ -273,7 +274,7 @@ struct NFAMatcher(Copyable, Movable, RegexMatcher):
     """NFA-based matcher with lazy DFA acceleration.
 
     Owns an optional heap-allocated `LazyDFA`. The lazy DFA is stored
-    behind a nullable `UnsafePointer` rather than an `Optional[LazyDFA]`
+    behind a nullable `Pointer` rather than an `Optional[LazyDFA]`
     inline so that calling `mut self` methods on it (the lazy DFA caches
     transitions as it runs) is possible through the read-only `self` that
     the `RegexMatcher` trait demands. An empty `Optional` means no lazy
@@ -287,11 +288,11 @@ struct NFAMatcher(Copyable, Movable, RegexMatcher):
     """The underlying NFA engine for pattern matching."""
     var ast: ASTNode[MutUntrackedOrigin]
     """The parsed AST representation of the regex pattern."""
-    var _lazy_dfa_ptr: Optional[UnsafePointer[LazyDFA, MutUntrackedOrigin]]
+    var _lazy_dfa_ptr: Optional[Pointer[LazyDFA, MutUntrackedOrigin]]
     """Heap-allocated lazy DFA. None when the pattern is not eligible
     for lazy-DFA acceleration (e.g., PikeVM program exceeds MAX_STATES).
     """
-    var _onepass_ptr: Optional[UnsafePointer[OnePassNFA, MutUntrackedOrigin]]
+    var _onepass_ptr: Optional[Pointer[OnePassNFA, MutUntrackedOrigin]]
     """Heap-allocated OnePass NFA for unambiguous patterns. None when
     the pattern failed the one-pass check. Preferred over the lazy DFA
     and the backtracking NFA when available since it does not pay per-
@@ -310,7 +311,7 @@ struct NFAMatcher(Copyable, Movable, RegexMatcher):
         if vm.is_supported():
             if _program_has_end_anchor(vm.program):
                 self._onepass_ptr = compile_onepass(vm.program.copy())
-            var ptr = alloc[LazyDFA](1)
+            var ptr = unsafe_alloc[LazyDFA](1)
             # `unsafe_write` constructs into uninitialized memory.
             # The previous `self._lazy_dfa_ptr[] = LazyDFA(vm^)` form ran
             # move-assignment into garbage storage, which was the source
@@ -325,13 +326,13 @@ struct NFAMatcher(Copyable, Movable, RegexMatcher):
         self.engine = copy.engine.copy()
         self.ast = copy.ast
         if copy._lazy_dfa_ptr:
-            var ptr = alloc[LazyDFA](1)
+            var ptr = unsafe_alloc[LazyDFA](1)
             ptr.unsafe_write(copy._lazy_dfa_ptr.value()[].copy())
             self._lazy_dfa_ptr = ptr
         else:
             self._lazy_dfa_ptr = None
         if copy._onepass_ptr:
-            var ptr = alloc[OnePassNFA](1)
+            var ptr = unsafe_alloc[OnePassNFA](1)
             ptr.unsafe_write(copy._onepass_ptr.value()[].copy())
             self._onepass_ptr = ptr
         else:
@@ -1180,7 +1181,7 @@ def _init_regex_cache() -> RegexCache:
     return RegexCache()
 
 
-def _get_regex_cache() -> UnsafePointer[RegexCache, MutUntrackedOrigin]:
+def _get_regex_cache() -> Pointer[RegexCache, MutUntrackedOrigin]:
     """Returns an pointer to the global regex cache."""
     try:
         return _CACHE_GLOBAL.get_or_create_ptr()
@@ -1196,7 +1197,7 @@ def _get_regex_cache() -> UnsafePointer[RegexCache, MutUntrackedOrigin]:
 # the public API only accepts `StringSlice` which is read-only, so
 # such misuse requires going out of the typed API.
 #
-# We cannot cache the `UnsafePointer[CompiledRegex]` returned from the
+# We cannot cache the `Pointer[CompiledRegex]` returned from the
 # regex Dict across calls: an intervening `compile_regex` on a
 # different pattern can rehash the Dict and invalidate prior pointers.
 # Caching only `hash(pattern)` is safe — we re-probe the Dict but skip
@@ -1234,7 +1235,7 @@ def _init_last_sub_cache() -> _LastSubCache:
     )
 
 
-def _get_last_sub_cache() -> UnsafePointer[_LastSubCache, MutUntrackedOrigin]:
+def _get_last_sub_cache() -> Pointer[_LastSubCache, MutUntrackedOrigin]:
     try:
         return _LAST_SUB_CACHE_GLOBAL.get_or_create_ptr()
     except e:
@@ -1243,10 +1244,10 @@ def _get_last_sub_cache() -> UnsafePointer[_LastSubCache, MutUntrackedOrigin]:
 
 def _compile_and_cache(
     pattern: ImmSlice,
-) raises -> UnsafePointer[CompiledRegex, MutUntrackedOrigin]:
+) raises -> Pointer[CompiledRegex, MutUntrackedOrigin]:
     """Compile a regex pattern and return a pointer into the global cache.
 
-    Returns an UnsafePointer to the cached CompiledRegex, avoiding the
+    Returns an Pointer to the cached CompiledRegex, avoiding the
     copy that compile_regex() must do when returning by value. Callers
     must not store this pointer past the current call — the cache may
     rehash on a subsequent compile_regex() call.
@@ -1258,13 +1259,13 @@ def _compile_and_cache(
 def _compile_and_cache_with_key(
     pattern: ImmSlice,
     key: UInt64,
-) raises -> UnsafePointer[CompiledRegex, MutUntrackedOrigin]:
+) raises -> Pointer[CompiledRegex, MutUntrackedOrigin]:
     """Variant of `_compile_and_cache` that takes a precomputed hash.
 
     Used by `sub()` with a pointer-identity fast path so repeat calls
     with the same `StaticString` pattern skip the `hash()` call
     entirely. The Dict lookup itself is unavoidable (pointers into the
-    cache can rehash, so we cannot cache the resulting `UnsafePointer`
+    cache can rehash, so we cannot cache the resulting `Pointer`
     across calls without stale-pointer risk)."""
     var regex_cache_ptr = _get_regex_cache()
 
@@ -1272,17 +1273,17 @@ def _compile_and_cache_with_key(
         try:
             ref cached = regex_cache_ptr[][key]
             if cached.pattern == pattern:
-                return UnsafePointer(to=cached)
+                return Pointer(to=cached)
         except:
             pass
 
     var compiled = CompiledRegex(String(pattern))
     try:
         regex_cache_ptr[][key] = compiled
-        return UnsafePointer(to=regex_cache_ptr[][key])
+        return Pointer(to=regex_cache_ptr[][key])
     except e:
         # Dict insertion must succeed (failure here would indicate an
-        # allocator bug). 1.0.0b1 forbids returning a null UnsafePointer
+        # allocator bug). 1.0.0b1 forbids returning a null Pointer
         # sentinel, so propagate the error instead of silently producing
         # a dangling pointer.
         raise e
@@ -1316,7 +1317,7 @@ def compile_regex(pattern: ImmSlice) raises -> CompiledRegex:
 
 def clear_regex_cache():
     """Clear the compiled regex cache."""
-    regex_cache_ptr = _get_regex_cache()
+    var regex_cache_ptr = _get_regex_cache()
     regex_cache_ptr[].clear()
 
 
@@ -1552,8 +1553,8 @@ def _detect_fixed_width_groups(
 @always_inline
 def _apply_template_fixed(
     template: List[_ReplSegment],
-    repl_ptr: UnsafePointer[Byte, ImmutAnyOrigin],
-    text_ptr: UnsafePointer[Byte, ImmutAnyOrigin],
+    repl_ptr: Pointer[Byte, ImmutAnyOrigin],
+    text_ptr: Pointer[Byte, ImmutAnyOrigin],
     match_start: Int,
     group_offsets: Array[Int, 10],
     group_widths: Array[Int, 10],
@@ -1586,7 +1587,7 @@ def _apply_template_groups[
     O: ImmOrigin
 ](
     template: List[_ReplSegment],
-    repl_ptr: UnsafePointer[Byte, ImmutAnyOrigin],
+    repl_ptr: Pointer[Byte, ImmutAnyOrigin],
     groups: List[Match[O]],
     group_idx: Array[Int, 10],
 ) -> String:

--- a/src/regex/matching.mojo
+++ b/src/regex/matching.mojo
@@ -1,4 +1,5 @@
-from std.memory import UnsafePointer, unsafe_memcpy, alloc
+from std.memory import Pointer, unsafe_memcpy
+from std.memory.alloc import unsafe_alloc
 
 
 struct Match[origin: ImmOrigin](Copyable, Movable, TrivialRegisterPassable):
@@ -17,7 +18,7 @@ struct Match[origin: ImmOrigin](Copyable, Movable, TrivialRegisterPassable):
     """Starting position of the match in the text."""
     var end_idx: Int
     """Ending position of the match in the text (exclusive)."""
-    var text_ptr: UnsafePointer[Byte, Self.origin]
+    var text_ptr: Pointer[Byte, Self.origin]
     """Origin-tracked pointer to the start of the backing text bytes. Does
     not own memory; the `origin` parameter ties its lifetime to the source
     text. We store the base pointer (not a full slice) to keep Match at a
@@ -59,10 +60,10 @@ struct MatchList[origin: ImmOrigin](Copyable, Movable, Sized):
     comptime DEFAULT_RESERVE_SIZE = 8
     """Default number of matches to reserve on first allocation."""
 
-    var _data: UnsafePointer[Match[Self.origin], MutUntrackedOrigin]
+    var _data: Pointer[Match[Self.origin], MutUntrackedOrigin]
     """Internal list storing the matches. Dangling (and never read
     from) until the first allocation runs through `_realloc`; tracked
-    via `_capacity > 0` since 1.0.0b1 forbids null UnsafePointer
+    via `_capacity > 0` since 1.0.0b1 forbids null Pointer
     sentinels."""
     var _len: Int
     var _capacity: Int
@@ -72,7 +73,7 @@ struct MatchList[origin: ImmOrigin](Copyable, Movable, Sized):
         capacity: Int = 0,
     ):
         """Initialize empty Matches container."""
-        self._data = UnsafePointer[
+        self._data = Pointer[
             Match[Self.origin], MutUntrackedOrigin
         ].unsafe_dangling()
         self._capacity = 0
@@ -87,7 +88,7 @@ struct MatchList[origin: ImmOrigin](Copyable, Movable, Sized):
         copy: Self,
     ):
         """Copy constructor."""
-        self._data = UnsafePointer[
+        self._data = Pointer[
             Match[Self.origin], MutUntrackedOrigin
         ].unsafe_dangling()
         self._len = 0
@@ -128,7 +129,7 @@ struct MatchList[origin: ImmOrigin](Copyable, Movable, Sized):
 
     @no_inline
     def _realloc(mut self, new_capacity: Int):
-        var new_data = alloc[Match[Self.origin]](new_capacity)
+        var new_data = unsafe_alloc[Match[Self.origin]](new_capacity)
 
         if self._capacity > 0:
             unsafe_memcpy(dest=new_data, src=self._data, count=len(self))

--- a/src/regex/nfa.mojo
+++ b/src/regex/nfa.mojo
@@ -1,4 +1,4 @@
-from std.memory import UnsafePointer
+from std.memory import Pointer
 
 from regex.ast import (
     ASTNode,
@@ -600,7 +600,9 @@ struct NFAEngine(Copyable, Engine):
         # Expand the range pattern if needed
         if range_pattern.startswith("[") and range_pattern.endswith("]"):
             # It's a pattern like "[a-z]", need to expand it
-            var inner = range_pattern[byte=1:-1]
+            var inner = range_pattern[
+                byte = 1 : range_pattern.byte_length() - 1
+            ]
 
             # Handle common patterns with specialized matchers
             # Return None for simple ranges to use RangeBasedMatcher instead
@@ -972,7 +974,9 @@ struct NFAEngine(Copyable, Engine):
                 var opt = ast.get_value()
                 if opt:
                     ref range_pattern = opt.value()
-                    var inner = range_pattern[byte=1:-1]
+                    var inner = range_pattern[
+                        byte = 1 : range_pattern.byte_length() - 1
+                    ]
                     ch_found = byte_in_string(ch_code, inner)
         else:
             # RANGE_KIND_OTHER: use direct byte-level range matching.
@@ -1555,7 +1559,9 @@ struct NFAEngine(Copyable, Engine):
                         max_matches,
                     )
             elif kind == RANGE_KIND_COMPLEX_ALNUM:
-                var inner = range_pattern[byte=1:-1]
+                var inner = range_pattern[
+                    byte = 1 : range_pattern.byte_length() - 1
+                ]
                 var pos = str_i
                 var match_count = 0
                 var actual_max = max_matches
@@ -1646,7 +1652,9 @@ struct NFAEngine(Copyable, Engine):
     ](self, range_pattern: StringSlice[O], ch_code: Int) -> Bool:
         """Helper function to check if a character matches a range pattern."""
         if range_pattern.startswith("[") and range_pattern.endswith("]"):
-            var inner = range_pattern[byte=1:-1]
+            var inner = range_pattern[
+                byte = 1 : range_pattern.byte_length() - 1
+            ]
 
             # Handle simple ranges like [c-n]
             if inner.byte_length() == 3 and inner[byte=1] == "-":
@@ -1666,7 +1674,7 @@ struct NFAEngine(Copyable, Engine):
     ](
         self,
         matcher: RangeBasedMatcher,
-        str_ptr: UnsafePointer[Byte, O],
+        str_ptr: Pointer[Byte, O],
         str: StringSlice[O],
         str_i: Int,
         min_matches: Int,
@@ -1697,7 +1705,7 @@ struct NFAEngine(Copyable, Engine):
         range_start: Int,
         range_end: Int,
         positive_logic: Bool,
-        str_ptr: UnsafePointer[Byte, O],
+        str_ptr: Pointer[Byte, O],
         str: StringSlice[O],
         str_i: Int,
         min_matches: Int,

--- a/src/regex/onepass.mojo
+++ b/src/regex/onepass.mojo
@@ -24,7 +24,8 @@ bytecode, with an added ambiguity check: if any byte can fire more than
 one distinct follow-up closure, the pattern is rejected.
 """
 
-from std.memory import alloc, UnsafePointer
+from std.memory import Pointer
+from std.memory.alloc import unsafe_alloc
 
 from regex.matching import Match, MatchList
 from regex.pikevm import (
@@ -178,7 +179,7 @@ def _hash_set(nfa_set: SIMD[DType.uint8, MAX_STATES]) -> UInt64:
 
 def compile_onepass(
     var program: Program,
-) -> Optional[UnsafePointer[OnePassNFA, MutUntrackedOrigin]]:
+) -> Optional[Pointer[OnePassNFA, MutUntrackedOrigin]]:
     # Compile a PikeVM program into a OnePass NFA and heap-allocate it.
     # Returns None when the pattern is not one-pass (caller falls back
     # to another engine).
@@ -337,7 +338,7 @@ def compile_onepass(
         is_match_flags.append(states[i].is_match)
         is_end_match_flags.append(states[i].is_end_match)
 
-    var ptr = alloc[OnePassNFA](1)
+    var ptr = unsafe_alloc[OnePassNFA](1)
     ptr.unsafe_write(
         OnePassNFA(
             runtime_transitions^,

--- a/src/regex/parser.mojo
+++ b/src/regex/parser.mojo
@@ -21,7 +21,7 @@ from regex.tokens import (
     NotToken,
     Wildcard,
 )
-from std.memory import alloc
+from std.memory.alloc import unsafe_alloc
 
 from regex.ast import (
     ASTNode,
@@ -478,7 +478,7 @@ def parse(pattern: String) raises -> ASTNode[ImmUntrackedOrigin]:
     """
     # Create a persistent Regex object to hold the pattern and children
     # Allocate on heap to ensure it survives function return
-    var regex_ptr = alloc[Regex[ImmUntrackedOrigin]](1)
+    var regex_ptr = unsafe_alloc[Regex[ImmUntrackedOrigin]](1)
     regex_ptr.unsafe_write(Regex[ImmUntrackedOrigin](pattern))
 
     # Tokenize the pattern

--- a/src/regex/pikevm.mojo
+++ b/src/regex/pikevm.mojo
@@ -607,7 +607,7 @@ struct PikeVMEngine(Copyable, Movable):
         mut count: Int,
         mut seen: SIMD[DType.uint8, MAX_STATES],
         pc: Int,
-        text_ptr: UnsafePointer[UInt8, _],
+        text_ptr: Pointer[UInt8, _],
         pos: Int,
         text_len: Int,
     ):
@@ -725,7 +725,7 @@ struct LazyDFA(Copyable, Movable):
     @always_inline
     def _find_first_candidate(
         self,
-        text_ptr: UnsafePointer[Byte, _],
+        text_ptr: Pointer[Byte, _],
         start: Int,
         text_len: Int,
     ) -> Int:
@@ -871,7 +871,7 @@ struct LazyDFA(Copyable, Movable):
         mut self,
         state_id: Int,
         ch: Int,
-        text_ptr: UnsafePointer[UInt8, _],
+        text_ptr: Pointer[UInt8, _],
         pos: Int,
         text_len: Int,
     ) -> Int:
@@ -948,9 +948,9 @@ struct LazyDFA(Copyable, Movable):
         var count = 0
         var seen = SIMD[DType.uint8, MAX_STATES](0)
         # Dummy text_ptr for epsilon closure (no bytes consumed). 1.0.0b1
-        # forbids constructing a null UnsafePointer; `unsafe_dangling` is
+        # forbids constructing a null Pointer; `unsafe_dangling` is
         # the supported non-null placeholder.
-        var dummy = UnsafePointer[UInt8, MutAnyOrigin].unsafe_dangling()
+        var dummy = Pointer[UInt8, MutAnyOrigin].unsafe_dangling()
         self.pikevm._add_state(pcs, count, seen, pc, dummy, pos, 0)
 
         if count == 0 and not self._has_match_in_set(seen):

--- a/src/regex/simd_matchers.mojo
+++ b/src/regex/simd_matchers.mojo
@@ -7,7 +7,7 @@ Based on techniques from: http://0x80.pl/notesen/2018-10-18-simd-byte-lookup.htm
 from std.os import abort
 from std.sys.info import simd_width_of
 from std.ffi import _Global
-from std.memory import UnsafePointer
+from std.memory import Pointer
 from regex.aliases import (
     SIMD_MATCHER_NONE,
     SIMD_MATCHER_WHITESPACE,
@@ -370,7 +370,7 @@ def analyze_character_class_pattern(pattern: String) -> String:
     else:
         # Check if it's a simple range
         if pattern.startswith("[") and pattern.endswith("]") and "-" in pattern:
-            var inner = pattern[byte=1:-1]
+            var inner = pattern[byte = 1 : pattern.byte_length() - 1]
             if len(inner) == 3 and Int(
                 inner.unsafe_ptr()[unsafe_offset=1]
             ) == ord("-"):
@@ -389,7 +389,7 @@ def _init_range_matchers() -> RangeMatchers:
     return matchers^
 
 
-def _get_range_matchers() -> UnsafePointer[RangeMatchers, MutUntrackedOrigin]:
+def _get_range_matchers() -> Pointer[RangeMatchers, MutUntrackedOrigin]:
     """Returns a pointer to the global range matchers dictionary."""
     try:
         return _RANGE_MATCHERS_GLOBAL.get_or_create_ptr()
@@ -410,7 +410,7 @@ def _init_nibble_matchers() -> NibbleMatchers:
     return matchers^
 
 
-def _get_nibble_matchers() -> UnsafePointer[NibbleMatchers, MutUntrackedOrigin]:
+def _get_nibble_matchers() -> Pointer[NibbleMatchers, MutUntrackedOrigin]:
     """Returns a pointer to the global nibble matchers dictionary."""
     try:
         return _NIBBLE_MATCHERS_GLOBAL.get_or_create_ptr()

--- a/src/regex/simd_ops.mojo
+++ b/src/regex/simd_ops.mojo
@@ -91,7 +91,7 @@ def find_first_in_nibble_tables(
     lo_nibble: SIMD[DType.uint8, 16],
     hi_nibble: SIMD[DType.uint8, 16],
     filter: SIMD[DType.uint8, 256],
-    text_ptr: UnsafePointer[Byte, _],
+    text_ptr: Pointer[Byte, _],
     start: Int,
     text_len: Int,
 ) -> Int:
@@ -215,7 +215,7 @@ def _first_true(r: SIMD[DType.bool, SIMD_WIDTH]) -> Int:
 
 @always_inline
 def simd_find_byte(
-    text_ptr: UnsafePointer[Byte, _],
+    text_ptr: Pointer[Byte, _],
     start: Int,
     text_len: Int,
     needle: UInt8,
@@ -564,7 +564,7 @@ struct CharacterClassSIMD(
 
     @always_inline
     def find_first_nibble_match(
-        self, text_ptr: UnsafePointer[Byte, _], start: Int, text_len: Int
+        self, text_ptr: Pointer[Byte, _], start: Int, text_len: Int
     ) -> Int:
         """Find first matching character using a SIMD scan.
 
@@ -649,7 +649,7 @@ struct CharacterClassSIMD(
 
     @always_inline
     def count_consecutive_matches(
-        self, text_ptr: UnsafePointer[Byte, _], start: Int, text_len: Int
+        self, text_ptr: Pointer[Byte, _], start: Int, text_len: Int
     ) -> Int:
         """Count consecutive matching characters from start position.
 
@@ -786,7 +786,7 @@ struct CharacterClassSIMD(
         return pos - start
 
     def _check_chunk_simd(
-        self, text_ptr: UnsafePointer[Byte, _], pos: Int
+        self, text_ptr: Pointer[Byte, _], pos: Int
     ) -> SIMD[DType.bool, SIMD_WIDTH]:
         """Check a chunk of characters using SIMD operations.
 
@@ -1126,7 +1126,7 @@ def _init_simd_matchers() -> SIMDMatchers:
     return matchers^
 
 
-def _get_simd_matchers() -> UnsafePointer[SIMDMatchers, MutUntrackedOrigin]:
+def _get_simd_matchers() -> Pointer[SIMDMatchers, MutUntrackedOrigin]:
     """Returns a pointer to the global SIMD matchers dictionary."""
     try:
         return _SIMD_MATCHERS_GLOBAL.get_or_create_ptr()

--- a/tests/test_ast.mojo
+++ b/tests/test_ast.mojo
@@ -31,9 +31,7 @@ def test_ASTNode() raises:
     var pattern = String("")
     var regex = Regex[ImmUntrackedOrigin](pattern)
     var regex_ptr = (
-        UnsafePointer(to=regex)
-        .as_imm()
-        .unsafe_origin_cast[ImmUntrackedOrigin]()
+        Pointer(to=regex).as_imm().unsafe_origin_cast[ImmUntrackedOrigin]()
     )
     var ast_node = ASTNode[ImmUntrackedOrigin](
         type=ELEMENT, regex_ptr=regex_ptr, start_idx=0, end_idx=0

--- a/tests/test_dfa.mojo
+++ b/tests/test_dfa.mojo
@@ -331,7 +331,7 @@ def test_dfa_anchors_with_high_level_api() raises:
 def test_phone_numbers() raises:
     """Test phone number pattern matching using DFA."""
     # Complex phone number pattern with sequential character classes
-    pattern = "[+]*\\d+[-]*\\d+[-]*\\d+[-]*\\d+"
+    var pattern = "[+]*\\d+[-]*\\d+[-]*\\d+[-]*\\d+"
     var ast = parse(pattern)
     var dfa = compile_dfa_pattern(ast)
     var result = dfa.match_first("+1-541-236-5432", 0)

--- a/tests/test_nfa.mojo
+++ b/tests/test_nfa.mojo
@@ -1033,19 +1033,19 @@ def test_phone_numbers() raises:
     """Test phone number pattern matching using DFA."""
     # Simplified phone number pattern that works with current implementation
     # This tests basic phone number matching with + prefix and digit sequences
-    pattern = "[+]*\\d+[-]*\\d+[-]*\\d+[-]*\\d+"
-    result = match_first(pattern, "+1-541-236-5432")
+    var pattern = "[+]*\\d+[-]*\\d+[-]*\\d+[-]*\\d+"
+    var result = match_first(pattern, "+1-541-236-5432")
     assert_true(result.__bool__())
     assert_equal(result.value().get_match_text(), "+1-541-236-5432")
 
 
 def test_es_phone_numbers() raises:
-    es_pattern = "[5-9]\\d{8}"
-    phone = "810123456"
+    var es_pattern = "[5-9]\\d{8}"
+    var phone = "810123456"
     var result = match_first(es_pattern, phone)
     assert_true(result.__bool__())
     assert_equal(result.value().get_match_text(), phone)
-    es_fixed_line_pattern = "96906(?:0[0-8]|1[1-9]|[2-9]\\d)\\d\\d|9(?:69(?:0[0-57-9]|[1-9]\\d)|73(?:[0-8]\\d|9[1-9]))\\d{4}|(?:8(?:[1356]\\d|[28][0-8]|[47][1-9])|9(?:[135]\\d|[268][0-8]|4[1-9]|7[124-9]))\\d{6}"
+    var es_fixed_line_pattern = "96906(?:0[0-8]|1[1-9]|[2-9]\\d)\\d\\d|9(?:69(?:0[0-57-9]|[1-9]\\d)|73(?:[0-8]\\d|9[1-9]))\\d{4}|(?:8(?:[1356]\\d|[28][0-8]|[47][1-9])|9(?:[135]\\d|[268][0-8]|4[1-9]|7[124-9]))\\d{6}"
     var result2 = match_first(es_fixed_line_pattern, phone)
     assert_true(result2.__bool__())
     assert_equal(result2.value().get_match_text(), phone)

--- a/tests/test_onepass.mojo
+++ b/tests/test_onepass.mojo
@@ -1,4 +1,4 @@
-from std.memory import UnsafePointer
+from std.memory import Pointer
 from std.testing import assert_equal, assert_true, assert_false, TestSuite
 
 from regex.ast import ASTNode
@@ -10,7 +10,7 @@ from regex.aliases import ImmSlice
 
 def _build_onepass(
     pattern: String,
-) raises -> Optional[UnsafePointer[OnePassNFA, MutUntrackedOrigin]]:
+) raises -> Optional[Pointer[OnePassNFA, MutUntrackedOrigin]]:
     """Parse a pattern, compile to PikeVM bytecode, attempt OnePass
     compilation, and return the heap pointer (None if not one-pass)."""
     var ast = parse(pattern)


### PR DESCRIPTION
Moves mojo-regex off the nightly toolchain onto the **released Mojo 1.0.0**. `pixi.toml` now uses the stable `https://conda.modular.com/max` channel (was `max-nightly`) and pins `mojo ==1.0.0`. `mojo --version` → `Mojo 1.0.0 (ed45d567)`.

This also **unblocks the v0.21.0 release**: recipe PR modular-community#293 has been waiting for a stable-channel Mojo, which now exists.

## Source migrations required by the stable release

| Change | Fix | Sites |
|---|---|---|
| `get_static_string` removed from public stdlib | build the comptime `_Global` slot name with a type-annotated comptime `StaticString` concatenation (`"__ctregex__:" + pattern`) | 1 |
| `UnsafePointer` deprecated → `Pointer` | rename the type annotations; we already use `unsafe_*` ops everywhere, so the safe `Pointer` is a drop-in | 47 |
| `alloc` (no `Layout`) deprecated → `unsafe_alloc` | import from `std.memory.alloc`, rename calls | 8 |
| negative slice indices now out-of-bounds | `x[byte=1:-1]` → `x[byte=1 : x.byte_length() - 1]` (the char-class "strip the brackets" slices) | 7 |
| implicit-declaration warnings | add `var` to the flagged assignments (dfa, matcher, nfa/dfa tests) | 8 |

## The tricky one: comptime-regex + char classes

`classify_range_kind`'s complex-alnum detection used `StringSlice` `in` (substring search) and negative slicing. Those lower to a SIMD substring scan that **over-reads a 16-byte chunk past the end of a short class**. Benign at runtime (the padding is readable), but stable 1.0.0's comptime interpreter tracks exact bounds and rejects it as out-of-bounds — which broke `search["[abc]"]` / `search["[^abc]"]` (a *compile* error, uncatchable, so no runtime fallback).

Reworked it to a scalar byte scan (`_has_range_seq`, using `unsafe_ptr` byte access, which stays comptime-evaluable). Runtime classification is unchanged — `[a-zA-Z0-9._%+-]` still classifies as COMPLEX_ALNUM, `[abc]` as OTHER — and the comptime char-class envelope is fully preserved (`test_comptime_regex`'s 12 tests, including the char-class families, pass).

## Verification

- **389 tests pass**, zero failures, zero runtime assert errors.
- **Zero compiler warnings** across `src`, `tests` and the `bench_engine` build.
- No benchmark timing taken (mechanical API migration + one comptime-path rework; the full engine suite is the correctness gate, and machine load was ~4).

Folds into the in-flight v0.21.0 per the mid-version rules (no version bump). Follow-up: update recipe #293 to `mojo_version: "=1.0.0"` + rev this commit, which finally lets the release build.
