### PR TITLE
Fix bench harness out-of-bounds slice under Mojo 1.0.0

### DIFF
--- a/benchmarks/bench_engine.mojo
+++ b/benchmarks/bench_engine.mojo
@@ -159,18 +159,31 @@ def _find_median(mut times: List[Float64]) -> Float64:
     return (times[n // 2 - 1] + times[n // 2]) / 2.0
 
 
+def _pad_to(width: Int, used: Int) -> String:
+    """Return the spaces needed to pad `used` columns out to `width` (never
+    negative)."""
+    var n = width - used
+    return " " * n if n > 0 else ""
+
+
 def _print_result(name: String, median_ms: Float64, total_iters: Int):
     """Print benchmark result in table format."""
-    var padded_name = name + " " * (25 - name.byte_length())
+    var mstr = String(median_ms)
+    # Truncate to the column width without over-slicing: `[byte=:24]` on a
+    # shorter string is an out-of-bounds slice under Mojo 1.0.0.
+    var take = 24 if mstr.byte_length() > 24 else mstr.byte_length()
+    var mcol = String(mstr[byte=0:take])
+    var iters = String(total_iters)
     print(
         "| "
-        + padded_name
+        + name
+        + _pad_to(25, name.byte_length())
         + " | "
-        + String(median_ms)[byte=:24]
-        + " " * (25 - String(median_ms)[byte=:24].byte_length())
+        + mcol
+        + _pad_to(25, mcol.byte_length())
         + " | "
-        + String(total_iters)
-        + " " * (6 - String(total_iters).byte_length())
+        + iters
+        + _pad_to(6, iters.byte_length())
         + " |"
     )
 


### PR DESCRIPTION
The benchmark harness crashes at runtime on stable Mojo 1.0.0.

`_print_result` truncated the formatted median with `String(median_ms)[byte=:24]`. Under 1.0.0's stricter slice bounds, that is an **out-of-bounds slice** whenever the number formats to fewer than 24 bytes (i.e. almost always) - `Assert Error: slice end index 24 is out of bounds`. The module *builds* fine, so `pixi run test` never caught it (the benchmark isn't part of the test suite).

Fix: truncate to `min(24, length)` and clamp column padding to non-negative via a small `_pad_to` helper. The suite now runs to completion (90 results, no crash).

## Also: benchmark regression check (stable 1.0.0)

With the harness fixed and the machine idle, ran the full suite on stable 1.0.0. Hot benchmarks are at-or-below the CHANGELOG-documented figures (same machine, prior toolchains), i.e. **no regression from the stable upgrade**:

| benchmark | stable 1.0.0 | documented |
|---|---|---|
| `pure_dfa_paren` | 58 ns | ~67 ns |
| `literal_match_short` | 51 ns | ~83 ns |
| `literal_match_long` | 398 ns | ~565 ns |
| `optimize_extreme_quantifiers` | 58 ns | ~57-76 ns |

Consistent with the objdump analysis in #180 showing the `UnsafePointer`->`Pointer` migration is codegen-identical. Folds into the in-flight v0.21.0 (no version bump).