### PR TITLE
Add split() (re.split equivalent)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ print(cleaned)  # "hello world"
 # Capture group interpolation
 var formatted = sub("(\\d{3})(\\d{3})(\\d{4})", "\\1-\\2-\\3", "6502530000")
 print(formatted)  # "650-253-0000"
+
+# Splitting (re.split equivalent)
+var fields = split("\\s*,\\s*", "a, b ,c,  d")
+for f in fields:
+    print(f)  # "a" "b" "c" "d"
 ```
 
 ## Compile-time patterns (experimental)
@@ -90,7 +95,6 @@ pixi run mojo run -I src benchmarks/bench_engine.mojo
 
 - Named groups (`(?<name>...)`)
 - Case insensitive matching
-- String splitting (`split()`)
 - Non-greedy quantifiers (`*?`, `+?`, `??`)
 - Word boundaries (`\b`, `\B`)
 - Unicode character classes (`\p{L}`, `\p{N}`)

--- a/src/regex/__init__.mojo
+++ b/src/regex/__init__.mojo
@@ -1,1 +1,1 @@
-from .matcher import match_first, findall, search, sub, Match
+from .matcher import match_first, findall, search, split, sub, Match

--- a/src/regex/matcher.mojo
+++ b/src/regex/matcher.mojo
@@ -1371,7 +1371,9 @@ def split[
         text: Text to split.
         maxsplit: Maximum number of splits to perform. `0` (the default)
             means no limit; after `maxsplit` splits the remainder of the
-            text is returned unsplit as the final element.
+            text is returned unsplit as the final element. A negative
+            value performs no split at all (matching Python's `re.split`),
+            returning the whole text as a single element.
 
     Returns:
         The list of substrings between matches.
@@ -1381,7 +1383,7 @@ def split[
     var prev_end = 0
     var splits_done = 0
     for i in range(len(matches)):
-        if maxsplit > 0 and splits_done >= maxsplit:
+        if maxsplit != 0 and splits_done >= maxsplit:
             break
         ref m = matches[i]
         result.append(String(text[byte = prev_end : m.start_idx]))

--- a/src/regex/matcher.mojo
+++ b/src/regex/matcher.mojo
@@ -1354,6 +1354,43 @@ def findall[
     return compiled_ptr[].match_all(text)
 
 
+def split[
+    O: ImmOrigin
+](pattern: ImmSlice, text: StringSlice[O], maxsplit: Int = 0) raises -> List[
+    String
+]:
+    """Split `text` by the occurrences of `pattern` (equivalent to re.split).
+
+    The text between successive non-overlapping matches is returned as a
+    list of substrings; the matched separators themselves are removed. A
+    separator at the very start or end (or two adjacent separators)
+    yields an empty string in that position, matching Python's `re.split`.
+
+    Args:
+        pattern: Regex pattern to split on.
+        text: Text to split.
+        maxsplit: Maximum number of splits to perform. `0` (the default)
+            means no limit; after `maxsplit` splits the remainder of the
+            text is returned unsplit as the final element.
+
+    Returns:
+        The list of substrings between matches.
+    """
+    var matches = findall(pattern, text)
+    var result = List[String]()
+    var prev_end = 0
+    var splits_done = 0
+    for i in range(len(matches)):
+        if maxsplit > 0 and splits_done >= maxsplit:
+            break
+        ref m = matches[i]
+        result.append(String(text[byte = prev_end : m.start_idx]))
+        prev_end = m.end_idx
+        splits_done += 1
+    result.append(String(text[byte = prev_end : text.byte_length()]))
+    return result^
+
+
 def match_first[
     O: ImmOrigin
 ](pattern: ImmSlice, text: StringSlice[O]) raises -> Optional[Match[O]]:

--- a/tests/test_split.mojo
+++ b/tests/test_split.mojo
@@ -1,0 +1,74 @@
+from std.testing import assert_equal, assert_true, TestSuite
+
+from regex import split
+
+
+def test_split_literal() raises:
+    var parts = split(",", "a,b,c")
+    assert_equal(len(parts), 3)
+    assert_equal(parts[0], "a")
+    assert_equal(parts[1], "b")
+    assert_equal(parts[2], "c")
+
+
+def test_split_regex_whitespace() raises:
+    var parts = split("\\s+", "hello   world  foo")
+    assert_equal(len(parts), 3)
+    assert_equal(parts[0], "hello")
+    assert_equal(parts[1], "world")
+    assert_equal(parts[2], "foo")
+
+
+def test_split_adjacent_separators() raises:
+    # Two adjacent separators yield an empty field between them.
+    var parts = split(",", "a,,b")
+    assert_equal(len(parts), 3)
+    assert_equal(parts[0], "a")
+    assert_equal(parts[1], "")
+    assert_equal(parts[2], "b")
+
+
+def test_split_leading_and_trailing() raises:
+    var parts = split(",", ",a,")
+    assert_equal(len(parts), 3)
+    assert_equal(parts[0], "")
+    assert_equal(parts[1], "a")
+    assert_equal(parts[2], "")
+
+
+def test_split_no_match() raises:
+    var parts = split(",", "abcdef")
+    assert_equal(len(parts), 1)
+    assert_equal(parts[0], "abcdef")
+
+
+def test_split_empty_text() raises:
+    var parts = split(",", "")
+    assert_equal(len(parts), 1)
+    assert_equal(parts[0], "")
+
+
+def test_split_maxsplit() raises:
+    # At most `maxsplit` splits; the remainder is returned unsplit.
+    var parts = split(",", "a,b,c,d", maxsplit=2)
+    assert_equal(len(parts), 3)
+    assert_equal(parts[0], "a")
+    assert_equal(parts[1], "b")
+    assert_equal(parts[2], "c,d")
+
+
+def test_split_maxsplit_zero_is_unlimited() raises:
+    var parts = split(",", "a,b,c,d", maxsplit=0)
+    assert_equal(len(parts), 4)
+    assert_equal(parts[3], "d")
+
+
+def test_split_char_class() raises:
+    var parts = split("[;,]", "a;b,c;d")
+    assert_equal(len(parts), 4)
+    assert_equal(parts[0], "a")
+    assert_equal(parts[3], "d")
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_split.mojo
+++ b/tests/test_split.mojo
@@ -63,6 +63,13 @@ def test_split_maxsplit_zero_is_unlimited() raises:
     assert_equal(parts[3], "d")
 
 
+def test_split_negative_maxsplit_no_split() raises:
+    # A negative maxsplit performs no split (matches Python re.split).
+    var parts = split(",", "a,b,c", maxsplit=-1)
+    assert_equal(len(parts), 1)
+    assert_equal(parts[0], "a,b,c")
+
+
 def test_split_char_class() raises:
     var parts = split("[;,]", "a;b,c;d")
     assert_equal(len(parts), 4)


### PR DESCRIPTION
First feature of the **0.22 cycle** ([road-to-1.0](docs/roadmap-1.0.md)).

Adds a top-level `split(pattern, text, maxsplit=0)` returning the substrings between non-overlapping matches, matching Python's `re.split` semantics:

```mojo
split("\\s*,\\s*", "a, b ,c,  d")   # ["a", "b", "c", "d"]
split(",", "a,,b")                # ["a", "", "b"]  (empty field between adjacent seps)
split(",", ",a,")                 # ["", "a", ""]  (leading/trailing)
split(",", "a,b,c,d", maxsplit=2) # ["a", "b", "c,d"]  (remainder unsplit)
```

## Why start the cycle here

Of 0.22's three features, `split()` is the clean, **engine-free** one: it iterates the existing `findall` match list and slices the text between matches, so it carries **zero risk to the matching hot paths**. Non-greedy quantifiers and `\b` follow as dedicated PRs since they touch the engine (non-greedy is a deep NFA backtracking-order change).

## Verification

- 9 new tests covering literal/regex separators, adjacent/leading/trailing empties, no-match, empty text, `maxsplit`, and char-class separators.
- **398 tests total**, zero compiler warnings.

Removes `split()` from the README Missing Features list and adds a usage example. Folds into the in-flight v0.21.0 per the mid-version rules (no version bump).